### PR TITLE
Partial fixes for make_arviz

### DIFF
--- a/pertpy/tools/_coda/_sccoda.py
+++ b/pertpy/tools/_coda/_sccoda.py
@@ -393,33 +393,6 @@ class Sccoda(CompositionalModel2):
                 ref_index=ref_index,
                 sample_adata=sample_adata,
             )
-        else:
-            posterior_predictive = None
-
-        if num_prior_samples > 0:
-            prior = Predictive(self.model, num_samples=num_prior_samples)(
-                rng_key,
-                counts=None,
-                covariates=numpyro_covariates,
-                n_total=numpyro_n_total,
-                ref_index=ref_index,
-                sample_adata=sample_adata,
-            )
-        else:
-            prior = None
-
-        import arviz as az
-
-        # Create arviz object
-        if use_posterior_predictive:
-            posterior_predictive = Predictive(self.model, self.mcmc.get_samples())(
-                rng_key,
-                counts=None,
-                covariates=numpyro_covariates,
-                n_total=numpyro_n_total,
-                ref_index=ref_index,
-                sample_adata=sample_adata,
-            )
             # Remove problematic posterior predictive arrays with wrong dimensions
             if posterior_predictive and "counts" in posterior_predictive:
                 counts_shape = posterior_predictive["counts"].shape
@@ -453,6 +426,9 @@ class Sccoda(CompositionalModel2):
         else:
             prior = None
 
+        import arviz as az
+
+        # Create arviz object
         arviz_data = az.from_numpyro(
             self.mcmc, prior=prior, posterior_predictive=posterior_predictive, dims=dims, coords=coords
         )

--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -559,6 +559,15 @@ class Tasccoda(CompositionalModel2):
                 ref_index=ref_index,
                 sample_adata=sample_adata,
             )
+            # Remove problematic posterior predictive arrays with wrong dimensions
+            if posterior_predictive and "counts" in posterior_predictive:
+                counts_shape = posterior_predictive["counts"].shape
+                expected_dims = 2  # ['sample', 'cell_type']
+                if len(counts_shape) != expected_dims:
+                    posterior_predictive = {k: v for k, v in posterior_predictive.items() if k != "counts"}
+                    logger.warning(
+                        f"Removed 'counts' from posterior_predictive due to dimension mismatch: got {len(counts_shape)}D, expected {expected_dims}D"
+                    )
         else:
             posterior_predictive = None
 
@@ -571,6 +580,15 @@ class Tasccoda(CompositionalModel2):
                 ref_index=ref_index,
                 sample_adata=sample_adata,
             )
+            # Remove problematic prior arrays with wrong dimensions
+            if prior and "counts" in prior:
+                counts_shape = prior["counts"].shape
+                expected_dims = 2  # ['sample', 'cell_type']
+                if len(counts_shape) != expected_dims:
+                    prior = {k: v for k, v in prior.items() if k != "counts"}
+                    logger.warning(
+                        f"Removed 'counts' from prior due to dimension mismatch: got {len(counts_shape)}D, expected {expected_dims}D"
+                    )
         else:
             prior = None
 


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] Referenced issue is linked
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->

1. In `_sccoda.py`, `posterior_predictive` and `prior` were defined twice inside `make_arviz`. Removing the redundant definition *somewhat* mitigates the performance regression reported in [#833](https://github.com/scverse/pertpy/issues/833).
2. In `_tasccoda.py`, added the same checks for wrong `posterior_predictive["counts"]` dimensions that were added for scCODA in 8a513dcac5a790486748e01871c1fa562e181e59.