### PR TITLE
Fix CI

### DIFF
--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -2236,7 +2236,7 @@ class CompositionalModel2(ABC):
 
 
 def get_a(
-    tree: tt.tree,
+    tree: tt.Toytree,
 ) -> tuple[np.ndarray, int]:
     """Calculate ancestor matrix from a toytree tree
 
@@ -2275,7 +2275,7 @@ def get_a(
     return A, n_nodes - 1
 
 
-def collapse_singularities(tree: tt.tree) -> tt.tree:
+def collapse_singularities(tree: tt.Toytree) -> tt.Toytree:
     """Collapses (deletes) nodes in a toytree tree that are singularities (have only one child).
 
     Args:

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -2236,7 +2236,7 @@ class CompositionalModel2(ABC):
 
 
 def get_a(
-    tree: tt.Toytree,
+    tree: tt.core.ToyTree,
 ) -> tuple[np.ndarray, int]:
     """Calculate ancestor matrix from a toytree tree
 
@@ -2275,7 +2275,7 @@ def get_a(
     return A, n_nodes - 1
 
 
-def collapse_singularities(tree: tt.Toytree) -> tt.Toytree:
+def collapse_singularities(tree: tt.core.ToyTree) -> tt.core.ToyTree:
     """Collapses (deletes) nodes in a toytree tree that are singularities (have only one child).
 
     Args:

--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -207,7 +207,7 @@ class Tasccoda(CompositionalModel2):
             ) from None
 
         # toytree tree - only for legacy reasons, can be removed in the final version
-        if isinstance(adata.uns[tree_key], tt.tree):
+        if isinstance(adata.uns[tree_key], tt.Toytree):
             # Collapse singularities in the tree
             phy_tree = collapse_singularities(adata.uns[tree_key])
 

--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -207,7 +207,7 @@ class Tasccoda(CompositionalModel2):
             ) from None
 
         # toytree tree - only for legacy reasons, can be removed in the final version
-        if isinstance(adata.uns[tree_key], tt.Toytree):
+        if isinstance(adata.uns[tree_key], tt.core.ToyTree):
             # Collapse singularities in the tree
             phy_tree = collapse_singularities(adata.uns[tree_key])
 

--- a/pertpy/tools/_distances/_distances.py
+++ b/pertpy/tools/_distances/_distances.py
@@ -214,9 +214,9 @@ class Distance:
             >>> D = Distance(X, Y)
         """
         if issparse(X):
-            X = X.A
+            X = X.toarray()
         if issparse(Y):
-            Y = Y.A
+            Y = Y.toarray()
 
         if len(X) == 0 or len(Y) == 0:
             raise ValueError("Neither X nor Y can be empty.")

--- a/tests/preprocessing/test_grna_assignment.py
+++ b/tests/preprocessing/test_grna_assignment.py
@@ -35,7 +35,7 @@ class TestGuideRnaProcessingAndPlotting:
         ga = pt.pp.GuideAssignment()
         ga.assign_by_threshold(adata, assignment_threshold=threshold, output_layer=output_layer)
         assert output_layer in adata.layers
-        assert np.all(np.logical_xor(adata.X < threshold, adata.layers[output_layer].A == 1))
+        assert np.all(np.logical_xor(adata.X < threshold, adata.layers[output_layer].toarray() == 1))
 
     def test_grna_max_assignment(self, adata):
         threshold = 5


### PR DESCRIPTION
1. Fix types for ToyTree for isinstance check
2. Now using `toarray()` for densifying sparse scipy matrices instead of deprecated `.A`