### PR TITLE
Remove explicit anndata in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ dependencies = [
     "pyarrow",
     "blitzgsea",
     "lamin_utils",
-    "anndata",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I don't remember why we added it.