### PR TITLE
Fix empty figure returns when show=True in plotting functions

### DIFF
--- a/pertpy/_doc.py
+++ b/pertpy/_doc.py
@@ -15,6 +15,5 @@ def _doc_params(**kwds):  # pragma: no cover
 
 
 doc_common_plot_args = """\
-show: if `True`, shows the plot.
-            return_fig: if `True`, returns figure of the plot.\
+return_fig: if `True`, returns figure of the plot, that can be used for saving.\
 """

--- a/pertpy/metadata/_cell_line.py
+++ b/pertpy/metadata/_cell_line.py
@@ -703,7 +703,6 @@ class CellLine(MetaData):
         metadata_key: str = "bulk_rna_broad",
         category: str = "cell line",
         subset_identifier: str | int | Iterable[str] | Iterable[int] | None = None,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Visualise the correlation of cell lines with annotated metadata.
@@ -798,10 +797,9 @@ class CellLine(MetaData):
                 },
             )
 
-            if show:
-                plt.show()
             if return_fig:
                 return plt.gcf()
+            plt.show()
             return None
         else:
-            raise NotImplementedError
+            raise NotImplementedError("Only 'cell line' category is supported for correlation comparison.")

--- a/pertpy/preprocessing/_guide_rna.py
+++ b/pertpy/preprocessing/_guide_rna.py
@@ -117,7 +117,6 @@ class GuideAssignment:
         layer: str | None = None,
         order_by: np.ndarray | str | None = None,
         key_to_save_order: str = None,
-        show: bool = True,
         return_fig: bool = False,
         **kwargs,
     ) -> Figure | None:
@@ -194,8 +193,7 @@ class GuideAssignment:
         finally:
             del adata.obs[temp_col_name]
 
-        if show:
-            plt.show()
         if return_fig:
             return fig
+        plt.show()
         return None

--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -978,7 +978,6 @@ class Augur:
         *,
         top_n: int = None,
         ax: Axes = None,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plot scatterplot of differential prioritization.
@@ -1037,10 +1036,9 @@ class Augur:
         legend1 = ax.legend(*scatter.legend_elements(), loc="center left", title="z-scores", bbox_to_anchor=(1, 0.5))
         ax.add_artist(legend1)
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1051,7 +1049,6 @@ class Augur:
         key: str = "augurpy_results",
         top_n: int = 10,
         ax: Axes = None,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plot a lollipop plot of the n features with largest feature importances.
@@ -1105,10 +1102,9 @@ class Augur:
         plt.ylabel("Gene")
         plt.yticks(y_axes_range, n_features["genes"])
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1118,7 +1114,6 @@ class Augur:
         *,
         key: str = "augurpy_results",
         ax: Axes = None,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plot a lollipop plot of the mean augur values.
@@ -1168,10 +1163,9 @@ class Augur:
         plt.ylabel("Cell Type")
         plt.yticks(y_axes_range, results["summary_metrics"].sort_values("mean_augur_score", axis=1).columns)
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1181,7 +1175,6 @@ class Augur:
         results2: dict[str, Any],
         *,
         top_n: int = None,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Create scatterplot with two augur results.
@@ -1239,8 +1232,7 @@ class Augur:
         plt.xlabel("Augur scores 1")
         plt.ylabel("Augur scores 2")
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None

--- a/pertpy/tools/_cinemaot.py
+++ b/pertpy/tools/_cinemaot.py
@@ -658,7 +658,6 @@ class Cinemaot:
         title: str = "CINEMA-OT matching matrix",
         min_val: float = 0.01,
         ax: Axes | None = None,
-        show: bool = True,
         return_fig: bool = False,
         **kwargs,
     ) -> Figure | None:
@@ -717,10 +716,9 @@ class Cinemaot:
         g = sns.heatmap(df, annot=True, ax=ax, **kwargs)
         plt.title(title)
 
-        if show:
-            plt.show()
         if return_fig:
             return g
+        plt.show()
         return None
 
 

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1467,8 +1467,10 @@ class CompositionalModel2(ABC):
 
         if show:
             plt.show()
-        if return_fig:
-            return plt.gcf()
+        if return_fig and plot_facets:
+            return g
+        if return_fig and not plot_facets:
+            return  plt.gcf()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1199,7 +1199,6 @@ class CompositionalModel2(ABC):
         level_order: list[str] = None,
         figsize: tuple[float, float] | None = None,
         dpi: int | None = 100,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plots a stacked barplot for all levels of a covariate or all samples (if feature_name=="samples").
@@ -1278,10 +1277,9 @@ class CompositionalModel2(ABC):
                 show_legend=show_legend,
             )
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1300,7 +1298,6 @@ class CompositionalModel2(ABC):
         args_barplot: dict | None = None,
         figsize: tuple[float, float] | None = None,
         dpi: int | None = 100,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Barplot visualization for effects.
