### PR TITLE
Fix layer handling in Mixscape.mixscape to resolve errors with adata.raw

### DIFF
--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -227,7 +227,7 @@ class Mixscape:
                 X = adata_comp.layers["X_pert"]
             except KeyError:
                 raise KeyError(
-                    "No 'X_pert' found in .layers! Please run pert_sign first to calculate perturbation signature!"
+                    "No 'X_pert' found in .layers! Please run perturbation_signature first to calculate perturbation signature!"
                 ) from None
         # initialize return variables
         adata.obs[f"{new_class_name}_p_{perturbation_type.lower()}"] = 0
@@ -461,7 +461,13 @@ class Mixscape:
             adata_split = adata[split_mask].copy()
             # find top DE genes between cells with targeting and non-targeting gRNAs
             sc.tl.rank_genes_groups(
-                adata_split, layer=layer, groupby=labels, groups=genes, reference=control, method="t-test"
+                adata_split,
+                layer=layer,
+                groupby=labels,
+                groups=genes,
+                reference=control,
+                method="t-test",
+                use_raw=False,
             )
             # get DE genes for each gene
             for gene in genes:


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->
 
-   [X] Referenced issue is linked (#617)

**Description of changes**

- Added `use_raw=False` to the `sc.tl.rank_genes_groups` method call
- Currently, `Mixscape.mixscape` fails for `adata` objects where `adata.raw` is present. This is due to the internal call of `sc.tl.rank_genes_groups`, which uses `adata.raw` by default for computation if `use_raw` is not explicitly set to `False`. If a layer is specified when calling `Mixscape.mixscape`, this will cause the `rank_genes_groups` method to fail with the error: `ValueError: Cannot specify "layer" and have "use_raw=True"`. If no layer is specified, `rank_genes_groups` will use `adata.raw` for computation, potentially leading to errors like the one reported in #617.

**Discussion point**

- Currently, the layer is set to `X_pert` by default only after `sc.tl.rank_genes_groups` is called, meaning it will run on `X` unless the user provides a different layer. Should we change this? On what basis should the perturbation markers be calculated? Rather based on the `X_pert` layer?
