### PR TITLE
Align Mixscape with Seurat’s implementation

### DIFF
--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -211,8 +211,7 @@ class Mixscape:
             test_method: Method to use for differential expression testing.
             iter_num: Number of normalmixEM iterations to run if convergence does not occur.
             scale: Scale the data specified in `layer` before running the GaussianMixture model on it.
-            split_by: Provide the column `.obs` if multiple biological replicates exist to calculate
-                    the perturbation signature for every replicate separately.
+            split_by: Provide `.obs` column with experimental condition/cell type annotation, if perturbations are condition/cell type-specific.
             pval_cutoff: P-value cut-off for selection of significantly DE genes.
             perturbation_type: specify type of CRISPR perturbation expected for labeling mixscape classifications.
             random_state: Random seed for the GaussianMixture model.
@@ -239,7 +238,7 @@ class Mixscape:
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
             >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
-            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert")
         """
         if copy:
             adata = adata.copy()
@@ -434,8 +433,8 @@ class Mixscape:
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
             >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
-            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
-            >>> ms_pt.lda(mdata["rna"], "gene_target", "NT", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert")
+            >>> ms_pt.lda(mdata["rna"], "gene_target", "NT")
         """
         if copy:
             adata = adata.copy()
@@ -606,7 +605,7 @@ class Mixscape:
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
             >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
-            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert")
             >>> ms_pt.plot_barplot(mdata["rna"], guide_rna_column="NT")
 
         Preview:
@@ -712,7 +711,7 @@ class Mixscape:
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
             >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
-            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert")
             >>> ms_pt.plot_heatmap(
             ...     adata=mdata["rna"], labels="gene_target", target_gene="IFNGR2", layer="X_pert", control="NT"
             ... )
@@ -788,7 +787,7 @@ class Mixscape:
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
             >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
-            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert")
             >>> ms_pt.plot_perturbscore(adata=mdata["rna"], labels="gene_target", target_gene="IFNGR2", color="orange")
 
         Preview:
@@ -962,7 +961,7 @@ class Mixscape:
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
             >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
-            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert")
             >>> ms_pt.plot_violin(
             ...     adata=mdata["rna"], target_gene_idents=["NT", "IFNGR2 NP", "IFNGR2 KO"], groupby="mixscape_class"
             ... )
@@ -1146,7 +1145,7 @@ class Mixscape:
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
             >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
-            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert")
             >>> ms_pt.lda(mdata["rna"], "gene_target", "NT", split_by="replicate")
             >>> ms_pt.plot_lda(adata=mdata["rna"], control="NT")
 

--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -305,7 +305,7 @@ class Mixscape:
                     de_genes = perturbation_markers[(category, gene)]
                     de_genes_indices = self._get_column_indices(adata, list(de_genes))
 
-                    dat = X[np.asarray(all_cells)][:, de_genes_indices] #TODO: Improve indexing here
+                    dat = X[np.asarray(all_cells)][:, de_genes_indices]
                     dat_cells = all_cells[all_cells].index
                     if scale:
                         dat = sc.pp.scale(dat)
@@ -1186,8 +1186,8 @@ class CustomGaussianMixture(GaussianMixture):
     def __init__(
         self,
         n_components: int,
-        fixed_means: None | np.ndarray = None,
-        fixed_covariances: None | np.ndarray = None,
+        fixed_means: None | list = None,
+        fixed_covariances: None | list = None,
         **kwargs
     ):
         """

--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -239,7 +239,7 @@ class Mixscape:
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
             >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
-            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
         """
         if copy:
             adata = adata.copy()
@@ -382,11 +382,13 @@ class Mixscape:
         adata: AnnData,
         labels: str,
         control: str,
+        *,
         mixscape_class_global: str | None = "mixscape_class_global",
         layer: str | None = None,
         n_comps: int | None = 10,
         min_de_genes: int | None = 5,
         logfc_threshold: float | None = 0.25,
+        test_method: str | None = "wilcoxon",
         split_by: str | None = None,
         pval_cutoff: float | None = 5e-2,
         perturbation_type: str | None = "KO",
@@ -399,11 +401,12 @@ class Mixscape:
             labels: The column of `.obs` with target gene labels.
             control: Control category from the `pert_key` column.
             mixscape_class_global: The column of `.obs` with mixscape global classification result (perturbed, NP or NT).