@@ -1465,12 +1462,11 @@ class CompositionalModel2(ABC):
             cell_types = pd.unique(plot_df["Cell Type"])
             ax.set_xticklabels(cell_types, rotation=90)
 
-        if show:
-            plt.show()
         if return_fig and plot_facets:
             return g
         if return_fig and not plot_facets:
-            return  plt.gcf()
+            return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1491,7 +1487,6 @@ class CompositionalModel2(ABC):
         level_order: list[str] = None,
         figsize: tuple[float, float] | None = None,
         dpi: int | None = 100,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Grouped boxplot visualization.
@@ -1699,10 +1694,11 @@ class CompositionalModel2(ABC):
                     title=feature_name,
                 )
 
-        if show:
-            plt.show()
-        if return_fig:
+        if return_fig and plot_facets:
+            return g
+        if return_fig and not plot_facets:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1718,7 +1714,6 @@ class CompositionalModel2(ABC):
         figsize: tuple[float, float] | None = None,
         dpi: int | None = 100,
         ax: plt.Axes | None = None,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plots total variance of relative abundance versus minimum relative abundance of all cell types for determination of a reference cell type.
@@ -1822,10 +1817,9 @@ class CompositionalModel2(ABC):
 
         ax.legend(loc="upper left", bbox_to_anchor=(1, 1), ncol=1, title="Is abundant")
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1841,7 +1835,6 @@ class CompositionalModel2(ABC):
         figsize: tuple[float, float] | None = (None, None),
         dpi: int | None = 100,
         save: str | bool = False,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Tree | None:
         """Plot a tree using input ete3 tree object.
@@ -1905,10 +1898,9 @@ class CompositionalModel2(ABC):
 
         if save is not None:
             tree.render(save, tree_style=tree_style, units=units, w=figsize[0], h=figsize[1], dpi=dpi)  # type: ignore
-        if show:
-            return tree.render("%%inline", tree_style=tree_style, units=units, w=figsize[0], h=figsize[1], dpi=dpi)  # type: ignore
         if return_fig:
             return tree, tree_style
+        return tree.render("%%inline", tree_style=tree_style, units=units, w=figsize[0], h=figsize[1], dpi=dpi)  # type: ignore
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1927,7 +1919,6 @@ class CompositionalModel2(ABC):
         figsize: tuple[float, float] | None = (None, None),
         dpi: int | None = 100,
         save: str | bool = False,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Tree | None:
         """Plot a tree with colored circles on the nodes indicating significant effects with bar plots which indicate leave-level significant effects.
@@ -2094,15 +2085,16 @@ class CompositionalModel2(ABC):
 
             if save:
                 plt.savefig(save)
+            if return_fig:
+                return plt.gcf()
 
-        if save and not show_leaf_effects:
-            tree2.render(save, tree_style=tree_style, units=units)
-        if show:
-            if not show_leaf_effects:
-                return tree2.render("%%inline", tree_style=tree_style, units=units, w=figsize[0], h=figsize[1], dpi=dpi)
-        if return_fig:
-            if not show_leaf_effects:
+        else:
+            if save:
+                tree2.render(save, tree_style=tree_style, units=units)
+            if return_fig:
                 return tree2, tree_style
+            return tree2.render("%%inline", tree_style=tree_style, units=units, w=figsize[0], h=figsize[1], dpi=dpi)
+
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -2117,7 +2109,6 @@ class CompositionalModel2(ABC):
         color_map: Colormap | str | None = None,
         palette: str | Sequence[str] | None = None,
         ax: Axes = None,
-        show: bool = True,
         return_fig: bool = False,
         **kwargs,
     ) -> Figure | None:
@@ -2211,10 +2202,9 @@ class CompositionalModel2(ABC):
             **kwargs,
         )
 
-        if show:
-            plt.show()
         if return_fig:
             return fig
+        plt.show()
         return None
 
 

--- a/pertpy/tools/_dialogue.py
+++ b/pertpy/tools/_dialogue.py
@@ -1070,7 +1070,6 @@ class Dialogue:
         *,
         split_which: tuple[str, str] = None,
         mcp: str = "mcp_0",
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plots split violin plots for a given MCP and split variable.
@@ -1110,10 +1109,9 @@ class Dialogue:
         ax = sns.violinplot(data=df, x=celltype_key, y=mcp, hue=split_key, split=True)
         ax.set_xticklabels(ax.get_xticklabels(), rotation=90)
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1125,7 +1123,6 @@ class Dialogue:
         sample_id: str,
         *,
         mcp: str = "mcp_0",
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Generate a pairplot visualization for multi-cell perturbation (MCP) data.
@@ -1167,8 +1164,7 @@ class Dialogue:
         mcp_pivot = pd.concat([mcp_pivot, aggstats[color]], axis=1)
         sns.pairplot(mcp_pivot, hue=color, corner=True)
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None

