### PR TITLE
Remove anndata pin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,10 @@ jobs:
 #                    - os: ubuntu-latest
 #                      python: "3.12"
 #                      run_mode: "fast"
-#                    - os: ubuntu-latest
-#                      python: "3.12"
-#                      run_mode: slow
-#                      pip-flags: "--pre"
+                    - os: ubuntu-latest
+                      python: "3.12"
+                      run_mode: slow
+                      pip-flags: "--pre"
 
         env:
             OS: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "pyarrow",
     "blitzgsea",
     "lamin_utils",
-    "anndata <0.10.9"  # pydeseq2 bug
+    "anndata",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Referenced issue is linked (closes #652)

**Description of changes**

The bug in PyDESeq2 caused by the new Anndata release has been fixed (see https://github.com/owkin/PyDESeq2/issues/306), so we can remove the Anndata pin.