### PR TITLE
Speedup Mixscape's lda function

### DIFF
--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -481,7 +481,7 @@ class Mixscape:
                 sc.pp.scale(gene_subset)
                 sc.tl.pca(gene_subset, n_comps=n_comps)
                 # project cells into PCA space of gene_subset
-                projected_pcs[key[1]] = np.dot(X, gene_subset.varm["PCs"])
+                projected_pcs[key[1]] = np.asarray(np.dot(X, gene_subset.varm["PCs"]))
         # concatenate all pcs into a single matrix.
         projected_pcs_array = np.concatenate(list(projected_pcs.values()), axis=1)
 


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [ ] Referenced issue is linked N/A
-   [ ] If you've fixed a bug or added code that should be tested, add tests! N/A
-   [ ] Documentation in `docs` is updated N/A

**Description of changes**
Speedup Mixscape's lda function by removing unused computations of sc.tl.ingest.

<!-- Please state what you've changed and how it might affect the user. -->

**Technical details**
The whole `scanpy.tools.ingest` computations, including neighborhood search, has been used in the `Mixscape.lda` computation until now.
However, its only the projection into reference PCA space that is needed. Which is [this part](https://github.com/scverse/scanpy/blob/cb83cfc08536eaca43e593218da14fae37c7e6dc/src/scanpy/tools/_ingest.py#L360) of scanpy's ingest.

This PR changes the `scanpy.tools.ingest` call with the required computations only, mean-centering the query matrix, and a matrix multiplication.

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**
`Mixscape.lda` dominated the runtime in my example mixscape workflows. Very rough verification of improved speed:

Before this change:
for 40k cells, overall runtime 1min45 seconds (`Mixscape.lda` runtime 33 seconds)
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/3432e039-d940-4a65-bdc8-4c76c23f2e3f" />


With this change:
for 40k cells, overall runtime 1min20sec (`Mixscape.lda` runtime 8.5 seconds)
<img width="1195" alt="image" src="https://github.com/user-attachments/assets/79d8dabb-fb82-48b3-ac28-a7798ae6195e" />



<!-- Add any other context or screenshots here. -->

Script, executed with `scalene <scriptname>.py --off`
```py
import muon as mu
import numpy as np
import pertpy as pt
import scanpy as sc
import pandas as pd
from scalene import scalene_profiler

# Load dataset
mdata = pt.dt.papalexi_2021()

rng = np.random.default_rng(42)
choice = rng.choice(mdata["rna"].n_obs, size=40_000, replace=True)
mdata = mdata[choice, :].copy()
mdata["rna"].obs_names_make_unique()
mdata["adt"].obs.index = mdata["rna"].obs.index.astype(str)
mdata["hto"].obs.index = mdata["rna"].obs.index.astype(str)
mdata["gdo"].obs.index = mdata["rna"].obs.index.astype(str)

scalene_profiler.start()

# Preprocessing
# RNA
sc.pp.highly_variable_genes(mdata["rna"], n_top_genes=1000, flavor='seurat_v3', subset=True)
sc.pp.normalize_total(mdata["rna"])
sc.pp.log1p(mdata["rna"])
mdata["rna"].layers["scaled"] = mdata["rna"].X.copy()
sc.pp.scale(mdata["rna"], layer="scaled")

# Protein
mu.prot.pp.clr(mdata["adt"])

# Gene expression-based cell clustering UMAP
sc.pp.pca(mdata["rna"], n_comps=50, layer="scaled")
sc.pp.neighbors(mdata["rna"], metric="cosine")
sc.tl.umap(mdata["rna"])

# Mitigating confounding effects
mixscape_identifier = pt.tl.Mixscape()
mdata["rna"].X = mdata["rna"].X.toarray()

mixscape_identifier.perturbation_signature(
    mdata["rna"], "perturbation", "NT", split_by="replicate", n_neighbors=20, n_dims=40,
)

adata_pert = mdata["rna"].copy()
adata_pert.X = adata_pert.layers["X_pert"]
sc.pp.pca(adata_pert)
sc.pp.neighbors(adata_pert, metric="cosine")
sc.tl.umap(adata_pert)

# Identify cells with no detectable perturbation
mixscape_identifier.mixscape(
    adata=mdata["rna"], control="NT", labels="gene_target", layer="X_pert", random_state=None,
)

# Visualizing perturbation responses with Linear Discriminant Analysis (LDA)
mixscape_identifier.lda(
    adata=mdata["rna"], control="NT", labels="gene_target"
)

```