### PR TITLE
Fix: Validate 'type' parameter in Tasccoda.load

### DIFF
--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -123,7 +123,7 @@ class Tasccoda(CompositionalModel2):
         elif type == "sample_level":
             mdata = MuData({modality_key_1: AnnData(), modality_key_2: adata})
         else:
-            raise ValueError(f'{type} is not a supported type, expected "cell_level" or "sample_level"')
+            raise ValueError(f'{type} is not a supported type, expected "cell_level" or "sample_level".')
         import_tree(
             data=mdata,
             modality_1=modality_key_1,

--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -123,7 +123,7 @@ class Tasccoda(CompositionalModel2):
         elif type == "sample_level":
             mdata = MuData({modality_key_1: AnnData(), modality_key_2: adata})
         else:
-            raise ValueError(f'{type} is not a supported type, please refer to "cell_level" or "sample_level" type')
+            raise ValueError(f'{type} is not a supported type, expected "cell_level" or "sample_level"')
         import_tree(
             data=mdata,
             modality_1=modality_key_1,

--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -120,8 +120,10 @@ class Tasccoda(CompositionalModel2):
                 covariate_df=covariate_df,
             )
             mdata = MuData({modality_key_1: adata, modality_key_2: adata_coda})
-        else:
+        elif type == "sample_level":
             mdata = MuData({modality_key_1: AnnData(), modality_key_2: adata})
+        else:
+            raise ValueError(f'{type} is not a supported type, please refer to "cell_level" or "sample_level" type')
         import_tree(
             data=mdata,
             modality_1=modality_key_1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 scripts.clean = "git clean -fdX -- {args:docs}"
 
 [tool.hatch.envs.hatch-test]
-features = [ "test" ]
+features = [ "test", "tcoda" ]
 
 [tool.ruff]
 src = ["src"]

--- a/tests/tools/_coda/test_tasccoda.py
+++ b/tests/tools/_coda/test_tasccoda.py
@@ -58,6 +58,13 @@ def test_prepare(smillie_adata):
     assert np.sum(mdata["coda"].obsm["covariate_matrix"]) == 8
 
 
+def test_load_invalid_type_raises_error(smillie_adata):
+    """Check that pt.tl.Tasccoda().load() raises a ValueError for an invalid type, i.e, not 'sample_level' nor 'cell_level'"""
+    invalid_type = "an_invalid_string"
+    with pytest.raises(ValueError, match=f'"{invalid_type}" is not a supported type'):
+        tasccoda.load(smillie_adata, type=invalid_type)
+
+
 def test_run_nuts(smillie_adata):
     mdata = tasccoda.load(
         smillie_adata,

--- a/tests/tools/_coda/test_tasccoda.py
+++ b/tests/tools/_coda/test_tasccoda.py
@@ -59,9 +59,8 @@ def test_prepare(smillie_adata):
 
 
 def test_load_invalid_type_raises_error(smillie_adata):
-    """Check that pt.tl.Tasccoda().load() raises a ValueError for an invalid type, i.e, not 'sample_level' nor 'cell_level'"""
     invalid_type = "an_invalid_string"
-    with pytest.raises(ValueError, match=f'"{invalid_type}" is not a supported type'):
+    with pytest.raises(ValueError, match=f"{invalid_type} is not a supported type"):
         tasccoda.load(smillie_adata, type=invalid_type)
 
 


### PR DESCRIPTION
**Description of changes**

This PR fixes a bug in `pertpy.tl.Tasccoda.load` where providing an invalid string to the `type` parameter would not raise an error, leading to silent and incorrect behavior.

Now, the function validates the `type` parameter and raises a clear `ValueError` if it's not one of the supported options ("cell_level" or "sample_level"), guiding the user towards the correct usage.

**Technical details**

- Added an `elif` condition to explicitly check for `"sample_level"`.
- The final `else` block now raises a `ValueError` with an informative message.
- Updated `pyproject.toml` to include `tcoda` dependencies in the test environment, which was necessary to run the relevant test suite.

All tests for tascCoda passed correctly.

**Additional context**

Closes #838 

This is my first open source contribution, so any feedback is greatly appreciated!