-            layer: Key from `adata.layers` whose value will be used to perform tests on.
+            layer: Layer to use for identifying differentially expressed genes. If `None`, adata.X is used.
             control: Control category from the `pert_key` column.
             n_comps: Number of principal components to use.
             min_de_genes: Required number of genes that are differentially expressed for method to separate perturbed and non-perturbed cells.
             logfc_threshold: Limit testing to genes which show, on average, at least X-fold difference (log-scale) between the two groups of cells.
+            test_method: Method to use for differential expression testing.
             split_by: Provide the column `.obs` if multiple biological replicates exist to calculate
             pval_cutoff: P-value cut-off for selection of significantly DE genes.
             perturbation_type: Specify type of CRISPR perturbation expected for labeling mixscape classifications.
@@ -422,9 +425,9 @@ class Mixscape:
             >>> import pertpy as pt
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
-            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", "replicate")
-            >>> ms_pt.mixscape(adata=mdata["rna"], control="NT", labels="gene_target", layer="X_pert")
-            >>> ms_pt.lda(adata=mdata["rna"], control="NT", labels="gene_target", layer="X_pert")
+            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
+            >>> ms_pt.lda(mdata["rna"], "gene_target", "NT", split_by="replicate")
         """
         if copy:
             adata = adata.copy()
@@ -452,6 +455,7 @@ class Mixscape:
             pval_cutoff=pval_cutoff,
             min_de_genes=min_de_genes,
             logfc_threshold=logfc_threshold,
+            test_method=test_method,
         )
         adata_subset = adata[
             (adata.obs[mixscape_class_global] == perturbation_type) | (adata.obs[mixscape_class_global] == control)

--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -253,7 +253,16 @@ class Mixscape:
             split_masks = [split_obs == category for category in categories]
 
         perturbation_markers = self._get_perturbation_markers(
-            adata, split_masks, categories, labels, control, de_layer, pval_cutoff, min_de_genes, logfc_threshold, test_method
+            adata=adata,
+            split_masks=split_masks,
+            categories=categories,
+            labels=labels,
+            control=control,
+            layer=de_layer,
+            pval_cutoff=pval_cutoff,
+            min_de_genes=min_de_genes,
+            logfc_threshold=logfc_threshold,
+            test_method=test_method,
         )
 
         adata_comp = adata
@@ -317,11 +326,9 @@ class Mixscape:
                         vec = np.mean(dat[guide_cells_dat_idx], axis=0) - np.mean(dat[nt_cells_dat_idx], axis=0)
 
                         # project cells onto the perturbation vector
-                        if isinstance(dat, spmatrix): #TODO: Why sum?
-                            #pvec = np.sum(np.multiply(dat.toarray(), vec), axis=1) / np.sum(np.multiply(vec, vec))
+                        if isinstance(dat, spmatrix):
                             pvec = np.dot(dat.toarray(), vec) / np.dot(vec, vec)
                         else:
-                            #pvec = np.sum(np.multiply(dat, vec), axis=1) / np.sum(np.multiply(vec, vec))
                             pvec = np.dot(dat, vec) / np.dot(vec, vec)
                         pvec = pd.Series(np.asarray(pvec).flatten(), index=list(all_cells.index[all_cells]))
 
@@ -444,9 +451,8 @@ class Mixscape:
             categories = split_obs.unique()
             split_masks = [split_obs == category for category in categories]
 
-        mixscape_identifier = pt.tl.Mixscape()
         # determine gene sets across all splits/groups through differential gene expression
-        perturbation_markers = mixscape_identifier._get_perturbation_markers(
+        perturbation_markers = self._get_perturbation_markers(
             adata=adata,
             split_masks=split_masks,
             categories=categories,
@@ -1176,7 +1182,7 @@ class Mixscape:
         plt.show()
         return None
 
-class CustomGaussianMixture(GaussianMixture): #TODO: Improve class, add tests
+class CustomGaussianMixture(GaussianMixture):
     def __init__(
         self,
         n_components: int,

--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -414,7 +414,7 @@ class Mixscape:
             min_de_genes: Required number of genes that are differentially expressed for method to separate perturbed and non-perturbed cells.
             logfc_threshold: Limit testing to genes which show, on average, at least X-fold difference (log-scale) between the two groups of cells.
             test_method: Method to use for differential expression testing.
-            split_by: Provide the column `.obs` if multiple biological replicates exist to calculate
+            split_by: Provide `.obs` column with experimental condition/cell type annotation, if perturbations are condition/cell type-specific.
             pval_cutoff: P-value cut-off for selection of significantly DE genes.
             perturbation_type: Specify type of CRISPR perturbation expected for labeling mixscape classifications.
             copy: Determines whether a copy of the `adata` is returned.

--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -342,7 +342,7 @@ class Mixscape:
 
                         means_init = np.array([[pvec[nt_cells].mean()], [pvec[guide_cells].mean()]])
                         std_init = np.array([pvec[nt_cells].std(), pvec[guide_cells].std()])
-                        mm = CustomGaussianMixture(
+                        mm = MixscapeGaussianMixture(
                             n_components=2,
                             covariance_type="spherical",
                             means_init=means_init,
@@ -1181,16 +1181,15 @@ class Mixscape:
         plt.show()
         return None
 
-class CustomGaussianMixture(GaussianMixture):
+class MixscapeGaussianMixture(GaussianMixture):
     def __init__(
         self,
         n_components: int,
-        fixed_means: None | list = None,
-        fixed_covariances: None | list = None,
+        fixed_means:  Sequence[float] | None = None,
+        fixed_covariances: Sequence[float] | None = None,
         **kwargs
     ):
-        """
-        Custom Gaussian Mixture Model where means and covariances can be fixed for specific components.
+        """Custom Gaussian Mixture Model where means and covariances can be fixed for specific components.
 
         Args:
             n_components: Number of Gaussian components
@@ -1202,7 +1201,7 @@ class CustomGaussianMixture(GaussianMixture):
         self.fixed_means = fixed_means
         self.fixed_covariances = fixed_covariances
 
-    def _m_step(self, X, log_resp):
+    def _m_step(self, X: np.ndarray, log_resp: np.ndarray):
         """Modified M-step to respect fixed means and covariances."""
         super()._m_step(X, log_resp)
 

--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -334,16 +334,15 @@ class Mixscape:
                                 gv_list[gene] = {}
                             gv_list[gene][category] = gv
 
-                        guide_norm = self._define_normal_mixscape(pvec[guide_cells])
-                        nt_norm = self._define_normal_mixscape(pvec[nt_cells])
-                        means_init = np.array([[nt_norm[0]], [guide_norm[0]]])
-                        precisions_init = np.array([nt_norm[1], guide_norm[1]])
+                        means_init = np.array([[pvec[nt_cells].mean()], [pvec[guide_cells].mean()]])
+                        std_init = np.array([pvec[nt_cells].std(), pvec[guide_cells].std()])
                         mm = GaussianMixture(
                             n_components=2,
                             covariance_type="spherical",
                             means_init=means_init,
-                            precisions_init=precisions_init,
+                            precisions_init=1 / (std_init ** 2),
                             random_state=random_state,
+                            max_iter=5000,
                         ).fit(np.asarray(pvec).reshape(-1, 1))
                         probabilities = mm.predict_proba(np.array(pvec[orig_guide_cells_index]).reshape(-1, 1))
                         lik_ratio = probabilities[:, 0] / probabilities[:, 1]
@@ -559,20 +558,6 @@ class Mixscape:
 
         return indices
 
-    def _define_normal_mixscape(self, X: np.ndarray | sparse.spmatrix | pd.DataFrame | None) -> list[float]:
-        """Calculates the mean and standard deviation of a matrix.
-
-        Args:
-            X: The matrix to calculate the properties for.
-
-        Returns:
-            Mean and standard deviation of the matrix.
-        """
-        mu = X.mean()
-        sd = X.std()
-
-        return [mu, sd]
-
     @_doc_params(common_plot_args=doc_common_plot_args)
     def plot_barplot(  # pragma: no cover
         self,
@@ -612,8 +597,8 @@ class Mixscape:
             >>> import pertpy as pt
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
-            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", "replicate")
-            >>> ms_pt.mixscape(adata=mdata["rna"], control="NT", labels="gene_target", layer="X_pert")
+            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
             >>> ms_pt.plot_barplot(mdata["rna"], guide_rna_column="NT")
 
         Preview:
@@ -718,8 +703,8 @@ class Mixscape:
             >>> import pertpy as pt
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
-            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", "replicate")
-            >>> ms_pt.mixscape(adata=mdata["rna"], control="NT", labels="gene_target", layer="X_pert")
+            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
             >>> ms_pt.plot_heatmap(
             ...     adata=mdata["rna"], labels="gene_target", target_gene="IFNGR2", layer="X_pert", control="NT"
             ... )
@@ -794,8 +779,8 @@ class Mixscape:
             >>> import pertpy as pt
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
-            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", "replicate")
-            >>> ms_pt.mixscape(adata=mdata["rna"], control="NT", labels="gene_target", layer="X_pert")
+            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
             >>> ms_pt.plot_perturbscore(adata=mdata["rna"], labels="gene_target", target_gene="IFNGR2", color="orange")
 
         Preview:
@@ -968,8 +953,8 @@ class Mixscape:
             >>> import pertpy as pt
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
-            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", "replicate")
-            >>> ms_pt.mixscape(adata=mdata["rna"], control="NT", labels="gene_target", layer="X_pert")
+            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
             >>> ms_pt.plot_violin(
             ...     adata=mdata["rna"], target_gene_idents=["NT", "IFNGR2 NP", "IFNGR2 KO"], groupby="mixscape_class"
             ... )
@@ -1152,9 +1137,9 @@ class Mixscape:
             >>> import pertpy as pt
             >>> mdata = pt.dt.papalexi_2021()
             >>> ms_pt = pt.tl.Mixscape()
-            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", "replicate")
-            >>> ms_pt.mixscape(adata=mdata["rna"], control="NT", labels="gene_target", layer="X_pert")
-            >>> ms_pt.lda(adata=mdata["rna"], control="NT", labels="gene_target", layer="X_pert")
+            >>> ms_pt.perturbation_signature(mdata["rna"], "perturbation", "NT", split_by="replicate")
+            >>> ms_pt.mixscape(mdata["rna"], "gene_target", "NT", layer="X_pert", split_by="replicate")
+            >>> ms_pt.lda(mdata["rna"], "gene_target", "NT", split_by="replicate")
             >>> ms_pt.plot_lda(adata=mdata["rna"], control="NT")
 
         Preview:

--- a/tests/tools/test_mixscape.py
+++ b/tests/tools/test_mixscape.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import anndata
 import numpy as np
 import pandas as pd
-import scanpy as sc
 import pertpy as pt
 import pytest
 from scipy import sparse

--- a/tests/tools/test_mixscape.py
+++ b/tests/tools/test_mixscape.py
@@ -3,9 +3,12 @@ from pathlib import Path
 import anndata
 import numpy as np
 import pandas as pd
+import scanpy as sc
 import pertpy as pt
 import pytest
 from scipy import sparse
+
+from pertpy.tools._mixscape import CustomGaussianMixture
 
 CWD = Path(__file__).parent.resolve()
 
@@ -49,7 +52,7 @@ def adata():
     # obs for random AnnData
     gene_target = {"gene_target": ["NT"] * num_cells_per_group + ["target_gene_a"] * num_cells_per_group * 2}
     gene_target = pd.DataFrame(gene_target)
-    label = {"label": ["control", "treatment", "treatment"] * num_cells_per_group}
+    label = {"label": ["control"] * num_cells_per_group + ["treatment"] * num_cells_per_group* 2 }
     label = pd.DataFrame(label)
     obs = pd.concat([gene_target, label], axis=1)
     obs = obs.set_index(np.arange(num_cells_per_group * 3))
@@ -68,9 +71,9 @@ def adata():
 
 
 def test_mixscape(adata):
-    mixscape_identifier = pt.tl.Mixscape()
     adata.layers["X_pert"] = adata.X
-    mixscape_identifier.mixscape(adata=adata, control="NT", labels="gene_target")
+    mixscape_identifier = pt.tl.Mixscape()
+    mixscape_identifier.mixscape(adata=adata, labels="gene_target", control="NT", test_method="t-test")
     np_result = adata.obs["mixscape_class_global"] == "NP"
     np_result_correct = np_result[num_cells_per_group : num_cells_per_group * 2]
 
@@ -94,8 +97,8 @@ def test_perturbation_signature(adata):
 def test_lda(adata):
     adata.layers["X_pert"] = adata.X
     mixscape_identifier = pt.tl.Mixscape()
-    mixscape_identifier.mixscape(adata=adata, control="NT", labels="gene_target")
-    mixscape_identifier.lda(adata=adata, labels="gene_target", control="NT")
+    mixscape_identifier.mixscape(adata=adata, labels="gene_target", control="NT", test_method="t-test")
+    mixscape_identifier.lda(adata=adata, labels="gene_target", control="NT", test_method="t-test")
 
     assert "mixscape_lda" in adata.uns
 
@@ -155,4 +158,16 @@ def test_deterministic_perturbation_signature():
     assert np.allclose(adata.layers["X_pert"][obs["cell_class"] == "NT"], 0)
     assert np.allclose(adata.layers["X_pert"][obs["cell_class"] == "NP"], 0)
     assert np.allclose(adata.layers["X_pert"][obs["cell_class"] == "KO"], -np.concatenate([pert_effect] * len(groups), axis=0))
+
+def test_custom_gaussian_mixture_model():
+    X = np.random.rand(100)
+
+    fixed_means = [0.2, None]
+    fixed_covariances = [None, 0.1]
+
+    model = CustomGaussianMixture(n_components=2, fixed_means=fixed_means, fixed_covariances=fixed_covariances)
+    model.fit(X.reshape(-1, 1))
+
+    assert np.allclose(model.means_[0], fixed_means[0])
+    assert np.allclose(model.covariances_[1], fixed_covariances[1])
 

--- a/tests/tools/test_mixscape.py
+++ b/tests/tools/test_mixscape.py
@@ -7,7 +7,7 @@ import pertpy as pt
 import pytest
 from scipy import sparse
 
-from pertpy.tools._mixscape import CustomGaussianMixture
+from pertpy.tools._mixscape import MixscapeGaussianMixture
 
 CWD = Path(__file__).parent.resolve()
 
@@ -158,13 +158,13 @@ def test_deterministic_perturbation_signature():
     assert np.allclose(adata.layers["X_pert"][obs["cell_class"] == "NP"], 0)
     assert np.allclose(adata.layers["X_pert"][obs["cell_class"] == "KO"], -np.concatenate([pert_effect] * len(groups), axis=0))
 
-def test_custom_gaussian_mixture_model():
+def test_mixscape_gaussian_mixture():
     X = np.random.rand(100)
 
     fixed_means = [0.2, None]
     fixed_covariances = [None, 0.1]
 
-    model = CustomGaussianMixture(n_components=2, fixed_means=fixed_means, fixed_covariances=fixed_covariances)
+    model = MixscapeGaussianMixture(n_components=2, fixed_means=fixed_means, fixed_covariances=fixed_covariances)
     model.fit(X.reshape(-1, 1))
 
     assert np.allclose(model.means_[0], fixed_means[0])


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

- [X] Referenced issue is linked
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Documentation in `docs` is updated

**Description of changes**

I made the following updates to `pt.tl.Mixscape()`:  

- Added a `de_layer` parameter to `mixscape()`, since DEG computation should be based on `adata.X`, while the rest of the method operates on `adata.layers[X_pert]`, i.e., the perturbation signature. Seurat’s implementation also includes this parameter (see [here](https://github.com/satijalab/seurat/blob/9755c164d99828dbc5dd9c8364389766cd4ff7fd/R/mixscape.R#L692)).  
- Added a `test_method` parameter to `mixscape()` and `lda()` to specify the test used for DEG computation. Seurat uses Wilcoxon by default (see [here](https://github.com/satijalab/seurat/blob/9755c164d99828dbc5dd9c8364389766cd4ff7fd/R/mixscape.R#L1316)), while pertpy previously always used a t-test. Hence, users can now choose their preferred method.  
- Added a `scale` parameter to `mixscape`. By default, Seurat scales DEG expression within the respective group (see [here](https://github.com/satijalab/seurat/blob/9755c164d99828dbc5dd9c8364389766cd4ff7fd/R/mixscape.R#L802)), so I introduced an option to enable this in pertpy too, which is set to `True` by default.  
- Fixed an issue in the loop that assigns cells to NP and KO. Previously, the loop always used the original labels at the beginning of each iteration instead of updating them based on the previous iteration’s results. Now, it correctly updates the labels until convergence. This was also mentioned in issue #688.
- Implemented a `CustomGaussianMixture` model. `mixscape()` fits a Gaussian Mixture Model to perturbed and non-perturbed cells, which is then used to assign cells to NP or KO. However, Seurat’s model fixes the mean and standard deviation for the NT distributions (see [here](https://github.com/satijalab/seurat/blob/9755c164d99828dbc5dd9c8364389766cd4ff7fd/R/mixscape.R#L827)), whereas Scikit-learn’s `GaussianMixture` does not support this. Hence, so far, our implementation effectively fit two distributions instead of only one as in Seurat's case. To address this, I created a `CustomGaussianMixture` class that inherits from `GaussianMixture` and overrides the M-step of the EM algorithm, allowing to fix certain mean and/or covariance values.  
- Updated Gaussian Mixture Model initialization to align with Seurat’s approach. Seurat’s model allows specifying initial standard deviation values, while Scikit-learn’s implementation specifies precision (inverse of variance). I adjusted our initialization so that we now have the same behavior as in Seurat.
