### PR TITLE
PRISM drug response metadata annotation

### DIFF
--- a/pertpy/metadata/_cell_line.py
+++ b/pertpy/metadata/_cell_line.py
@@ -215,13 +215,13 @@ class CellLine(MetaData):
 
         Args:
             adata: The data object to annotate.
-            query_id: The column of `.obs` with cell line information.
+            query_id: The column of ``.obs`` with cell line information.
             reference_id: The type of cell line identifier in the metadata, e.g. ModelID, CellLineName	or StrippedCellLineName.
                           If fetching cell line metadata from Cancerrxgene, it is recommended to choose "stripped_cell_line_name".
             fetch: The metadata to fetch.
             cell_line_source: The source of cell line metadata, DepMap or Cancerrxgene.
             verbosity: The number of unmatched identifiers to print, can be either non-negative values or "all".
-            copy: Determines whether a copy of the `adata` is returned.
+            copy: Determines whether a copy of ``adata`` is returned.
 
         Returns:
             Returns an AnnData object with cell line annotation.
@@ -334,7 +334,8 @@ class CellLine(MetaData):
 
         Args:
             adata: The data object to annotate.
-            query_id: The column of `.obs` with cell line information. Defaults to "cell_line_name" if `cell_line_source` is sanger, otherwise "DepMap_ID".
+            query_id: The column of `.obs` with cell line information.
+                Defaults to "cell_line_name" if `cell_line_source` is sanger, otherwise "DepMap_ID".
             cell_line_source: The bulk rna expression data from either broad or sanger cell line.
             verbosity: The number of unmatched identifiers to print, can be either non-negative values or "all".
             copy: Determines whether a copy of the `adata` is returned.
@@ -580,7 +581,6 @@ class CellLine(MetaData):
 
         return adata
 
-
     def annotate_from_prism(
         self,
         adata: AnnData,
@@ -593,6 +593,7 @@ class CellLine(MetaData):
 
         For each cell, we fetch drug response data as IC50, EC50 and AUC for its
         corresponding cell line and perturbation from PRISM fitted data results file.
+        Note that all rows where either `depmap_id` or `name` is missing will be dropped.
 
         Args:
             adata: The data object to annotate.

--- a/tests/metadata/test_cell_line.py
+++ b/tests/metadata/test_cell_line.py
@@ -26,7 +26,7 @@ def adata() -> AnnData:
             "DepMap_ID": ["ACH-000016", "ACH-000049", "ACH-001208", "ACH-000956"] * NUM_CELLS_PER_ID,
             "perturbation": ["Midostaurin"] * NUM_CELLS_PER_ID * 4,
         },
-        index=[str(i) for i in range(NUM_GENES)],
+        index=[str(i) for i in range(NUM_CELLS)],
     )
 
     var_data = {"gene_name": [f"gene{i}" for i in range(1, NUM_GENES + 1)]}
@@ -49,6 +49,23 @@ def test_gdsc_annotation(adata):
     pt_metadata.annotate(adata)
     pt_metadata.annotate_from_gdsc(adata, query_id="StrippedCellLineName")
     assert "ln_ic50" in adata.obs
+    assert "auc" in adata.obs
+
+
+def test_prism_annotation(adata):
+    adata.obs = pd.DataFrame(
+        {
+            "DepMap_ID": ["ACH-000879", "ACH-000488", "ACH-000488", "ACH-000008"] * NUM_CELLS_PER_ID,
+            "perturbation": ["cytarabine", "cytarabine", "secnidazole", "flutamide"] * NUM_CELLS_PER_ID,
+        },
+        index=[str(i) for i in range(NUM_CELLS)],
+    )
+
+    pt_metadata.annotate(adata)
+    pt_metadata.annotate_from_prism(adata, query_id="DepMap_ID")
+    assert "ic50" in adata.obs
+    assert "ec50" in adata.obs
+    assert "auc" in adata.obs
 
 
 def test_protein_expression_annotation(adata):

--- a/tests/metadata/test_cell_line.py
+++ b/tests/metadata/test_cell_line.py
@@ -48,8 +48,8 @@ def test_cell_line_annotation(adata):
 def test_gdsc_annotation(adata):
     pt_metadata.annotate(adata)
     pt_metadata.annotate_from_gdsc(adata, query_id="StrippedCellLineName")
-    assert "ln_ic50" in adata.obs
-    assert "auc" in adata.obs
+    assert "ln_ic50_gdsc" in adata.obs
+    assert "auc_gdsc" in adata.obs
 
 
 def test_prism_annotation(adata):
@@ -63,9 +63,9 @@ def test_prism_annotation(adata):
 
     pt_metadata.annotate(adata)
     pt_metadata.annotate_from_prism(adata, query_id="DepMap_ID")
-    assert "ic50" in adata.obs
-    assert "ec50" in adata.obs
-    assert "auc" in adata.obs
+    assert "ic50_prism" in adata.obs
+    assert "ec50_prism" in adata.obs
+    assert "auc_prism" in adata.obs
 
 
 def test_protein_expression_annotation(adata):

--- a/tests/metadata/test_cell_line.py
+++ b/tests/metadata/test_cell_line.py
@@ -16,10 +16,7 @@ pt_metadata = pt.md.CellLine()
 
 @pytest.fixture
 def adata() -> AnnData:
-    rng = np.random.default_rng(seed=1)
-
-    X = rng.normal(0, 1, (NUM_CELLS, NUM_GENES))
-    X = np.where(X < 0, 0, X)
+    X = np.random.default_rng().normal(0, 1, (NUM_CELLS, NUM_GENES))
 
     obs = pd.DataFrame(
         {


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

- [X] Referenced issue is linked (closes #715)
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Documentation in `docs` is updated

**Description of changes**

- Added a method to annotate drug responses using the DepMap PRISM Repurposing 19Q4 secondary screen dose-response curve parameters.
- If multiple measurements for one cell line and drug are present, we take the mean IC50, EC50, and AUC values.
- PRISM IC50, EC50, and AUC values are stored in `adata.obs`.
- Added AUC annotation for GDSC data (stored in the same GDSC file we already downloaded for ln(IC50) annotation).

