### PR TITLE
Support for scipy 1.14

### DIFF
--- a/pertpy/preprocessing/_guide_rna.py
+++ b/pertpy/preprocessing/_guide_rna.py
@@ -48,7 +48,7 @@ class GuideAssignment:
         """
         counts = adata.X if layer is None else adata.layers[layer]
         if scipy.sparse.issparse(counts):
-            counts = counts.A
+            counts = counts.toarray()
 
         assigned_grnas = np.where(counts >= assignment_threshold, 1, 0)
         assigned_grnas = scipy.sparse.csr_matrix(assigned_grnas)
@@ -92,7 +92,7 @@ class GuideAssignment:
         """
         counts = adata.X if layer is None else adata.layers[layer]
         if scipy.sparse.issparse(counts):
-            counts = counts.A
+            counts = counts.toarray()
 
         assigned_grna = np.where(
             counts.max(axis=1).squeeze() >= assignment_threshold,
@@ -152,9 +152,9 @@ class GuideAssignment:
 
         if order_by is None:
             if scipy.sparse.issparse(data):
-                max_values = data.max(axis=1).A.squeeze()
+                max_values = data.max(axis=1).toarray().squeeze()
                 data_argmax = data.argmax(axis=1).A.squeeze()
-                max_guide_index = np.where(max_values != data.min(axis=1).A.squeeze(), data_argmax, -1)
+                max_guide_index = np.where(max_values != data.min(axis=1).toarray().squeeze(), data_argmax, -1)
             else:
                 max_guide_index = np.where(
                     data.max(axis=1).squeeze() != data.min(axis=1).squeeze(), data.argmax(axis=1).squeeze(), -1

--- a/pertpy/tools/_milo.py
+++ b/pertpy/tools/_milo.py
@@ -1014,7 +1014,7 @@ class Milo:
         if subset_nhoods is None:
             subset_nhoods = nhood_adata.obs_names
 
-        pl_df = pd.DataFrame(nhood_adata[subset_nhoods].X.A, columns=nhood_adata.var_names).melt(
+        pl_df = pd.DataFrame(nhood_adata[subset_nhoods].X.toarray(), columns=nhood_adata.var_names).melt(
             var_name=nhood_adata.uns["sample_col"], value_name="n_cells"
         )
         pl_df = pd.merge(pl_df, nhood_adata.var)

--- a/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
@@ -408,7 +408,7 @@ class PLDataset(Dataset):
 
     def __getitem__(self, idx):
         """Returns a sample and corresponding perturbations applied (labels)"""
-        sample = self.data[idx].A.squeeze() if scipy.sparse.issparse(self.data) else self.data[idx]
+        sample = self.data[idx].toarray().squeeze() if scipy.sparse.issparse(self.data) else self.data[idx]
         num_label = self.labels.iloc[idx]
         str_label = self.pert_labels.iloc[idx]
 


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [ ] Referenced issue is linked
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

The new scipy version (1.14+) deprecate the use of `.A` to access the array value of sparse matrices, which breaks some functions within pertpy. This PR fixes the issue by using the `toarray()` function to access the array value of sparse matrices.

**Technical details**

The PR fix works on both the new scipy version (1.14+) and older scipy version (1.13.1) as well. However, I was only able to test the guide RNA and milo functions, not the discriminator classifier function.

