### PR TITLE
Fixed plotting for mixscape.plot_barplot and sccoda.plot_effects_barplot

### DIFF
--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1378,7 +1378,6 @@ class CompositionalModel2(ABC):
         if len(covariate_names_zero) != 0:
             if plot_facets:
                 if plot_zero_covariate and not plot_zero_cell_type:
-                    plot_df = plot_df[plot_df["value"] != 0]
                     for covariate_name_zero in covariate_names_zero:
                         new_row = {
                             "Covariate": covariate_name_zero,

--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -521,6 +521,7 @@ class Mixscape:
         legend_title_size: int = 8,
         legend_text_size: int = 8,
         legend_bbox_to_anchor: tuple[float, float] = None,
+        figsize: tuple[float, float] = (25, 25),
         show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
@@ -537,6 +538,7 @@ class Mixscape:
             legend_title_size: Size of the legend title.
             legend_text_size: Size of the legend text.
             legend_bbox_to_anchor: The bbox that the legend will be anchored.
+            figsize: The size of the figure.
             {common_plot_args}
 
         Returns:
@@ -574,7 +576,7 @@ class Mixscape:
 
         color_mapping = {"KO": "salmon", "NP": "lightgray", "NT": "grey"}
         unique_genes = NP_KO_cells["gene"].unique()
-        fig, axs = plt.subplots(int(len(unique_genes) / 5), 5, figsize=(25, 25), sharey=True)
+        fig, axs = plt.subplots(int(len(unique_genes) / 5), 5, figsize=figsize, sharey=True)
         for i, gene in enumerate(unique_genes):
             ax = axs[int(i / 5), i % 5]
             grouped_df = (
@@ -594,11 +596,8 @@ class Mixscape:
             ax.set_title(gene, bbox={"facecolor": "white", "edgecolor": "black", "pad": 1}, fontsize=axis_title_size)
             ax.set(xlabel="sgRNA", ylabel="% of cells")
             sns.despine(ax=ax, top=True, right=True, left=False, bottom=False)
-            ax.set_xticklabels(ax.get_xticklabels(), rotation=0, ha="right", fontsize=axis_text_x_size)
-            ax.set_yticklabels(ax.get_yticklabels(), rotation=0, fontsize=axis_text_y_size)
-
-            fig.subplots_adjust(right=0.8)
-            fig.subplots_adjust(hspace=0.5, wspace=0.5)
+            ax.set_xticks(ax.get_xticks(),ax.get_xticklabels(), rotation=0, ha="right", fontsize=axis_text_x_size)
+            ax.set_yticks(ax.get_yticks(), ax.get_yticklabels(), rotation=0, fontsize=axis_text_y_size)
             ax.legend(
                 title="Mixscape Class",
                 loc="center right",
@@ -608,10 +607,14 @@ class Mixscape:
                 title_fontsize=legend_title_size,
             )
 
+        fig.subplots_adjust(right=0.8)
+        fig.subplots_adjust(hspace=0.5, wspace=0.5)
+        plt.tight_layout()
+
         if show:
             plt.show()
         if return_fig:
-            return plt.gcf()
+            return  fig
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -792,12 +795,6 @@ class Mixscape:
                 plt.legend(title="gene_target", title_fontsize=14, fontsize=12)
                 sns.despine()
 
-            if show:
-                plt.show()
-            if return_fig:
-                return plt.gcf()
-            return None
-
         # If before_mixscape is False, split densities based on mixscape classifications
         else:
             if palette is None:
@@ -854,11 +851,11 @@ class Mixscape:
                 plt.legend(title="mixscape class", title_fontsize=14, fontsize=12)
                 sns.despine()
 
-            if show:
-                plt.show()
-            if return_fig:
-                return plt.gcf()
-            return None
+        if show:
+            plt.show()
+        if return_fig:
+            return plt.gcf()
+        return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
     def plot_violin(  # pragma: no cover


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Referenced issue is linked (#659, #598, https://github.com/theislab/single-cell-best-practices/issues/271 - I'll close the issues manually once this PR is merged, because I'd like to add one comment each to explain the changes to the users who opened the issue)

**Description of changes**

**mixscape.plot_barplot issue**
As reported in #659, the effects bar plot wasn't visible. Adding a simple `plt.tight_layout()` fixed the issue. I also resolved some warnings that occurred during plotting by using `ax.set_xticks` instead of `ax.set_xticklabels`.

**sccoda.plot_effects_barplot**
Reported in #598 and https://github.com/theislab/single-cell-best-practices/issues/271.
These issues were basically reporting the same problem: there was a bug in the code that caused covariates with only zero effects to be filtered out of the plotting dataframe, even when the `plot_zero_covariate` parameter was set to `True` (which is the default). This also led to incorrect figure titles. I resolved the issue by removing the line of code causing the bug.

For these results:
<img width="505" alt="Bildschirmfoto 2024-10-11 um 11 20 18" src="https://github.com/user-attachments/assets/266905b4-9400-45bd-93f5-1d3e703e9602">

So far, the generated plot looked like this (one plot missing, wrong titles):
<img width="795" alt="Bildschirmfoto 2024-10-11 um 11 20 49" src="https://github.com/user-attachments/assets/1f3466f8-5ace-4bbb-8aa8-30aeb8a25c8b">

NOW, i.e. after merging this PR, it will look like this:
![Bildschirmfoto 2024-10-11 um 11 21 22](https://github.com/user-attachments/assets/3ce8ea16-8d10-4531-b3f8-98e3dd77c403)
![Bildschirmfoto 2024-10-11 um 11 21 55](https://github.com/user-attachments/assets/6b44965e-f17f-429b-9629-04866155a4d9)
