### PR TITLE
Restore scGen batch-removal tutorial in the docs

### DIFF
--- a/docs/tutorials/tools.md
+++ b/docs/tutorials/tools.md
@@ -55,6 +55,14 @@
    notebooks/scgen_perturbation_prediction
 ```
 
+## Batch correction
+
+```{eval-rst}
+.. nbgallery::
+
+   notebooks/scgen_batch_removal
+```
+
 ## Perturbation space
 
 ```{eval-rst}


### PR DESCRIPTION
Brings back the scGen batch-removal tutorial and renders it in the docs.

## Changes
- Bumps the `docs/tutorials/notebooks` submodule to include the restored `scgen_batch_removal.ipynb` (scverse/pertpy-tutorials#66).
- Adds `notebooks/scgen_batch_removal` to the tutorials gallery in `docs/tutorials/tools.md` under a new **Batch correction** section, so it renders.

## Context
The batch-removal tutorial was removed from `pertpy-tutorials` in late 2023 (`4ef5318`). It has been restored and modernized (current `pt.tl.Scgen` API, `kang_2018` schema, runs in ~2 min on CPU). The docs build renders stored notebook outputs (`nb_execution_mode = "off"`), and the notebook's outputs were regenerated with the scGen reproduction fix in #1028.

## Dependencies / merge order
1. Merge scverse/pertpy-tutorials#66 first.
2. Re-point this submodule to the resulting `main` commit (the current pointer is the PR branch commit), then merge.
3. Best paired with #1028 (scGen reproduction fix), which makes the demonstrated results correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)