### PR TITLE
(fix) Add `toytree>=3.0` pin to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tcoda = [
-    "toytree",
+    "toytree>=3.0",
     "ete4",
     "pyqt6"
 ]


### PR DESCRIPTION
While trying to run a `tascCODA` model I ran into an error caused by a check done here:
https://github.com/scverse/pertpy/blob/512c0e0f3eb25f2df915e5a4fcbeb7dcbddbd6e4/pertpy/tools/_coda/_tasccoda.py#L207

The error raised was:
```python
AttributeError: module 'toytree' has no attribute 'core'
```

`toytree.core` was introduced in version `3.0.0`: https://github.com/eaton-lab/toytree/blob/3.0.0/toytree/__init__.py

I was running `toytree-2.0.5`, upgrading to `toytree-3.0.10` fixed the bug.

This just ads a pin in `pyproject.toml` to make the requirement explicit.


(Congrats on version 1 release!)
