### PR TITLE
Add uncertainty score in KNN label_transfer in PerturbationSpace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
           - id: mypy
             args: [--no-strict-optional, --ignore-missing-imports]
             additional_dependencies:
-                ["types-pkg-resources", "types-requests", "types-attrs"]
+                ["types-setuptools", "types-requests", "types-attrs"]
     - repo: local
       hooks:
           - id: forbid-to-commit

--- a/pertpy/tools/_perturbation_space/_perturbation_space.py
+++ b/pertpy/tools/_perturbation_space/_perturbation_space.py
@@ -371,6 +371,10 @@ class PerturbationSpace:
     ) -> None:
         """Impute missing values in the specified column using KNN imputation in the space defined by `use_rep`.
 
+        Uncertainty is calculated as the entropy of the label distribution in the neighborhood of the target cell.
+        In other words, a cell where all neighbors have the same set of labels will have an uncertainty of 0, whereas a cell
+        where all neighbors have many different labels will have high uncertainty.
+
         Args:
             adata: The AnnData object containing single-cell data.
             column: The column name in adata.obs to perform imputation on.

--- a/pertpy/tools/_perturbation_space/_perturbation_space.py
+++ b/pertpy/tools/_perturbation_space/_perturbation_space.py
@@ -374,7 +374,7 @@ class PerturbationSpace:
         Args:
             adata: The AnnData object containing single-cell data.
             column: The column name in adata.obs to perform imputation on.
-            column_certainty_score: The column name in adata.obs to store the certainty score of the label transfer.
+            column_uncertainty_score_key: The column name in adata.obs to store the uncertainty score of the label transfer.
             target_val: The target value to impute.
             neighbors_key: The key in adata.uns where the neighbors are stored.
 
@@ -398,7 +398,6 @@ class PerturbationSpace:
         labels = adata.obs[column].astype(str)
         target_cells = labels == target_val
 
-        # get neighbor graph from adata
         connectivities = adata.obsp[adata.uns[neighbors_key]["connectivities_key"]]
         # convert labels to an incidence matrix
         one_hot_encoded_labels = adata.obs[column].astype(str).str.get_dummies()
@@ -410,8 +409,6 @@ class PerturbationSpace:
         )
         # choose best label for each target cell
         best_labels = weighted_label_occurence.drop(target_val, axis=1)[target_cells].idxmax(axis=1)
-
-        # apply imputation
         adata.obs[column] = labels
         adata.obs.loc[target_cells, column] = best_labels
 

--- a/tests/tools/_perturbation_space/test_simple_perturbation_space.py
+++ b/tests/tools/_perturbation_space/test_simple_perturbation_space.py
@@ -247,7 +247,6 @@ def test_label_transfer():
     ps.label_transfer(adata)
     assert "unknown" not in adata.obs["perturbation"]
     assert all(adata.obs["perturbation_transfer_uncertainty"] >= 0)
-    assert all(adata.obs["perturbation_transfer_uncertainty"] <= 1)
     assert not all(adata.obs["perturbation_transfer_uncertainty"] == 0)
     is_known = adata.obs["perturbation"] != "unknown"
     assert all(adata.obs.loc[is_known, "perturbation_transfer_uncertainty"] == 0)

--- a/tests/tools/_perturbation_space/test_simple_perturbation_space.py
+++ b/tests/tools/_perturbation_space/test_simple_perturbation_space.py
@@ -248,5 +248,5 @@ def test_label_transfer():
     assert "unknown" not in adata.obs["perturbation"]
     assert all(adata.obs["perturbation_transfer_uncertainty"] >= 0)
     assert not all(adata.obs["perturbation_transfer_uncertainty"] == 0)
-    is_known = adata.obs["perturbation"] != "unknown"
+    is_known = perturbations != "unknown"
     assert all(adata.obs.loc[is_known, "perturbation_transfer_uncertainty"] == 0)

--- a/tests/tools/_perturbation_space/test_simple_perturbation_space.py
+++ b/tests/tools/_perturbation_space/test_simple_perturbation_space.py
@@ -244,10 +244,10 @@ def test_label_transfer():
     sc.tl.umap(adata)
 
     ps = pt.tl.PseudobulkSpace()
-    ps.label_transfer(adata, n_neighbors=5, use_rep="X_umap")
+    ps.label_transfer(adata)
     assert "unknown" not in adata.obs["perturbation"]
-    assert all(adata.obs["perturbation_transfer_certainty"] >= 0)
-    assert all(adata.obs["perturbation_transfer_certainty"] <= 1)
-    assert not all(adata.obs["perturbation_transfer_certainty"] == 1)
+    assert all(adata.obs["perturbation_transfer_uncertainty"] >= 0)
+    assert all(adata.obs["perturbation_transfer_uncertainty"] <= 1)
+    assert not all(adata.obs["perturbation_transfer_uncertainty"] == 0)
     is_known = adata.obs["perturbation"] != "unknown"
-    assert all(adata.obs.loc[is_known, "perturbation_transfer_certainty"] == 1)
+    assert all(adata.obs.loc[is_known, "perturbation_transfer_uncertainty"] == 0)

--- a/tests/tools/_perturbation_space/test_simple_perturbation_space.py
+++ b/tests/tools/_perturbation_space/test_simple_perturbation_space.py
@@ -246,3 +246,8 @@ def test_label_transfer():
     ps = pt.tl.PseudobulkSpace()
     ps.label_transfer(adata, n_neighbors=5, use_rep="X_umap")
     assert "unknown" not in adata.obs["perturbation"]
+    assert all(adata.obs["perturbation_transfer_certainty"] >= 0)
+    assert all(adata.obs["perturbation_transfer_certainty"] <= 1)
+    assert not all(adata.obs["perturbation_transfer_certainty"] == 1)
+    is_known = adata.obs["perturbation"] != "unknown"
+    assert all(adata.loc[is_known, "perturbation_transfer_certainty"] == 1)

--- a/tests/tools/_perturbation_space/test_simple_perturbation_space.py
+++ b/tests/tools/_perturbation_space/test_simple_perturbation_space.py
@@ -246,6 +246,7 @@ def test_label_transfer():
         ps.label_transfer(adata)
 
     sc.pp.neighbors(adata, use_rep="X")
+    sc.tl.umap(adata)
     ps = pt.tl.PseudobulkSpace()
     ps.label_transfer(adata)
     assert "unknown" not in adata.obs["perturbation"]

--- a/tests/tools/_perturbation_space/test_simple_perturbation_space.py
+++ b/tests/tools/_perturbation_space/test_simple_perturbation_space.py
@@ -250,4 +250,4 @@ def test_label_transfer():
     assert all(adata.obs["perturbation_transfer_certainty"] <= 1)
     assert not all(adata.obs["perturbation_transfer_certainty"] == 1)
     is_known = adata.obs["perturbation"] != "unknown"
-    assert all(adata.loc[is_known, "perturbation_transfer_certainty"] == 1)
+    assert all(adata.obs.loc[is_known, "perturbation_transfer_certainty"] == 1)

--- a/tests/tools/_perturbation_space/test_simple_perturbation_space.py
+++ b/tests/tools/_perturbation_space/test_simple_perturbation_space.py
@@ -240,9 +240,12 @@ def test_label_transfer():
     adata = AnnData(X)
     perturbations = np.array(["A", "B", "C"] * 22 + ["unknown"] * 3)
     adata.obs["perturbation"] = perturbations
-    sc.pp.neighbors(adata, use_rep="X")
-    sc.tl.umap(adata)
 
+    with pytest.raises(ValueError):
+        ps = pt.tl.PseudobulkSpace()
+        ps.label_transfer(adata)
+
+    sc.pp.neighbors(adata, use_rep="X")
     ps = pt.tl.PseudobulkSpace()
     ps.label_transfer(adata)
     assert "unknown" not in adata.obs["perturbation"]


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] Referenced issue is linked (NA; addresses reviewer comment)
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated (NA)

**Description of changes**

Certainty is quantified as the fraction of nearest neighbors belonging to the classified (i.e. the most abundant) label compared to the total number of nearest neighbors. This is saved in a new specified column in adata.obs as a score between 0 and 1. Cells that had a label to begin with will get highest certainty assigned.

<!-- Please state what you've changed and how it might affect the user. -->
<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**

<!-- Add any other context or screenshots here. -->
![image](https://github.com/user-attachments/assets/821bba23-c053-4345-a478-1c2d0bc05022)
![image](https://github.com/user-attachments/assets/cd01710a-2669-4664-b641-2f1972836814)