--- a/pertpy/tools/_differential_gene_expression/_base.py
+++ b/pertpy/tools/_differential_gene_expression/_base.py
@@ -125,7 +125,6 @@ class MethodBase(ABC):
         shape_order: list[str] | None = None,
         x_label: str | None = None,
         y_label: str | None = None,
-        show: bool = True,
         return_fig: bool = False,
         **kwargs: int,
     ) -> Figure | None:
@@ -484,10 +483,9 @@ class MethodBase(ABC):
 
         plt.legend(loc=1, bbox_to_anchor=legend_pos, frameon=False)
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -511,7 +509,6 @@ class MethodBase(ABC):
         pvalue_template=lambda x: f"p={x:.2e}",
         boxplot_properties=None,
         palette=None,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Creates a pairwise expression plot from a Pandas DataFrame or Anndata.
@@ -679,10 +676,9 @@ class MethodBase(ABC):
             )
 
         plt.tight_layout()
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -696,7 +692,6 @@ class MethodBase(ABC):
         symbol_col: str = "variable",
         y_label: str = "Log2 fold change",
         figsize: tuple[int, int] = (10, 5),
-        show: bool = True,
         return_fig: bool = False,
         **barplot_kwargs,
     ) -> Figure | None:
@@ -762,10 +757,9 @@ class MethodBase(ABC):
         plt.xlabel("")
         plt.ylabel(y_label)
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -782,7 +776,6 @@ class MethodBase(ABC):
         figsize: tuple[int, int] = (10, 2),
         x_label: str = "Contrast",
         y_label: str = "Gene",
-        show: bool = True,
         return_fig: bool = False,
         **heatmap_kwargs,
     ) -> Figure | None:
@@ -880,10 +873,9 @@ class MethodBase(ABC):
         plt.xlabel(x_label)
         plt.ylabel(y_label)
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
 

--- a/pertpy/tools/_enrichment.py
+++ b/pertpy/tools/_enrichment.py
@@ -304,7 +304,6 @@ class Enrichment:
         groupby: str = None,
         key: str = "pertpy_enrichment",
         ax: Axes | None = None,
-        show: bool = True,
         return_fig: bool = False,
         **kwargs,
     ) -> DotPlot | None:
@@ -417,10 +416,9 @@ class Enrichment:
             **kwargs,
         )
 
-        if show:
-            plt.show()
         if return_fig:
             return fig
+        plt.show()
         return None
 
     def plot_gsea(

--- a/pertpy/tools/_milo.py
+++ b/pertpy/tools/_milo.py
@@ -727,7 +727,6 @@ class Milo:
         color_map: Colormap | str | None = None,
         palette: str | Sequence[str] | None = None,
         ax: Axes | None = None,
-        show: bool = True,
         return_fig: bool = False,
         **kwargs,
     ) -> Figure | None:
@@ -803,10 +802,9 @@ class Milo:
             **kwargs,
         )
 
-        if show:
-            plt.show()
         if return_fig:
             return fig
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -820,7 +818,6 @@ class Milo:
         color_map: Colormap | str | None = None,
         palette: str | Sequence[str] | None = None,
         ax: Axes | None = None,
-        show: bool = True,
         return_fig: bool = False,
         **kwargs,
     ) -> Figure | None:
@@ -866,10 +863,9 @@ class Milo:
             **kwargs,
         )
 
-        if show:
-            plt.show()
         if return_fig:
             return fig
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -882,7 +878,6 @@ class Milo:
         alpha: float = 0.1,
         subset_nhoods: list[str] = None,
         palette: str | Sequence[str] | dict[str, str] | None = None,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plot beeswarm plot of logFC against nhood labels
@@ -994,10 +989,9 @@ class Milo:
         plt.legend(loc="upper left", title=f"< {int(alpha * 100)}% SpatialFDR", bbox_to_anchor=(1, 1), frameon=False)
         plt.axvline(x=0, ymin=0, ymax=1, color="black", linestyle="--")
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1008,7 +1002,6 @@ class Milo:
         *,
         subset_nhoods: list[str] = None,
         log_counts: bool = False,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plot boxplot of cell numbers vs condition of interest.
@@ -1050,8 +1043,7 @@ class Milo:
         plt.xticks(rotation=90)
         plt.xlabel(test_var)
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None

