### PR TITLE
Make JAX scGen reproduce PyTorch scGen

### DIFF
--- a/pertpy/tools/_scgen/_base_components.py
+++ b/pertpy/tools/_scgen/_base_components.py
@@ -20,7 +20,7 @@ class FlaxEncoder(nn.Module):
     activation_fn: jaxlib.xla_extension.CompiledFunction = nn.activation.leaky_relu  # type: ignore
     training: bool | None = None
     var_activation: jaxlib.xla_extension.CompiledFunction = jnp.exp  # type: ignore
-    # var_eps: float=1e-4,
+    var_eps: float = 1e-4
 
     @nn.compact
     def __call__(self, x: jnp.ndarray, training: bool | None = None) -> tuple[float, float]:
@@ -50,7 +50,7 @@ class FlaxEncoder(nn.Module):
         mean_x = nn.Dense(self.n_latent)(x)
         logvar_x = nn.Dense(self.n_latent)(x)
 
-        return mean_x, self.var_activation(logvar_x)
+        return mean_x, self.var_activation(logvar_x) + self.var_eps
 
 
 class FlaxDecoder(nn.Module):

--- a/pertpy/tools/_scgen/_scgenvae.py
+++ b/pertpy/tools/_scgen/_scgenvae.py
@@ -27,6 +27,8 @@ class JaxSCGENVAE(JaxBaseModuleClass):
     def setup(self):
         use_batch_norm_encoder = self.use_batch_norm in ("encoder", "both")
         use_layer_norm_encoder = self.use_layer_norm in ("encoder", "both")
+        use_batch_norm_decoder = self.use_batch_norm in ("decoder", "both")
+        use_layer_norm_decoder = self.use_layer_norm in ("decoder", "both")
 
         self.encoder = FlaxEncoder(
             n_latent=self.n_latent,
@@ -44,6 +46,8 @@ class JaxSCGENVAE(JaxBaseModuleClass):
             n_output=self.n_input,
             n_layers=self.n_layers,
             n_hidden=self.n_hidden,
+            use_batch_norm=use_batch_norm_decoder,
+            use_layer_norm=use_layer_norm_decoder,
             activation_fn=nn.activation.leaky_relu,
             dropout_rate=self.dropout_rate,
             training=self.training,
@@ -128,4 +132,4 @@ class JaxSCGENVAE(JaxBaseModuleClass):
         return px
 
     def get_reconstruction_loss(self, x, px):
-        return jnp.sum((x - px) ** 2)
+        return jnp.sum((x - px) ** 2, axis=-1)

--- a/tests/tools/test_scgen.py
+++ b/tests/tools/test_scgen.py
@@ -8,9 +8,14 @@ except Exception:  # noqa: BLE001
 import warnings
 
 import anndata as ad
+import jax
+import jax.numpy as jnp
 import scanpy as sc
+from scvi import REGISTRY_KEYS
 
 import pertpy as pt
+from pertpy.tools._scgen._base_components import FlaxEncoder
+from pertpy.tools._scgen._scgenvae import JaxSCGENVAE
 
 
 def test_scgen():
@@ -64,3 +69,30 @@ def test_scgen():
         show=False,
         legend=False,
     )
+
+
+def test_scgen_reconstruction_loss_is_per_cell():
+    """The reconstruction loss must be summed per cell, matching PyTorch scGen, not over the whole minibatch."""
+    module = JaxSCGENVAE(n_input=5)
+    reconstruction_loss = module.get_reconstruction_loss(jnp.zeros((4, 5)), jnp.ones((4, 5)))
+    assert reconstruction_loss.shape == (4,)
+    assert jnp.allclose(reconstruction_loss, 5.0)
+
+
+def test_scgen_decoder_uses_batch_norm():
+    """With ``use_batch_norm="both"`` the decoder must use batch norm, matching PyTorch scGen."""
+    module = JaxSCGENVAE(n_input=6, n_hidden=8, n_latent=3, n_layers=2)
+    rngs = {name: jax.random.PRNGKey(i) for i, name in enumerate(module.required_rngs)}
+    variables = module.init(rngs, {REGISTRY_KEYS.X_KEY: jnp.ones((4, 6))})
+    decoder_params = variables["params"]["decoder"]
+    assert any(key.startswith("BatchNorm") for key in decoder_params)
+
+
+def test_scgen_encoder_applies_var_eps():
+    """The encoder must add ``var_eps`` to the latent variance, matching PyTorch scGen."""
+    encoder = FlaxEncoder(n_latent=3, n_hidden=8, n_layers=1, dropout_rate=0.0, use_batch_norm=False, training=False)
+    x = jnp.ones((2, 4))
+    variables = encoder.init({"params": jax.random.PRNGKey(0)}, x)
+    _, var = encoder.apply(variables, x)
+    _, var_without_eps = encoder.clone(var_eps=0.0).apply(variables, x)
+    assert jnp.allclose(var - var_without_eps, 1e-4)


### PR DESCRIPTION
## Summary

pertpy's JAX scGen has never faithfully reproduced the canonical PyTorch scGen ([theislab/scgen](https://github.com/theislab/scgen)). Diffing the JAX module against the canonical source turned up **three concrete divergences**, all fixed here:

1. **Reconstruction loss reduced over the wrong axis (the dominant bug).**
   ```python
   # before — sums over the ENTIRE minibatch → scalar
   return jnp.sum((x - px) ** 2)
   # after — per cell, sum over genes → vector [batch], matching scGen's .sum(dim=1)
   return jnp.sum((x - px) ** 2, axis=-1)
   ```
   With `loss = mean(0.5 * rl + 0.5 * kl * kl_weight)`, the old scalar `rl` scaled with `batch_size`, dwarfing the KL term and making the objective batch-size dependent.

2. **Decoder was missing batch norm.** Canonical `DecoderSCGEN` uses scvi `FCLayers` (default `use_batch_norm=True`) and `SCGENVAE` runs with `use_batch_norm="both"`. pertpy built `FlaxDecoder` without passing `use_batch_norm`, so it defaulted to `False`. Now the decoder honors `use_batch_norm`/`use_layer_norm` like the encoder.

3. **Encoder did not add `var_eps`.** scvi's `Encoder` adds `var_eps=1e-4` to the latent variance; the Flax encoder now does too.

The architecture otherwise already matched (n_hidden=800, n_latent=100, n_layers=2, dropout=0.2, LeakyReLU, BN momentum/eps).

## Verification

- **Offline numerical parity:** with identical parameters and inputs, the module's training loss now equals the canonical scGen objective recomputed by hand — `6.5323769911546…` vs `6.5323769911546…`, matching to ~15 significant digits.
- The end-to-end train → `batch_removal` → `predict` → reg-mean/var pipeline still runs.

## Tests

Added three regression tests (no new dependency) pinning each fix:
- `test_scgen_reconstruction_loss_is_per_cell` — reconstruction loss has shape `(n_cells,)`.
- `test_scgen_decoder_uses_batch_norm` — the decoder has `BatchNorm` params under `use_batch_norm="both"`.
- `test_scgen_encoder_applies_var_eps` — the encoder adds `var_eps` to the variance.

## Note

This **changes outputs for existing users** — intentionally, since the prior behavior did not reproduce scGen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)