### PR TITLE
Add support for gamma parameter in MMD distance

### DIFF
--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1377,6 +1377,7 @@ class CompositionalModel2(ABC):
         plot_df.columns = covariate_names
         plot_df = pd.melt(plot_df, ignore_index=False, var_name="Covariate")
 
+        plot_df.index.name = "Cell Type"
         plot_df = plot_df.reset_index()
 
         if len(covariate_names_zero) != 0 and plot_facets and plot_zero_covariate and not plot_zero_cell_type:

--- a/pertpy/tools/_distances/_distance_tests.py
+++ b/pertpy/tools/_distances/_distance_tests.py
@@ -8,7 +8,7 @@ from rich.progress import track
 from sklearn.metrics import pairwise_distances
 from statsmodels.stats.multitest import multipletests
 
-from ._distances import Distance
+from ._distances import Distance, Metric
 
 if TYPE_CHECKING:
     from anndata import AnnData
@@ -43,7 +43,7 @@ class DistanceTest:
 
     def __init__(
         self,
-        metric: str,
+        metric: Metric,
         n_perms: int = 1000,
         layer_key: str = None,
         obsm_key: str = None,

--- a/pertpy/tools/_distances/_distances.py
+++ b/pertpy/tools/_distances/_distances.py
@@ -34,6 +34,31 @@ class MeanVar(NamedTuple):
     variance: float
 
 
+Metric = Literal[
+    "edistance",
+    "euclidean",
+    "root_mean_squared_error",
+    "mse",
+    "mean_absolute_error",
+    "pearson_distance",
+    "spearman_distance",
+    "kendalltau_distance",
+    "cosine_distance",
+    "r2_distance",
+    "mean_pairwise",
+    "mmd",
+    "wasserstein",
+    "sym_kldiv",
+    "t_test",
+    "ks_test",
+    "nb_ll",
+    "classifier_proba",
+    "classifier_cp",
+    "mean_var_distribution",
+    "mahalanobis",
+]
+
+
 class Distance:
     """Distance class, used to compute distances between groups of cells.
 
@@ -112,7 +137,7 @@ class Distance:
 
     def __init__(
         self,
-        metric: str = "edistance",
+        metric: Metric = "edistance",
         agg_fct: Callable = np.mean,
         layer_key: str = None,
         obsm_key: str = None,
@@ -660,19 +685,19 @@ class MMD(AbstractDistance):
         super().__init__()
         self.accepts_precomputed = False
 
-    def __call__(self, X: np.ndarray, Y: np.ndarray, kernel="linear", **kwargs) -> float:
+    def __call__(self, X: np.ndarray, Y: np.ndarray, *, kernel="linear", gamma=1.0, degree=2, **kwargs) -> float:
         if kernel == "linear":
             XX = np.dot(X, X.T)
             YY = np.dot(Y, Y.T)
             XY = np.dot(X, Y.T)
         elif kernel == "rbf":
-            XX = rbf_kernel(X, X, gamma=1.0)
-            YY = rbf_kernel(Y, Y, gamma=1.0)
-            XY = rbf_kernel(X, Y, gamma=1.0)
+            XX = rbf_kernel(X, X, gamma=gamma)
+            YY = rbf_kernel(Y, Y, gamma=gamma)
+            XY = rbf_kernel(X, Y, gamma=gamma)
         elif kernel == "poly":
-            XX = polynomial_kernel(X, X, degree=2, gamma=1.0, coef0=0)
-            YY = polynomial_kernel(Y, Y, degree=2, gamma=1.0, coef0=0)
-            XY = polynomial_kernel(X, Y, degree=2, gamma=1.0, coef0=0)
+            XX = polynomial_kernel(X, X, degree=degree, gamma=gamma, coef0=0)
+            YY = polynomial_kernel(Y, Y, degree=degree, gamma=gamma, coef0=0)
+            XY = polynomial_kernel(X, Y, degree=degree, gamma=gamma, coef0=0)
         else:
             raise ValueError(f"Kernel {kernel} not recognized.")
 

--- a/tests/tools/_distances/test_distances.py
+++ b/tests/tools/_distances/test_distances.py
@@ -127,8 +127,8 @@ def test_distance_layers(pairwise_distance, distance):
 @mark.parametrize("distance", actual_distances + pseudo_counts_distances)
 def test_distance_counts(adata, distance):
     if distance != "mahalanobis":  # skip, doesn't work because covariance matrix is a singular matrix, not invertible
-        Distance = pt.tl.Distance(distance, layer_key="counts")
-        df = Distance.pairwise(adata, groupby="perturbation")
+        distance = pt.tl.Distance(distance, layer_key="counts")
+        df = distance.pairwise(adata, groupby="perturbation")
         assert isinstance(df, DataFrame)
         assert df.columns.equals(df.index)
         assert np.sum(df.values - df.values.T) == 0


### PR DESCRIPTION
Fixes https://github.com/scverse/pertpy/issues/823

1. Now allows for:

```python
import pertpy as pt
adata = pt.dt.distance_example()
dist = pt.tl.Distance(metric="mmd")
df = dist.pairwise(adata, groupby="perturbation", gamma=0.5)
```

2. Improves typing for Metrics