--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -535,7 +535,6 @@ class Mixscape:
         legend_text_size: int = 8,
         legend_bbox_to_anchor: tuple[float, float] = None,
         figsize: tuple[float, float] = (25, 25),
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Barplot to visualize perturbation scores calculated by the `mixscape` function.
@@ -624,10 +623,9 @@ class Mixscape:
         fig.subplots_adjust(hspace=0.5, wspace=0.5)
         plt.tight_layout()
 
-        if show:
-            plt.show()
         if return_fig:
             return fig
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -643,7 +641,6 @@ class Mixscape:
         subsample_number: int | None = 900,
         vmin: float | None = -2,
         vmax: float | None = 2,
-        show: bool = True,
         return_fig: bool = False,
         **kwds,
     ) -> Figure | None:
@@ -696,10 +693,9 @@ class Mixscape:
             **kwds,
         )
 
-        if show:
-            plt.show()
         if return_fig:
             return fig
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -715,7 +711,6 @@ class Mixscape:
         split_by: str = None,
         before_mixscape: bool = False,
         perturbation_type: str = "KO",
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Density plots to visualize perturbation scores calculated by the `pt.tl.mixscape` function.
@@ -864,10 +859,9 @@ class Mixscape:
                 plt.legend(title="mixscape class", title_fontsize=14, fontsize=12)
                 sns.despine()
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -892,7 +886,6 @@ class Mixscape:
         ylabel: str | Sequence[str] | None = None,
         rotation: float | None = None,
         ax: Axes | None = None,
-        show: bool = True,
         return_fig: bool = False,
         **kwargs,
     ) -> Axes | Figure | None:
@@ -1060,12 +1053,9 @@ class Mixscape:
                 if rotation is not None:
                     ax.tick_params(axis="x", labelrotation=rotation)
 
-        show = settings.autoshow if show is None else show
         if hue is not None and stripplot is True:
             plt.legend(handles, labels)
 
-        if show:
-            plt.show()
         if return_fig:
             if multi_panel and groupby is None and len(ys) == 1:
                 return g
@@ -1073,6 +1063,7 @@ class Mixscape:
                 return axs[0]
             else:
                 return axs
+        plt.show()
         return None
 
     @_doc_params(common_plot_args=doc_common_plot_args)
@@ -1089,7 +1080,6 @@ class Mixscape:
         color_map: Colormap | str | None = None,
         palette: str | Sequence[str] | None = None,
         ax: Axes | None = None,
-        show: bool = True,
         return_fig: bool = False,
         **kwds,
     ) -> Figure | None:
@@ -1142,8 +1132,7 @@ class Mixscape:
             **kwds,
         )
 
-        if show:
-            plt.show()
         if return_fig:
             return fig
+        plt.show()
         return None

--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -181,7 +181,6 @@ class PseudobulkSpace(PerturbationSpace):
         adata: AnnData,
         groupby: str,
         *,
-        show: bool = True,
         return_fig: bool = False,
         **kwargs,
     ) -> Figure | None:
@@ -212,10 +211,9 @@ class PseudobulkSpace(PerturbationSpace):
         """
         fig = dc.plot_psbulk_samples(adata, groupby, return_fig=True, **kwargs)
 
-        if show:
-            plt.show()
         if return_fig:
             return fig
+        plt.show()
         return None
 
 

--- a/pertpy/tools/_scgen/_scgen.py
+++ b/pertpy/tools/_scgen/_scgen.py
@@ -654,7 +654,6 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
         stim_key: str,
         *,
         fontsize: float = 14,
-        show: bool = True,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plots the dot product between delta and latent representation of a linear classifier.
@@ -705,10 +704,9 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
         ax = plt.gca()
         ax.grid(False)
 
-        if show:
-            plt.show()
         if return_fig:
             return plt.gcf()
+        plt.show()
         return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "blitzgsea",
     "scikit-learn>= 1.4",  # https://github.com/scverse/pertpy/issues/700
     "lamin_utils",
+    "joblib"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ dependencies = [
     "blitzgsea",
     "scikit-learn>= 1.4",  # https://github.com/scverse/pertpy/issues/700
     "lamin_utils",
-    "joblib"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**Description of changes**

As discussed and mentioned in #702, the `show` parameter in all our plotting functions is somewhat obsolete. Additionally, if `show=True` and `return_fig=True`, an empty figure is returned because the Matplotlib plot is cleared by `show()`.  Hence, I removed the `show` parameter from all plotting functions and `plt.show()` is called by default, unless `return_fig=True`.

Additionally, for `pt.tl.Sccoda.plot_effects_barplot` and `pt.tl.Sccoda.plot_boxplots`, when `plot_facets=True`, an empty plot was returned since the plot wasn't created directly via Matplotlib. This issue has now been fixed too.  

