### PR TITLE
Type check pertpy and tests with mypy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,12 +105,29 @@ jobs:
           fail_ci_if_error: true
           use_oidc: true
 
+  lint:
+    name: Pre-commit checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          cache-dependency-glob: pyproject.toml
+      - run: uvx prek run --all-files --show-diff-on-failure --color=always
+
   check:
     name: Tests pass in all hatch environments
     if: always()
     needs:
       - get-environments
       - test
+      - lint
     runs-on: ubuntu-latest
     steps:
         - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 fail_fast: false
+ci:
+    skip: [mypy] # needs the project environment, which pre-commit.ci cannot provide
 default_language_version:
     python: python3
 default_stages:
@@ -33,13 +35,16 @@ repos:
           - id: check-merge-conflict
           - id: no-commit-to-branch
             args: ["--branch=main"]
-    - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v2.3.0
+    - repo: local
       hooks:
           - id: mypy
-            args: [--no-strict-optional, --ignore-missing-imports]
-            additional_dependencies:
-                ["types-setuptools", "types-requests", "types-attrs"]
+            name: mypy
+            entry: uv run --extra dev --extra de --extra tcoda --extra test mypy pertpy tests
+            language: system
+            types: [python]
+            files: ^(pertpy|tests)/
+            require_serial: true
+            pass_filenames: false
     - repo: https://github.com/zizmorcore/zizmor-pre-commit
       rev: v1.27.0
       hooks:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -159,9 +159,16 @@ git pull --rebase
 to integrate the changes into yours.
 While the [pre-commit.ci][] is useful, we strongly encourage installing and running pre-commit locally first to understand its usage.
 
+One of the hooks type-checks `pertpy` and `tests` with [mypy][].
+It runs against the project environment rather than an isolated one, so that the real types of the dependencies are used.
+This means it cannot run on [pre-commit.ci][] and is instead checked by the `Pre-commit checks` job of the GitHub Actions CI.
+Type hints are optional: mypy only checks functions that carry annotations, so untyped code is left untouched.
+To silence a specific line, append a `# type: ignore[<error-code>]` comment.
+
 Finally, most editors have an _autoformat on save_ feature.
 Consider enabling this option for [ruff][ruff-editors] and [biome][biome-editors].
 
+[mypy]: https://mypy.readthedocs.io/
 [pre-commit]: https://pre-commit.com/
 [pre-commit.ci]: https://pre-commit.ci/
 [ruff-editors]: https://docs.astral.sh/ruff/integrations/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -159,10 +159,8 @@ git pull --rebase
 to integrate the changes into yours.
 While the [pre-commit.ci][] is useful, we strongly encourage installing and running pre-commit locally first to understand its usage.
 
-One of the hooks type-checks `pertpy` and `tests` with [mypy][].
-It runs against the project environment rather than an isolated one, so that the real types of the dependencies are used.
-This means it cannot run on [pre-commit.ci][] and is instead checked by the `Pre-commit checks` job of the GitHub Actions CI.
-Type hints are optional: mypy only checks functions that carry annotations, so untyped code is left untouched.
+One of the hooks type-checks `pertpy` and `tests` with [mypy][], which the `Pre-commit checks` CI job runs on every pull request.
+Type hints are optional: mypy only checks functions that carry annotations.
 To silence a specific line, append a `# type: ignore[<error-code>]` comment.
 
 Finally, most editors have an _autoformat on save_ feature.

--- a/pertpy/__init__.py
+++ b/pertpy/__init__.py
@@ -13,7 +13,7 @@ warnings.filterwarnings("ignore", category=UserWarning, module="scvi._settings")
 warnings.filterwarnings("ignore", message="Environment variable.*redefined by R")
 warnings.filterwarnings("ignore", message="Transforming to str index.", category=ImplicitModificationWarning)
 
-import mudata
+import mudata  # type: ignore[import-untyped]
 
 mudata.set_options(pull_on_update=False)
 

--- a/pertpy/_logger.py
+++ b/pertpy/_logger.py
@@ -314,7 +314,7 @@ class RootLogger(logging.RootLogger):
         msg: str,
         *,
         extra: dict | None = None,
-        time: datetime = None,
+        time: datetime | None = None,
         deep: str | None = None,
     ) -> datetime:
         """Log message with level and return current time.

--- a/pertpy/_types.py
+++ b/pertpy/_types.py
@@ -12,27 +12,28 @@ SpBase = sparse.spmatrix
 RandomStateLike = int | np.random.Generator | np.random.RandomState | None
 
 
-def as_matrix(X: object) -> np.ndarray | CSBase:
-    """Narrow a matrix such as :attr:`~anndata.AnnData.X` to the types pertpy operates on.
+def cast_matrix(X: object) -> np.ndarray | CSBase:
+    """Cast a matrix such as :attr:`~anndata.AnnData.X` to the types pertpy operates on.
 
-    This is a static narrowing without a runtime effect: `AnnData` types its matrices as a union that also
-    includes backed, dask and cupy containers, none of which the functions using this helper accept.
+    `AnnData` types its matrices as a union that also includes backed, dask and cupy containers,
+    none of which the functions using this cast accept.
+    Like every `cast`, this only informs the type checker and does not convert anything at runtime.
     """
     return cast("np.ndarray | CSBase", X)
 
 
-def as_dense(X: object) -> np.ndarray:
-    """Narrow a matrix that the surrounding code only supports as a dense array.
+def cast_dense(X: object) -> np.ndarray:
+    """Cast a matrix that the surrounding code only supports as a dense array.
 
-    This is a static narrowing without a runtime effect, see :func:`as_matrix`.
+    Unlike :func:`fast_array_utils.conv.to_dense`, this does not densify anything, see :func:`cast_matrix`.
     """
     return cast("np.ndarray", X)
 
 
-def as_frame(df: object) -> pd.DataFrame:
-    """Narrow an annotation frame such as :attr:`~anndata.AnnData.obs` to a :class:`~pandas.DataFrame`.
+def cast_frame(df: object) -> pd.DataFrame:
+    """Cast an annotation frame such as :attr:`~anndata.AnnData.obs` to a :class:`~pandas.DataFrame`.
 
-    This is a static narrowing without a runtime effect: `AnnData` also types them as the `Dataset2D` of a
-    lazily read object, which the functions using this helper do not accept.
+    `AnnData` also types them as the `Dataset2D` of a lazily read object, which the functions using this cast
+    do not accept, see :func:`cast_matrix`.
     """
     return cast("pd.DataFrame", df)

--- a/pertpy/_types.py
+++ b/pertpy/_types.py
@@ -1,9 +1,38 @@
+from typing import cast
+
 import numpy as np
+import pandas as pd
 from scipy import sparse
 
-CSBase = sparse.csr_matrix | sparse.csc_matrix
+CSBase = sparse.csr_matrix | sparse.csc_matrix | sparse.csr_array | sparse.csc_array
 CSRBase = sparse.csr_matrix
 CSCBase = sparse.csc_matrix
 SpBase = sparse.spmatrix
 
 RandomStateLike = int | np.random.Generator | np.random.RandomState | None
+
+
+def as_matrix(X: object) -> np.ndarray | CSBase:
+    """Narrow a matrix such as :attr:`~anndata.AnnData.X` to the types pertpy operates on.
+
+    This is a static narrowing without a runtime effect: `AnnData` types its matrices as a union that also
+    includes backed, dask and cupy containers, none of which the functions using this helper accept.
+    """
+    return cast("np.ndarray | CSBase", X)
+
+
+def as_dense(X: object) -> np.ndarray:
+    """Narrow a matrix that the surrounding code only supports as a dense array.
+
+    This is a static narrowing without a runtime effect, see :func:`as_matrix`.
+    """
+    return cast("np.ndarray", X)
+
+
+def as_frame(df: object) -> pd.DataFrame:
+    """Narrow an annotation frame such as :attr:`~anndata.AnnData.obs` to a :class:`~pandas.DataFrame`.
+
+    This is a static narrowing without a runtime effect: `AnnData` also types them as the `Dataset2D` of a
+    lazily read object, which the functions using this helper do not accept.
+    """
+    return cast("pd.DataFrame", df)

--- a/pertpy/data/_dataloader.py
+++ b/pertpy/data/_dataloader.py
@@ -4,7 +4,7 @@ import time
 from pathlib import Path
 from zipfile import ZipFile
 
-import pooch
+import pooch  # type: ignore[import-untyped]
 import requests
 from rich.progress import Progress, TaskID
 
@@ -26,21 +26,22 @@ class _RichProgress:
         self._task: TaskID | None = None
         self.total: int | None = None
 
-    def _ensure_started(self) -> None:
-        if self._progress is None:
+    def _ensure_started(self) -> tuple[Progress, TaskID]:
+        if self._progress is None or self._task is None:
             self._progress = Progress(refresh_per_second=3)
             self._progress.start()
             self._task = self._progress.add_task(self._description, total=self.total or None)
+        return self._progress, self._task
 
     def update(self, n: int) -> None:
-        self._ensure_started()
-        if self.total is not None and self._progress.tasks[self._task].total != self.total:
-            self._progress.update(self._task, total=self.total or None)
-        self._progress.update(self._task, advance=n)
+        progress, task = self._ensure_started()
+        if self.total is not None and progress.tasks[task].total != self.total:
+            progress.update(task, total=self.total or None)
+        progress.update(task, advance=n)
 
     def reset(self) -> None:
-        self._ensure_started()
-        self._progress.reset(self._task, total=self.total or None)
+        progress, task = self._ensure_started()
+        progress.reset(task, total=self.total or None)
 
     def close(self) -> None:
         if self._progress is not None:

--- a/pertpy/data/_datasets.py
+++ b/pertpy/data/_datasets.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from anndata import AnnData
-from mudata import MuData
+from mudata import MuData  # type: ignore[import-untyped]
 from scanpy import settings
 
 from pertpy.data._dataloader import _download

--- a/pertpy/metadata/_cell_line.py
+++ b/pertpy/metadata/_cell_line.py
@@ -667,15 +667,15 @@ class CellLine(MetaData):
         corr, pvals = self._pairwise_correlation(
             cast_dense(overlapped_cl.X),
             metadata_values,
-            row_name=cast_frame(overlapped_cl.obs)[identifier],
-            col_name=cast_frame(overlapped_cl.obs)[identifier],
+            row_name=overlapped_cl.obs[identifier],
+            col_name=overlapped_cl.obs[identifier],
         )
         if missing_cl is not None:
             new_corr, new_pvals = self._pairwise_correlation(
                 cast_dense(missing_cl.X),
                 metadata_values,
-                row_name=cast_frame(missing_cl.obs)[identifier],
-                col_name=cast_frame(overlapped_cl.obs)[identifier],
+                row_name=missing_cl.obs[identifier],
+                col_name=overlapped_cl.obs[identifier],
             )
         else:
             new_corr = new_pvals = None
@@ -732,10 +732,10 @@ class CellLine(MetaData):
                 subset_identifier_list = (
                     [subset_identifier] if isinstance(subset_identifier, str | int) else list(subset_identifier)
                 )
-                identifiers = np.asarray(cast_frame(adata.obs)[identifier].values)
+                identifiers = np.asarray(adata.obs[identifier].values)
                 # Convert the valid identifiers to the index list
                 if all(isinstance(id, str) for id in subset_identifier_list):
-                    if set(subset_identifier_list).issubset(cast_frame(adata.obs)[identifier].unique()):
+                    if set(subset_identifier_list).issubset(adata.obs[identifier].unique()):
                         subset_indices = np.where(np.isin(identifiers, np.asarray(subset_identifier_list)))[0]
                     else:
                         raise ValueError("`Subset_identifier` must be found in adata.obs.`identifier`.")

--- a/pertpy/metadata/_cell_line.py
+++ b/pertpy/metadata/_cell_line.py
@@ -15,7 +15,7 @@ import pandas as pd
 from scipy import stats
 
 from pertpy._doc import _doc_params, doc_common_plot_args
-from pertpy._types import as_dense, as_frame, as_matrix
+from pertpy._types import cast_dense, cast_frame, cast_matrix
 
 from ._look_up import LookUp
 from ._metadata import MetaData
@@ -183,7 +183,7 @@ class CellLine(MetaData):
             # Sometimes there is already different cell line information in the AnnData object.
             # To avoid redundant information we will remove duplicate information from metadata after merging.
             adata.obs = (
-                as_frame(adata.obs)
+                cast_frame(adata.obs)
                 .merge(
                     cell_line_meta if fetch is None else cell_line_meta[fetch],
                     left_on=query_id,
@@ -199,7 +199,7 @@ class CellLine(MetaData):
             # which is redundant as they refer to the same information.
             # We will move the reference_id column.
             if query_id != reference_id:
-                del as_frame(adata.obs)[reference_id]
+                del cast_frame(adata.obs)[reference_id]
 
         else:
             raise ValueError(
@@ -464,7 +464,7 @@ class CellLine(MetaData):
             adata.obs.index.name = "original_index"
         old_index_name = adata.obs.index.name
         adata.obs = (
-            as_frame(adata.obs)
+            cast_frame(adata.obs)
             .reset_index()
             .set_index([query_id, query_perturbation])
             .assign(ln_ic50_gdsc=gdsc_data.set_index([reference_id, reference_perturbation]).ln_ic50)
@@ -517,7 +517,7 @@ class CellLine(MetaData):
         prism_data = self.drug_response_prism
         # PRISM starts most drug names with a lowercase letter, so we want to make it case-insensitive
         prism_data["name_lower"] = prism_data["name"].str.lower()
-        adata.obs["perturbation_lower"] = as_frame(adata.obs)[query_perturbation].str.lower()
+        adata.obs["perturbation_lower"] = cast_frame(adata.obs)[query_perturbation].str.lower()
 
         identifier_num_all = len(adata.obs[query_id].unique())
         not_matched_identifiers = list(set(adata.obs[query_id]) - set(prism_data["depmap_id"]))
@@ -534,7 +534,7 @@ class CellLine(MetaData):
             adata.obs.index.name = "original_index"
         old_index_name = adata.obs.index.name
         adata.obs = (
-            as_frame(adata.obs)
+            cast_frame(adata.obs)
             .reset_index()
             .set_index([query_id, "perturbation_lower"])
             .assign(ic50_prism=prism_data.set_index(["depmap_id", "name"]).ic50)
@@ -647,7 +647,7 @@ class CellLine(MetaData):
             raise ValueError("The metadata can not be found in adata.obsm")
         if identifier not in adata.obs:
             raise ValueError("The identifier can not be found in adata.obs")
-        if as_matrix(adata.X).shape[1] != adata.obsm[metadata_key].shape[1]:
+        if cast_matrix(adata.X).shape[1] != adata.obsm[metadata_key].shape[1]:
             raise ValueError(
                 "Dimensions of adata.X do not match those of metadata. Ensure that they have the same gene list."
             )
@@ -659,23 +659,23 @@ class CellLine(MetaData):
             )
 
         # Divide cell lines into those are present and not present in the metadata
-        metadata_df = as_frame(adata.obsm[metadata_key])
+        metadata_df = cast_frame(adata.obsm[metadata_key])
         overlapped_cl = adata[~metadata_df.isna().all(axis=1), :]
         missing_cl = adata[metadata_df.isna().all(axis=1), :]
 
-        metadata_values = as_frame(overlapped_cl.obsm[metadata_key]).values
+        metadata_values = cast_frame(overlapped_cl.obsm[metadata_key]).values
         corr, pvals = self._pairwise_correlation(
-            as_dense(overlapped_cl.X),
+            cast_dense(overlapped_cl.X),
             metadata_values,
-            row_name=as_frame(overlapped_cl.obs)[identifier],
-            col_name=as_frame(overlapped_cl.obs)[identifier],
+            row_name=cast_frame(overlapped_cl.obs)[identifier],
+            col_name=cast_frame(overlapped_cl.obs)[identifier],
         )
         if missing_cl is not None:
             new_corr, new_pvals = self._pairwise_correlation(
-                as_dense(missing_cl.X),
+                cast_dense(missing_cl.X),
                 metadata_values,
-                row_name=as_frame(missing_cl.obs)[identifier],
-                col_name=as_frame(overlapped_cl.obs)[identifier],
+                row_name=cast_frame(missing_cl.obs)[identifier],
+                col_name=cast_frame(overlapped_cl.obs)[identifier],
             )
         else:
             new_corr = new_pvals = None
@@ -725,17 +725,17 @@ class CellLine(MetaData):
                         f"Mean p-value: {np.mean(np.diag(pval)):.4f}",
                     )
                 )
-                plt.scatter(x=as_frame(adata.obsm[metadata_key]), y=as_dense(adata.X))
+                plt.scatter(x=cast_frame(adata.obsm[metadata_key]), y=cast_dense(adata.X))
                 plt.xlabel(metadata_key)
                 plt.ylabel("Baseline")
             else:
                 subset_identifier_list = (
                     [subset_identifier] if isinstance(subset_identifier, str | int) else list(subset_identifier)
                 )
-                identifiers = np.asarray(as_frame(adata.obs)[identifier].values)
+                identifiers = np.asarray(cast_frame(adata.obs)[identifier].values)
                 # Convert the valid identifiers to the index list
                 if all(isinstance(id, str) for id in subset_identifier_list):
-                    if set(subset_identifier_list).issubset(as_frame(adata.obs)[identifier].unique()):
+                    if set(subset_identifier_list).issubset(cast_frame(adata.obs)[identifier].unique()):
                         subset_indices = np.where(np.isin(identifiers, np.asarray(subset_identifier_list)))[0]
                     else:
                         raise ValueError("`Subset_identifier` must be found in adata.obs.`identifier`.")
@@ -747,8 +747,8 @@ class CellLine(MetaData):
                     raise ValueError("`Subset_identifier` must contain either all strings or all integers.")
 
                 plt.scatter(
-                    x=as_frame(adata.obsm[metadata_key]).iloc[subset_indices],
-                    y=as_dense(adata[subset_indices].X),
+                    x=cast_frame(adata.obsm[metadata_key]).iloc[subset_indices],
+                    y=cast_dense(adata[subset_indices].X),
                 )
                 plt.xlabel(
                     f"{metadata_key}: {identifiers[subset_indices[0]]}"

--- a/pertpy/metadata/_cell_line.py
+++ b/pertpy/metadata/_cell_line.py
@@ -15,6 +15,7 @@ import pandas as pd
 from scipy import stats
 
 from pertpy._doc import _doc_params, doc_common_plot_args
+from pertpy._types import as_dense, as_frame, as_matrix
 
 from ._look_up import LookUp
 from ._metadata import MetaData
@@ -182,7 +183,8 @@ class CellLine(MetaData):
             # Sometimes there is already different cell line information in the AnnData object.
             # To avoid redundant information we will remove duplicate information from metadata after merging.
             adata.obs = (
-                adata.obs.merge(
+                as_frame(adata.obs)
+                .merge(
                     cell_line_meta if fetch is None else cell_line_meta[fetch],
                     left_on=query_id,
                     right_on=reference_id,
@@ -197,7 +199,7 @@ class CellLine(MetaData):
             # which is redundant as they refer to the same information.
             # We will move the reference_id column.
             if query_id != reference_id:
-                del adata.obs[reference_id]
+                del as_frame(adata.obs)[reference_id]
 
         else:
             raise ValueError(
@@ -211,7 +213,7 @@ class CellLine(MetaData):
     def annotate_bulk_rna(
         self,
         adata: AnnData,
-        query_id: str = None,
+        query_id: str | None = None,
         cell_line_source: Literal["broad", "sanger"] = "sanger",
         verbosity: int | str = 5,
         gene_identifier: Literal["gene_name", "gene_ID", "both"] = "gene_ID",
@@ -462,7 +464,8 @@ class CellLine(MetaData):
             adata.obs.index.name = "original_index"
         old_index_name = adata.obs.index.name
         adata.obs = (
-            adata.obs.reset_index()
+            as_frame(adata.obs)
+            .reset_index()
             .set_index([query_id, query_perturbation])
             .assign(ln_ic50_gdsc=gdsc_data.set_index([reference_id, reference_perturbation]).ln_ic50)
             .assign(auc_gdsc=gdsc_data.set_index([reference_id, reference_perturbation]).auc)
@@ -514,7 +517,7 @@ class CellLine(MetaData):
         prism_data = self.drug_response_prism
         # PRISM starts most drug names with a lowercase letter, so we want to make it case-insensitive
         prism_data["name_lower"] = prism_data["name"].str.lower()
-        adata.obs["perturbation_lower"] = adata.obs[query_perturbation].str.lower()
+        adata.obs["perturbation_lower"] = as_frame(adata.obs)[query_perturbation].str.lower()
 
         identifier_num_all = len(adata.obs[query_id].unique())
         not_matched_identifiers = list(set(adata.obs[query_id]) - set(prism_data["depmap_id"]))
@@ -531,7 +534,8 @@ class CellLine(MetaData):
             adata.obs.index.name = "original_index"
         old_index_name = adata.obs.index.name
         adata.obs = (
-            adata.obs.reset_index()
+            as_frame(adata.obs)
+            .reset_index()
             .set_index([query_id, "perturbation_lower"])
             .assign(ic50_prism=prism_data.set_index(["depmap_id", "name"]).ic50)
             .assign(ec50_prism=prism_data.set_index(["depmap_id", "name"]).ec50)
@@ -595,7 +599,7 @@ class CellLine(MetaData):
         )
 
     def _pairwise_correlation(
-        self, mat1: np.array, mat2: np.array, row_name: Iterable, col_name: Iterable
+        self, mat1: np.ndarray, mat2: np.ndarray, row_name: Iterable, col_name: Iterable
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Calculate the row-wise pearson correlation between two matrices.
 
@@ -618,10 +622,10 @@ class CellLine(MetaData):
                     pvals[i, j] = pvals[j, i]
                 else:
                     corr[i, j], pvals[i, j] = stats.pearsonr(mat1[i], mat2[j])
-        corr = pd.DataFrame(corr, index=row_name, columns=col_name)
-        pvals = pd.DataFrame(pvals, index=row_name, columns=col_name)
+        corr_df = pd.DataFrame(corr, index=list(row_name), columns=list(col_name))
+        pvals_df = pd.DataFrame(pvals, index=list(row_name), columns=list(col_name))
 
-        return corr, pvals
+        return corr_df, pvals_df
 
     def correlate(
         self,
@@ -643,35 +647,35 @@ class CellLine(MetaData):
             raise ValueError("The metadata can not be found in adata.obsm")
         if identifier not in adata.obs:
             raise ValueError("The identifier can not be found in adata.obs")
-        if adata.X.shape[1] != adata.obsm[metadata_key].shape[1]:
+        if as_matrix(adata.X).shape[1] != adata.obsm[metadata_key].shape[1]:
             raise ValueError(
                 "Dimensions of adata.X do not match those of metadata. Ensure that they have the same gene list."
             )
         # Raise error if the genes are not the same
-        if (
-            isinstance(adata.obsm[metadata_key], pd.DataFrame)
-            and sum(adata.obsm[metadata_key].columns != adata.var.index.values) > 0
-        ):
+        metadata = adata.obsm[metadata_key]
+        if isinstance(metadata, pd.DataFrame) and sum(metadata.columns != adata.var.index.values) > 0:
             raise ValueError(
                 "Column name of metadata is not the same as the index of `adata.var`. Ensure that the genes are in the same order."
             )
 
         # Divide cell lines into those are present and not present in the metadata
-        overlapped_cl = adata[~adata.obsm[metadata_key].isna().all(axis=1), :]
-        missing_cl = adata[adata.obsm[metadata_key].isna().all(axis=1), :]
+        metadata_df = as_frame(adata.obsm[metadata_key])
+        overlapped_cl = adata[~metadata_df.isna().all(axis=1), :]
+        missing_cl = adata[metadata_df.isna().all(axis=1), :]
 
+        metadata_values = as_frame(overlapped_cl.obsm[metadata_key]).values
         corr, pvals = self._pairwise_correlation(
-            overlapped_cl.X,
-            overlapped_cl.obsm[metadata_key].values,
-            row_name=overlapped_cl.obs[identifier],
-            col_name=overlapped_cl.obs[identifier],
+            as_dense(overlapped_cl.X),
+            metadata_values,
+            row_name=as_frame(overlapped_cl.obs)[identifier],
+            col_name=as_frame(overlapped_cl.obs)[identifier],
         )
         if missing_cl is not None:
             new_corr, new_pvals = self._pairwise_correlation(
-                missing_cl.X,
-                overlapped_cl.obsm[metadata_key].values,
-                row_name=missing_cl.obs[identifier],
-                col_name=overlapped_cl.obs[identifier],
+                as_dense(missing_cl.X),
+                metadata_values,
+                row_name=as_frame(missing_cl.obs)[identifier],
+                col_name=as_frame(overlapped_cl.obs)[identifier],
             )
         else:
             new_corr = new_pvals = None
@@ -721,46 +725,41 @@ class CellLine(MetaData):
                         f"Mean p-value: {np.mean(np.diag(pval)):.4f}",
                     )
                 )
-                plt.scatter(x=adata.obsm[metadata_key], y=adata.X)
+                plt.scatter(x=as_frame(adata.obsm[metadata_key]), y=as_dense(adata.X))
                 plt.xlabel(metadata_key)
                 plt.ylabel("Baseline")
             else:
                 subset_identifier_list = (
                     [subset_identifier] if isinstance(subset_identifier, str | int) else list(subset_identifier)
                 )
+                identifiers = np.asarray(as_frame(adata.obs)[identifier].values)
                 # Convert the valid identifiers to the index list
                 if all(isinstance(id, str) for id in subset_identifier_list):
-                    if set(subset_identifier_list).issubset(adata.obs[identifier].unique()):
-                        subset_identifier_list = np.where(
-                            np.isin(adata.obs[identifier].values, subset_identifier_list)
-                        )[0]
+                    if set(subset_identifier_list).issubset(as_frame(adata.obs)[identifier].unique()):
+                        subset_indices = np.where(np.isin(identifiers, np.asarray(subset_identifier_list)))[0]
                     else:
                         raise ValueError("`Subset_identifier` must be found in adata.obs.`identifier`.")
                 elif all(isinstance(id, int) and 0 <= id < adata.n_obs for id in subset_identifier_list):
-                    pass
+                    subset_indices = np.asarray(subset_identifier_list, dtype=int)
                 elif all(isinstance(id, int) and (id < 0 or id >= adata.n_obs) for id in subset_identifier_list):
                     raise ValueError("`Subset_identifier` out of index.")
                 else:
                     raise ValueError("`Subset_identifier` must contain either all strings or all integers.")
 
                 plt.scatter(
-                    x=adata.obsm[metadata_key].iloc[subset_identifier_list],
-                    y=adata[subset_identifier_list].X,
+                    x=as_frame(adata.obsm[metadata_key]).iloc[subset_indices],
+                    y=as_dense(adata[subset_indices].X),
                 )
                 plt.xlabel(
-                    f"{metadata_key}: {adata.obs[identifier].values[subset_identifier_list[0]]}"
-                    if len(subset_identifier_list) == 1
+                    f"{metadata_key}: {identifiers[subset_indices[0]]}"
+                    if len(subset_indices) == 1
                     else f"{metadata_key}"
                 )
-                plt.ylabel(
-                    f"Baseline: {adata.obs[identifier].values[subset_identifier_list[0]]}"
-                    if len(subset_identifier_list) == 1
-                    else "Baseline"
-                )
+                plt.ylabel(f"Baseline: {identifiers[subset_indices[0]]}" if len(subset_indices) == 1 else "Baseline")
 
                 # Annotate with the correlation coefficient and p-value of the chosen cell lines
-                subset_cor = np.mean(np.diag(corr.iloc[subset_identifier_list, subset_identifier_list]))
-                subset_pval = np.mean(np.diag(pval.iloc[subset_identifier_list, subset_identifier_list]))
+                subset_cor = np.mean(np.diag(corr.iloc[subset_indices, subset_indices].to_numpy()))
+                subset_pval = np.mean(np.diag(pval.iloc[subset_indices, subset_indices].to_numpy()))
                 annotation = "\n".join(
                     (
                         f"Pearson correlation: {subset_cor:.4f}",

--- a/pertpy/metadata/_compound.py
+++ b/pertpy/metadata/_compound.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Literal
 
 import pandas as pd
 
-from pertpy._types import as_frame
+from pertpy._types import cast_frame
 
 from ._look_up import LookUp
 from ._metadata import MetaData
@@ -49,7 +49,7 @@ class Compound(MetaData):
 
         query_dict = {}
         not_matched_identifiers = []
-        for compound in as_frame(adata.obs)[query_id].dropna().astype(str).unique():
+        for compound in cast_frame(adata.obs)[query_id].dropna().astype(str).unique():
             if query_id_type == "name":
                 cids = pcp.get_compounds(compound, "name")
                 if len(cids) == 0:  # search did not work
@@ -91,7 +91,7 @@ class Compound(MetaData):
         if query_id_type == "cid":
             query_df["pubchem_ID"] = query_df["pubchem_ID"].astype("Int64")
             adata.obs = (
-                as_frame(adata.obs)
+                cast_frame(adata.obs)
                 .merge(
                     query_df,
                     left_on=query_id,
@@ -104,7 +104,7 @@ class Compound(MetaData):
             )
         else:
             adata.obs = (
-                as_frame(adata.obs)
+                cast_frame(adata.obs)
                 .merge(
                     query_df,
                     left_on=query_id,
@@ -115,7 +115,7 @@ class Compound(MetaData):
                 .filter(regex="^(?!.*_fromMeta)")
                 .set_index(adata.obs.index)
             )
-            adata.obs["pubchem_ID"] = as_frame(adata.obs)["pubchem_ID"].astype("Int64")
+            adata.obs["pubchem_ID"] = cast_frame(adata.obs)["pubchem_ID"].astype("Int64")
 
         return adata
 

--- a/pertpy/metadata/_compound.py
+++ b/pertpy/metadata/_compound.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Literal
 
 import pandas as pd
 
+from pertpy._types import as_frame
+
 from ._look_up import LookUp
 from ._metadata import MetaData
 
@@ -43,11 +45,11 @@ class Compound(MetaData):
         if query_id not in adata.obs.columns:
             raise ValueError(f"The requested query_id {query_id} is not in `adata.obs`.\n Please check again.")
 
-        import pubchempy as pcp
+        import pubchempy as pcp  # type: ignore[import-untyped]
 
         query_dict = {}
         not_matched_identifiers = []
-        for compound in adata.obs[query_id].dropna().astype(str).unique():
+        for compound in as_frame(adata.obs)[query_id].dropna().astype(str).unique():
             if query_id_type == "name":
                 cids = pcp.get_compounds(compound, "name")
                 if len(cids) == 0:  # search did not work
@@ -87,9 +89,10 @@ class Compound(MetaData):
         # Column is converted to float after merging due to unmatches
         # Convert back to integers afterwards
         if query_id_type == "cid":
-            query_df.pubchem_ID = query_df.pubchem_ID.astype("Int64")
+            query_df["pubchem_ID"] = query_df["pubchem_ID"].astype("Int64")
             adata.obs = (
-                adata.obs.merge(
+                as_frame(adata.obs)
+                .merge(
                     query_df,
                     left_on=query_id,
                     right_on="pubchem_ID",
@@ -101,7 +104,8 @@ class Compound(MetaData):
             )
         else:
             adata.obs = (
-                adata.obs.merge(
+                as_frame(adata.obs)
+                .merge(
                     query_df,
                     left_on=query_id,
                     right_index=True,
@@ -111,7 +115,7 @@ class Compound(MetaData):
                 .filter(regex="^(?!.*_fromMeta)")
                 .set_index(adata.obs.index)
             )
-            adata.obs.pubchem_ID = adata.obs.pubchem_ID.astype("Int64")
+            adata.obs["pubchem_ID"] = as_frame(adata.obs)["pubchem_ID"].astype("Int64")
 
         return adata
 

--- a/pertpy/metadata/_drug.py
+++ b/pertpy/metadata/_drug.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import pandas as pd
-from scanpy import settings
+from scanpy import settings  # type: ignore[import-untyped]
 
 from pertpy.data._dataloader import _download
 

--- a/pertpy/metadata/_look_up.py
+++ b/pertpy/metadata/_look_up.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 if TYPE_CHECKING:
     import pandas as pd
 
-import pubchempy as pcp
+import pubchempy as pcp  # type: ignore[import-untyped]
 
 
 class LookUp:
@@ -30,7 +30,9 @@ class LookUp:
                 Currently set to None for CompoundMetaData which does not require any DataFrames for transfer.
         """
         self.type = type
-        if type == "cell_line":
+        if type != "compound" and transfer_metadata is None:
+            raise ValueError(f"`transfer_metadata` is required to build a {type!r} lookup.")
+        if type == "cell_line" and transfer_metadata is not None:
             self.cell_line_meta = transfer_metadata[0]
             self.cl_cancer_project_meta = transfer_metadata[1]
             self.gene_annotation = transfer_metadata[2]
@@ -189,7 +191,7 @@ class LookUp:
 
             self.drug_response = drug_response(gdsc1_dict, gdsc2_dict)
 
-        elif type == "moa":
+        elif type == "moa" and transfer_metadata is not None:
             self.moa_meta = transfer_metadata[0]
             moa_annotation = namedtuple(
                 "moa_annotation",
@@ -228,7 +230,7 @@ class LookUp:
             }
             self.compound = compound_annotation(**compound_data)
 
-        elif type == "drug":
+        elif type == "drug" and transfer_metadata is not None:
             self.chembl = transfer_metadata[0]
             self.dgidb = transfer_metadata[1]
             self.pharmgkb = transfer_metadata[2]
@@ -534,7 +536,7 @@ class LookUp:
                     # flatten the target column and remove duplicates
                     not_matched_identifiers = list(set(query_id_list) - chembl_targets)
                 elif query_id_type == "compound":
-                    not_matched_identifiers = list(set(query_id_list) - self.chembl["compounds"])
+                    not_matched_identifiers = list(set(query_id_list) - set(self.chembl["compounds"]))
                 else:
                     raise ValueError(
                         "Gene-disease association is not available in chembl dataset, please try with pharmgkb."

--- a/pertpy/metadata/_metadata.py
+++ b/pertpy/metadata/_metadata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from scanpy import settings
+from scanpy import settings  # type: ignore[import-untyped]
 
 from pertpy._logger import logger
 from pertpy.data._dataloader import _download

--- a/pertpy/metadata/_moa.py
+++ b/pertpy/metadata/_moa.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
-from pertpy._types import as_frame
+from pertpy._types import cast_frame
 
 from ._look_up import LookUp
 from ._metadata import MetaData
@@ -66,7 +66,7 @@ class Moa(MetaData):
             verbosity=verbosity,
         )
 
-        obs = as_frame(adata.obs)
+        obs = cast_frame(adata.obs)
         adata.obs = (
             obs.merge(
                 self.clue,
@@ -82,7 +82,7 @@ class Moa(MetaData):
         # If target column is given, check whether it is one of the targets listed in the metadata
         # If inconsistent, treat this perturbagen as unmatched and overwrite the annotated metadata with NaN
         if target is not None:
-            annotated = as_frame(adata.obs)
+            annotated = cast_frame(adata.obs)
             target_meta = "target" if target != "target" else "target_fromMeta"
             annotated[target_meta] = annotated[target_meta].mask(
                 ~annotated.apply(lambda row: str(row[target]) in str(row[target_meta]), axis=1)
@@ -93,7 +93,7 @@ class Moa(MetaData):
         # If query_id and reference_id have different names, there will be a column for each of them after merging
         # which is redundant as they refer to the same information.
         if query_id != "pert_iname":
-            del as_frame(adata.obs)["pert_iname"]
+            del cast_frame(adata.obs)["pert_iname"]
 
         return adata
 

--- a/pertpy/metadata/_moa.py
+++ b/pertpy/metadata/_moa.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
+from pertpy._types import as_frame
+
 from ._look_up import LookUp
 from ._metadata import MetaData
 
@@ -64,32 +66,34 @@ class Moa(MetaData):
             verbosity=verbosity,
         )
 
+        obs = as_frame(adata.obs)
         adata.obs = (
-            adata.obs.merge(
+            obs.merge(
                 self.clue,
-                left_on=adata.obs[query_id].str.lower(),
-                right_on=self.clue["pert_iname"].str.lower(),
+                left_on=obs[query_id].str.lower().to_numpy(),
+                right_on=self.clue["pert_iname"].str.lower().to_numpy(),
                 how="left",
                 suffixes=("", "_fromMeta"),
             )
-            .set_index(adata.obs.index)
+            .set_index(obs.index)
             .drop("key_0", axis=1)
         )
 
         # If target column is given, check whether it is one of the targets listed in the metadata
         # If inconsistent, treat this perturbagen as unmatched and overwrite the annotated metadata with NaN
         if target is not None:
+            annotated = as_frame(adata.obs)
             target_meta = "target" if target != "target" else "target_fromMeta"
-            adata.obs[target_meta] = adata.obs[target_meta].mask(
-                ~adata.obs.apply(lambda row: str(row[target]) in str(row[target_meta]), axis=1)
+            annotated[target_meta] = annotated[target_meta].mask(
+                ~annotated.apply(lambda row: str(row[target]) in str(row[target_meta]), axis=1)
             )
             pertname_meta = "pert_iname" if query_id != "pert_iname" else "pert_iname_fromMeta"
-            adata.obs.loc[adata.obs[target_meta].isna(), [pertname_meta, "moa"]] = np.nan
+            annotated.loc[annotated[target_meta].isna(), [pertname_meta, "moa"]] = np.nan
 
         # If query_id and reference_id have different names, there will be a column for each of them after merging
         # which is redundant as they refer to the same information.
         if query_id != "pert_iname":
-            del adata.obs["pert_iname"]
+            del as_frame(adata.obs)["pert_iname"]
 
         return adata
 

--- a/pertpy/preprocessing/_guide_rna.py
+++ b/pertpy/preprocessing/_guide_rna.py
@@ -8,14 +8,14 @@ from warnings import warn
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from anndata import AnnData
 from numba import njit, prange
 from rich.progress import track
 from scipy.sparse import csr_matrix, issparse
 
 from pertpy._doc import _doc_params, doc_common_plot_args
-from pertpy._types import CSRBase
+from pertpy._types import CSBase, CSRBase, as_frame, as_matrix
 from pertpy.preprocessing._guide_rna_mixture import compute_count_thresholds, fit_poisson_gauss_mixture
 
 if TYPE_CHECKING:
@@ -83,7 +83,7 @@ class GuideAssignment:
     @njit(parallel=True)
     def _threshold_sparse_numba(data: np.ndarray, threshold: float) -> np.ndarray:
         out = np.zeros_like(data, dtype=np.int8)
-        for i in prange(data.shape[0]):
+        for i in prange(data.shape[0]):  # type: ignore[attr-defined]
             if data[i] >= threshold:
                 out[i] = 1
         return out
@@ -279,7 +279,7 @@ class GuideAssignment:
     ) -> np.ndarray | None:
         if model != "poisson_gauss_mixture":
             raise ValueError("Model not implemented. Please use 'poisson_gauss_mixture'.")
-        X = adata.X if layer is None else adata.layers[layer]
+        X = as_matrix(adata.X if layer is None else adata.layers[layer])
         result = self._fit_mixture_pg(
             X,
             guide_names=list(adata.var_names),
@@ -391,7 +391,7 @@ class GuideAssignment:
 
     def _fit_mixture_pg(
         self,
-        X: np.ndarray | CSRBase,
+        X: np.ndarray | CSBase,
         *,
         guide_names: list[str],
         n_iter: int,
@@ -404,7 +404,7 @@ class GuideAssignment:
 
         Dispatches the per-guide nonzero extraction and per-guide thresholding on dense vs sparse so that a sparse input never gets densified at full ``[cells, guides]`` size.
         """
-        if issparse(X):
+        if isinstance(X, CSBase):
             X_csc = X.tocsc()
             n_cells, n_guides = X_csc.shape
             if X_csc.data.size and X_csc.data.min() < 0:
@@ -537,7 +537,7 @@ class GuideAssignment:
         *,
         layer: str | None = None,
         order_by: np.ndarray | str | None = None,
-        key_to_save_order: str = None,
+        key_to_save_order: str | None = None,
         return_fig: bool = False,
         **kwargs,
     ) -> Figure | None:
@@ -576,12 +576,12 @@ class GuideAssignment:
             >>> ga.assign_by_threshold(gdo, assignment_threshold=5)
             >>> ga.plot_heatmap(gdo)
         """
-        data = adata.X if layer is None else adata.layers[layer]
+        data = as_matrix(adata.X if layer is None else adata.layers[layer])
 
         if order_by is None:
-            if issparse(data):
+            if isinstance(data, CSBase):
                 max_values = data.max(axis=1).toarray().squeeze()
-                data_argmax = data.argmax(axis=1).A.squeeze()
+                data_argmax = np.asarray(data.argmax(axis=1)).squeeze()
                 max_guide_index = np.where(max_values != data.min(axis=1).toarray().squeeze(), data_argmax, -1)
             else:
                 max_guide_index = np.where(
@@ -611,7 +611,7 @@ class GuideAssignment:
                 **kwargs,
             )
         finally:
-            del adata.obs[temp_col_name]
+            del as_frame(adata.obs)[temp_col_name]
 
         if return_fig:
             return fig

--- a/pertpy/preprocessing/_guide_rna.py
+++ b/pertpy/preprocessing/_guide_rna.py
@@ -15,7 +15,7 @@ from rich.progress import track
 from scipy.sparse import csr_matrix, issparse
 
 from pertpy._doc import _doc_params, doc_common_plot_args
-from pertpy._types import CSBase, CSRBase, as_frame, as_matrix
+from pertpy._types import CSBase, CSRBase, cast_frame, cast_matrix
 from pertpy.preprocessing._guide_rna_mixture import compute_count_thresholds, fit_poisson_gauss_mixture
 
 if TYPE_CHECKING:
@@ -279,7 +279,7 @@ class GuideAssignment:
     ) -> np.ndarray | None:
         if model != "poisson_gauss_mixture":
             raise ValueError("Model not implemented. Please use 'poisson_gauss_mixture'.")
-        X = as_matrix(adata.X if layer is None else adata.layers[layer])
+        X = cast_matrix(adata.X if layer is None else adata.layers[layer])
         result = self._fit_mixture_pg(
             X,
             guide_names=list(adata.var_names),
@@ -576,7 +576,7 @@ class GuideAssignment:
             >>> ga.assign_by_threshold(gdo, assignment_threshold=5)
             >>> ga.plot_heatmap(gdo)
         """
-        data = as_matrix(adata.X if layer is None else adata.layers[layer])
+        data = cast_matrix(adata.X if layer is None else adata.layers[layer])
 
         if order_by is None:
             if isinstance(data, CSBase):
@@ -611,7 +611,7 @@ class GuideAssignment:
                 **kwargs,
             )
         finally:
-            del as_frame(adata.obs)[temp_col_name]
+            del cast_frame(adata.obs)[temp_col_name]
 
         if return_fig:
             return fig

--- a/pertpy/preprocessing/_guide_rna_mixture.py
+++ b/pertpy/preprocessing/_guide_rna_mixture.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 import jax
 import jax.numpy as jnp
 import numpy as np
-import optax
+import optax  # type: ignore[import-untyped]
 from jax.scipy.special import gammaln, logsumexp
 from scipy.special import gammaln as _np_gammaln
 

--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -37,7 +37,7 @@ from statsmodels.stats.multitest import fdrcorrection  # type: ignore[import-unt
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
-from pertpy._types import CSBase, as_frame, as_matrix
+from pertpy._types import CSBase, cast_frame, cast_matrix
 from pertpy.tools.core import _is_raw_counts
 
 if TYPE_CHECKING:
@@ -125,7 +125,7 @@ class Augur:
         """
         if isinstance(input, AnnData):
             adata = input
-            obs_renamed = as_frame(adata.obs).rename(columns={cell_type_col: "cell_type", label_col: "label"})
+            obs_renamed = cast_frame(adata.obs).rename(columns={cell_type_col: "cell_type", label_col: "label"})
 
         elif isinstance(input, pd.DataFrame):
             if meta is None:
@@ -139,7 +139,7 @@ class Augur:
             cell_type = input[cell_type_col] if meta is None else meta[cell_type_col]
             X = input.drop([label_col, cell_type_col], axis=1) if meta is None else input
             adata = AnnData(X=X, obs=pd.DataFrame({"cell_type": cell_type, "label": label}))
-            obs_renamed = as_frame(adata.obs)
+            obs_renamed = cast_frame(adata.obs)
 
         if len(obs_renamed["label"].unique()) < 2:
             raise ValueError("Less than two unique labels in dataset. At least two are needed for the analysis.")
@@ -148,7 +148,7 @@ class Augur:
             final_adata = AnnData(
                 X=adata.X,
                 obs=obs_renamed,
-                var=as_frame(adata.var),
+                var=cast_frame(adata.var),
                 layers=cast("Mapping[str, np.ndarray | CSBase]", adata.layers),
             )
         else:
@@ -175,9 +175,9 @@ class Augur:
         if layer is not None:
             if layer not in final_adata.layers:
                 raise ValueError(f"Layer '{layer}' not found in AnnData object")
-            counts = as_matrix(final_adata.layers[layer])
+            counts = cast_matrix(final_adata.layers[layer])
         else:
-            counts = as_matrix(final_adata.X)
+            counts = cast_matrix(final_adata.X)
 
         if not _is_raw_counts(counts):
             logger.warning("Data does not appear to be raw counts. Augur developers recommend using raw counts.")
@@ -292,11 +292,11 @@ class Augur:
             subsample = sc.pp.subsample(adata[:, features], n_obs=subsample_size, copy=True, random_state=random_state)
 
         # filter features with 0 variance
-        var = as_frame(subsample.var)
+        var = cast_frame(subsample.var)
         var["highly_variable"] = False
-        var["means"] = np.ravel(as_matrix(subsample.X).mean(axis=0))
+        var["means"] = np.ravel(cast_matrix(subsample.X).mean(axis=0))
         # Converting because the Syntax for power for numpy arrays is different -> use sparse Syntax as default
-        X = as_matrix(subsample.X)
+        X = cast_matrix(subsample.X)
         if isinstance(X, np.ndarray):
             X = sparse.csc_matrix(X)
             subsample.X = X
@@ -346,7 +346,7 @@ class Augur:
         if augur_mode == "permute":
             # shuffle labels
             adata = adata.copy()
-            obs = as_frame(adata.obs)
+            obs = cast_frame(adata.obs)
             y_columns = obs.columns[obs.columns.str.startswith("y_")]
             obs[y_columns] = obs[y_columns].sample(frac=1, random_state=random_state).values
 
@@ -356,7 +356,7 @@ class Augur:
 
         else:
             # randomly sample features from highly variable genes
-            highly_variable_genes = adata.var_names[as_frame(adata.var)["highly_variable"]].tolist()
+            highly_variable_genes = adata.var_names[cast_frame(adata.var)["highly_variable"]].tolist()
             features = random.sample(highly_variable_genes, floor(len(highly_variable_genes) * feature_perc))
 
         # randomly sample samples for each label
@@ -532,7 +532,7 @@ class Augur:
             >>> results = ag_rfc.run_cross_validation(subsample=subsample, folds=3, subsample_idx=0, random_state=42, zero_division=0)
         """
         # Pass the dense matrix instead of subsample.to_df(); its arrow-backed string columns make scikit-learn re-validate dtypes on every fold and scorer, while the values (and results) stay identical.
-        x = np.asarray(to_dense(as_matrix(subsample.X)))
+        x = np.asarray(to_dense(cast_matrix(subsample.X)))
         genes = subsample.var_names.tolist()
         n_genes = len(genes)
         y = subsample.obs["y_"]
@@ -681,11 +681,11 @@ class Augur:
             >>> loaded_data = ag_rfc.load(adata)
             >>> ag_rfc.select_variance(loaded_data, var_quantile=0.5, filter_negative_residuals=False, span=0.75)
         """
-        var = as_frame(adata.var)
+        var = cast_frame(adata.var)
         var["highly_variable"] = False
-        var["means"] = np.ravel(as_matrix(adata.X).mean(axis=0))
+        var["means"] = np.ravel(cast_matrix(adata.X).mean(axis=0))
         # Converting because the Syntax for power for numpy arrays is different -> use sparse Syntax as default
-        X = as_matrix(adata.X)
+        X = cast_matrix(adata.X)
         if isinstance(X, np.ndarray):
             X = sparse.csc_matrix(X)
             adata.X = X
@@ -872,7 +872,7 @@ class Augur:
             results["summary_metrics"][cell_type] = self.average_metrics(results[cell_type])
 
             # add scores as observation to anndata
-            obs = as_frame(adata.obs)
+            obs = cast_frame(adata.obs)
             mask = obs["cell_type"].str.startswith(cell_type)
             obs.loc[mask, "augur_score"] = results["summary_metrics"][cell_type]["mean_augur_score"]
 

--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -532,7 +532,7 @@ class Augur:
             >>> results = ag_rfc.run_cross_validation(subsample=subsample, folds=3, subsample_idx=0, random_state=42, zero_division=0)
         """
         # Pass the dense matrix instead of subsample.to_df(); its arrow-backed string columns make scikit-learn re-validate dtypes on every fold and scorer, while the values (and results) stay identical.
-        x = np.asarray(to_dense(cast_matrix(subsample.X)))
+        x = np.asarray(to_dense(subsample.X))
         genes = subsample.var_names.tolist()
         n_genes = len(genes)
         y = subsample.obs["y_"]

--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 import random
 from collections import defaultdict
 from math import floor, nan
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import anndata as ad
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from anndata import AnnData
+from fast_array_utils.conv import to_dense
 from joblib import Parallel, delayed
 from rich.progress import track
 from scipy import sparse, stats
-from sklearn.base import is_classifier, is_regressor
-from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import (
+from sklearn.base import is_classifier, is_regressor  # type: ignore[import-untyped]
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor  # type: ignore[import-untyped]
+from sklearn.linear_model import LogisticRegression  # type: ignore[import-untyped]
+from sklearn.metrics import (  # type: ignore[import-untyped]
     accuracy_score,
     explained_variance_score,
     f1_score,
@@ -28,17 +29,20 @@ from sklearn.metrics import (
     roc_auc_score,
     root_mean_squared_error,
 )
-from sklearn.model_selection import StratifiedKFold, cross_validate
-from sklearn.preprocessing import LabelEncoder
-from skmisc.loess import loess
-from statsmodels.api import OLS
-from statsmodels.stats.multitest import fdrcorrection
+from sklearn.model_selection import StratifiedKFold, cross_validate  # type: ignore[import-untyped]
+from sklearn.preprocessing import LabelEncoder  # type: ignore[import-untyped]
+from skmisc.loess import loess  # type: ignore[import-untyped]
+from statsmodels.api import OLS  # type: ignore[import-untyped]
+from statsmodels.stats.multitest import fdrcorrection  # type: ignore[import-untyped]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
+from pertpy._types import CSBase, as_frame, as_matrix
 from pertpy.tools.core import _is_raw_counts
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
 
@@ -121,7 +125,7 @@ class Augur:
         """
         if isinstance(input, AnnData):
             adata = input
-            obs_renamed = adata.obs.rename(columns={cell_type_col: "cell_type", label_col: "label"})
+            obs_renamed = as_frame(adata.obs).rename(columns={cell_type_col: "cell_type", label_col: "label"})
 
         elif isinstance(input, pd.DataFrame):
             if meta is None:
@@ -135,13 +139,18 @@ class Augur:
             cell_type = input[cell_type_col] if meta is None else meta[cell_type_col]
             X = input.drop([label_col, cell_type_col], axis=1) if meta is None else input
             adata = AnnData(X=X, obs=pd.DataFrame({"cell_type": cell_type, "label": label}))
-            obs_renamed = adata.obs
+            obs_renamed = as_frame(adata.obs)
 
         if len(obs_renamed["label"].unique()) < 2:
             raise ValueError("Less than two unique labels in dataset. At least two are needed for the analysis.")
 
         if isinstance(input, AnnData):
-            final_adata = AnnData(X=adata.X, obs=obs_renamed, var=adata.var, layers=adata.layers)
+            final_adata = AnnData(
+                X=adata.X,
+                obs=obs_renamed,
+                var=as_frame(adata.var),
+                layers=cast("Mapping[str, np.ndarray | CSBase]", adata.layers),
+            )
         else:
             final_adata = adata
 
@@ -166,11 +175,11 @@ class Augur:
         if layer is not None:
             if layer not in final_adata.layers:
                 raise ValueError(f"Layer '{layer}' not found in AnnData object")
-            X = final_adata.layers[layer]
+            counts = as_matrix(final_adata.layers[layer])
         else:
-            X = final_adata.X
+            counts = as_matrix(final_adata.X)
 
-        if not _is_raw_counts(X):
+        if not _is_raw_counts(counts):
             logger.warning("Data does not appear to be raw counts. Augur developers recommend using raw counts.")
 
         return final_adata
@@ -283,16 +292,19 @@ class Augur:
             subsample = sc.pp.subsample(adata[:, features], n_obs=subsample_size, copy=True, random_state=random_state)
 
         # filter features with 0 variance
-        subsample.var["highly_variable"] = False
-        subsample.var["means"] = np.ravel(subsample.X.mean(axis=0))
+        var = as_frame(subsample.var)
+        var["highly_variable"] = False
+        var["means"] = np.ravel(as_matrix(subsample.X).mean(axis=0))
         # Converting because the Syntax for power for numpy arrays is different -> use sparse Syntax as default
-        if isinstance(subsample.X, np.ndarray):
-            subsample.X = sparse.csc_matrix(subsample.X)
-        subsample.var["var"] = np.ravel(subsample.X.power(2).mean(axis=0) - np.power(subsample.X.mean(axis=0), 2))
+        X = as_matrix(subsample.X)
+        if isinstance(X, np.ndarray):
+            X = sparse.csc_matrix(X)
+            subsample.X = X
+        var["var"] = np.ravel(X.power(2).mean(axis=0) - np.power(X.mean(axis=0), 2))
         # remove all features with 0 variance
-        subsample.var.loc[subsample.var["var"] > 0, "highly_variable"] = True
+        var.loc[var["var"] > 0, "highly_variable"] = True
 
-        return subsample[:, subsample.var["highly_variable"]]
+        return subsample[:, var["highly_variable"]]
 
     def draw_subsample(
         self,
@@ -334,16 +346,17 @@ class Augur:
         if augur_mode == "permute":
             # shuffle labels
             adata = adata.copy()
-            y_columns = [col for col in adata.obs if col.startswith("y_")]
-            adata.obs[y_columns] = adata.obs[y_columns].sample(frac=1, random_state=random_state).values
+            obs = as_frame(adata.obs)
+            y_columns = obs.columns[obs.columns.str.startswith("y_")]
+            obs[y_columns] = obs[y_columns].sample(frac=1, random_state=random_state).values
 
         if augur_mode == "velocity":
             # no feature selection, assuming this has already happenend in calculating velocity
-            features = adata.var_names
+            features = adata.var_names.tolist()
 
         else:
             # randomly sample features from highly variable genes
-            highly_variable_genes = adata.var_names[adata.var["highly_variable"]].tolist()
+            highly_variable_genes = adata.var_names[as_frame(adata.var)["highly_variable"]].tolist()
             features = random.sample(highly_variable_genes, floor(len(highly_variable_genes) * feature_perc))
 
         # randomly sample samples for each label
@@ -519,10 +532,7 @@ class Augur:
             >>> results = ag_rfc.run_cross_validation(subsample=subsample, folds=3, subsample_idx=0, random_state=42, zero_division=0)
         """
         # Pass the dense matrix instead of subsample.to_df(); its arrow-backed string columns make scikit-learn re-validate dtypes on every fold and scorer, while the values (and results) stay identical.
-        x = subsample.X
-        if sparse.issparse(x):
-            x = x.toarray()
-        x = np.asarray(x)
+        x = np.asarray(to_dense(as_matrix(subsample.X)))
         genes = subsample.var_names.tolist()
         n_genes = len(genes)
         y = subsample.obs["y_"]
@@ -671,15 +681,18 @@ class Augur:
             >>> loaded_data = ag_rfc.load(adata)
             >>> ag_rfc.select_variance(loaded_data, var_quantile=0.5, filter_negative_residuals=False, span=0.75)
         """
-        adata.var["highly_variable"] = False
-        adata.var["means"] = np.ravel(adata.X.mean(axis=0))
+        var = as_frame(adata.var)
+        var["highly_variable"] = False
+        var["means"] = np.ravel(as_matrix(adata.X).mean(axis=0))
         # Converting because the Syntax for power for numpy arrays is different -> use sparse Syntax as default
-        if isinstance(adata.X, np.ndarray):
-            adata.X = sparse.csc_matrix(adata.X)
-        adata.var["sds"] = np.ravel(np.sqrt(adata.X.power(2).mean(axis=0) - np.power(adata.X.mean(axis=0), 2)))
+        X = as_matrix(adata.X)
+        if isinstance(X, np.ndarray):
+            X = sparse.csc_matrix(X)
+            adata.X = X
+        var["sds"] = np.ravel(np.sqrt(X.power(2).mean(axis=0) - np.power(X.mean(axis=0), 2)))
         # remove all features with 0 variance
-        adata.var.loc[adata.var["sds"] > 0, "highly_variable"] = True
-        cvs = adata.var.loc[adata.var["highly_variable"], "means"] / adata.var.loc[adata.var["highly_variable"], "sds"]
+        var.loc[var["sds"] > 0, "highly_variable"] = True
+        cvs = var.loc[var["highly_variable"], "means"] / var.loc[var["highly_variable"], "sds"]
 
         # clip outliers, get best prediction model, get residuals
         lower = np.quantile(cvs, 0.01)
@@ -687,7 +700,7 @@ class Augur:
         keep = cvs.loc[cvs.between(lower, upper)].index
 
         cv0 = cvs.loc[keep]
-        mean0 = adata.var.loc[keep, "means"]
+        mean0 = var.loc[keep, "means"]
 
         if any(mean0 < 0):
             # if there are negative values, don't bother comparing to log-transformed
@@ -726,7 +739,7 @@ class Augur:
         n_subsamples: int = 50,
         subsample_size: int = 20,
         folds: int = 3,
-        min_cells: int = None,
+        min_cells: int | None = None,
         feature_perc: float = 0.5,
         var_quantile: float = 0.5,
         span: float = 0.75,
@@ -859,8 +872,9 @@ class Augur:
             results["summary_metrics"][cell_type] = self.average_metrics(results[cell_type])
 
             # add scores as observation to anndata
-            mask = adata.obs["cell_type"].str.startswith(cell_type)
-            adata.obs.loc[mask, "augur_score"] = results["summary_metrics"][cell_type]["mean_augur_score"]
+            obs = as_frame(adata.obs)
+            mask = obs["cell_type"].str.startswith(cell_type)
+            obs.loc[mask, "augur_score"] = results["summary_metrics"][cell_type]["mean_augur_score"]
 
             # concatenate feature importances for each subsample cv
             subsample_feature_importances_dicts = [cv["feature_importances"] for cv in results[cell_type]]
@@ -1035,8 +1049,8 @@ class Augur:
         self,
         results: pd.DataFrame,
         *,
-        top_n: int = None,
-        ax: Axes = None,
+        top_n: int | None = None,
+        ax: Axes | None = None,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plot scatterplot of differential prioritization.
@@ -1107,7 +1121,7 @@ class Augur:
         *,
         key: str = "augurpy_results",
         top_n: int = 10,
-        ax: Axes = None,
+        ax: Axes | None = None,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plot a lollipop plot of the n features with largest feature importances.
@@ -1169,7 +1183,7 @@ class Augur:
         data: dict[str, Any] | AnnData,
         *,
         key: str = "augurpy_results",
-        ax: Axes = None,
+        ax: Axes | None = None,
         return_fig: bool = False,
     ) -> Figure | None:
         """Plot a lollipop plot of the mean augur values.
@@ -1227,7 +1241,7 @@ class Augur:
         results1: dict[str, Any],
         results2: dict[str, Any],
         *,
-        top_n: int = None,
+        top_n: int | None = None,
         return_fig: bool = False,
     ) -> Figure | None:
         """Create scatterplot with two augur results.

--- a/pertpy/tools/_cinemaot.py
+++ b/pertpy/tools/_cinemaot.py
@@ -21,7 +21,7 @@ from sklearn.linear_model import LinearRegression  # type: ignore[import-untyped
 from sklearn.neighbors import NearestNeighbors  # type: ignore[import-untyped]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
-from pertpy._types import CSBase, as_dense, as_frame, as_matrix
+from pertpy._types import CSBase, cast_dense, cast_frame, cast_matrix
 
 if TYPE_CHECKING:
     from anndata import AnnData
@@ -97,7 +97,7 @@ class Cinemaot:
 
         transformer = FastICA(n_components=dim, random_state=0, whiten="arbitrary-variance")
         X_transformed = np.array(transformer.fit_transform(adata.obsm[use_rep][:, :dim]), dtype=np.float64)
-        groupvec = np.asarray((as_frame(adata.obs)[pert_key] == control * 1).values)  # control
+        groupvec = np.asarray((cast_frame(adata.obs)[pert_key] == control * 1).values)  # control
         xi = np.zeros(dim)
         j = 0
         for source_row in X_transformed.T:
@@ -152,7 +152,7 @@ class Cinemaot:
                 / ot_sink.apply(np.ones_like(X_transformed[adata.obs[pert_key] == control, :].T)).T
             )
 
-            adata_X = as_matrix(adata.X)
+            adata_X = cast_matrix(adata.X)
             X = to_dense(adata_X)
             te2 = (
                 X[adata.obs[pert_key] != control, :]
@@ -176,7 +176,7 @@ class Cinemaot:
                 ot_matrix / np.sum(ot_matrix, axis=1)[:, None], X_transformed[adata.obs[pert_key] == control, :]
             )
 
-            adata_X = as_matrix(adata.X)
+            adata_X = cast_matrix(adata.X)
             X = to_dense(adata_X)
 
             te2 = X[adata.obs[pert_key] != control, :] - np.matmul(
@@ -186,9 +186,9 @@ class Cinemaot:
                 del X
 
             adata.obsm[cf_rep] = cf
-            cf_matrix = as_dense(adata.obsm[cf_rep])
-            cf_matrix[as_frame(adata.obs)[pert_key] != control, :] = np.matmul(
-                ot_matrix / np.sum(ot_matrix, axis=1)[:, None], cf_matrix[as_frame(adata.obs)[pert_key] == control, :]
+            cf_matrix = cast_dense(adata.obsm[cf_rep])
+            cf_matrix[cast_frame(adata.obs)[pert_key] != control, :] = np.matmul(
+                ot_matrix / np.sum(ot_matrix, axis=1)[:, None], cf_matrix[cast_frame(adata.obs)[pert_key] == control, :]
             )
 
         TE = sc.AnnData(np.array(te2), obs=adata[adata.obs[pert_key] != control, :].obs.copy(), var=adata.var.copy())
@@ -329,10 +329,10 @@ class Cinemaot:
         sc.pp.neighbors(de, use_rep=de_rep)
         sc.tl.leiden(de, resolution=de_resolution, flavor="igraph")
         if use_raw:
-            counts = to_dense(as_matrix(adata.raw.X))
+            counts = to_dense(cast_matrix(adata.raw.X))
             df = pd.DataFrame(counts, columns=adata.raw.var_names, index=adata.raw.obs_names)
         else:
-            counts = to_dense(as_matrix(adata.X))
+            counts = to_dense(cast_matrix(adata.X))
             df = pd.DataFrame(counts, columns=adata.var_names, index=adata.obs_names)
 
         if label_list is None:
@@ -341,7 +341,7 @@ class Cinemaot:
             sc.tl.leiden(adata, resolution=cf_resolution, flavor="igraph")
             df["ct"] = adata.obs["leiden"].astype(str)
         df["ptb"] = "control"
-        df.loc[np.asarray(as_frame(adata.obs)[pert_key] != control), "ptb"] = as_frame(de.obs)["leiden"].astype(str)
+        df.loc[np.asarray(cast_frame(adata.obs)[pert_key] != control), "ptb"] = cast_frame(de.obs)["leiden"].astype(str)
         label_list.append("ptb")
         df = df.groupby(label_list).sum()
         new_index = df.index.map(lambda x: "_".join(map(str, x)))
@@ -377,7 +377,7 @@ class Cinemaot:
             >>> dim = model.get_dim(adata)
         """
         sk = SinkhornKnopp()
-        data = to_dense(as_matrix(adata.raw.X))
+        data = to_dense(cast_matrix(adata.raw.X))
         vm = (1e-3 + data + c * data * data) / (1 + c)
         sk.fit(vm)
         wm = np.dot(np.dot(np.sqrt(sk._D1), vm), np.sqrt(sk._D2))
@@ -418,10 +418,10 @@ class Cinemaot:
         X_pca1 = adata_.obsm[use_rep][adata_.obs[pert_key] == control, :]
         X_pca2 = adata_.obsm[use_rep][adata_.obs[pert_key] != control, :]
         nbrs = NearestNeighbors(n_neighbors=k, algorithm="ball_tree").fit(X_pca1)
-        mixscape_pca = as_dense(adata.obsm[use_rep]).copy()
+        mixscape_pca = cast_dense(adata.obsm[use_rep]).copy()
         mixscapematrix = nbrs.kneighbors_graph(X_pca2).toarray()
-        mixscape_pca[as_frame(adata_.obs)[pert_key] != control, :] = (
-            np.dot(mixscapematrix, mixscape_pca[as_frame(adata_.obs)[pert_key] == control, :]) / k
+        mixscape_pca[cast_frame(adata_.obs)[pert_key] != control, :] = (
+            np.dot(mixscapematrix, mixscape_pca[cast_frame(adata_.obs)[pert_key] == control, :]) / k
         )
 
         adata_.obsm["X_mpca"] = mixscape_pca
@@ -433,7 +433,7 @@ class Cinemaot:
         ref_label = "noncontrol"
         expr_label = "control"
 
-        obs_ = as_frame(adata_.obs)
+        obs_ = cast_frame(adata_.obs)
         obs_["ct"] = ref_label
         obs_.loc[obs_[pert_key] == control, "ct"] = expr_label
         pert_key = "ct"
@@ -613,10 +613,10 @@ class Cinemaot:
             >>> model = pt.tl.Cinemaot()
             >>> c_effect, s_effect = model.attribution_scatter(adata, pert_key="perturbation", control="No stimulation")
         """
-        cf = as_matrix(adata.obsm[cf_rep])
-        obs = as_frame(adata.obs)
-        X = as_matrix(adata.X)
-        source = as_matrix(adata.raw.X) if use_raw else X
+        cf = cast_matrix(adata.obsm[cf_rep])
+        obs = cast_frame(adata.obs)
+        X = cast_matrix(adata.X)
+        source = cast_matrix(adata.raw.X) if use_raw else X
         counts = to_dense(source) if isinstance(X, CSBase) else source
         Y0 = counts[obs[pert_key] == control, :]
         Y1 = counts[obs[pert_key] != control, :]
@@ -686,7 +686,7 @@ class Cinemaot:
         """
         adata_ = adata[adata.obs[pert_key] == control]
 
-        df = pd.DataFrame(as_dense(de.obsm[matching_rep]))
+        df = pd.DataFrame(cast_dense(de.obsm[matching_rep]))
         if de_label is None:
             de_label = "leiden"
             sc.pp.neighbors(de, use_rep="X_embedding")

--- a/pertpy/tools/_cinemaot.py
+++ b/pertpy/tools/_cinemaot.py
@@ -1,31 +1,33 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import jax
+import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 import scipy.stats as ss
-import sklearn.metrics
+import sklearn.metrics  # type: ignore[import-untyped]
+from fast_array_utils.conv import to_dense
 from ott.geometry.pointcloud import PointCloud
 from ott.problems.linear import linear_problem
 from ott.solvers.linear import sinkhorn, sinkhorn_lr
-from scanpy.plotting import _utils
-from scipy.sparse import issparse
+from scanpy.plotting import _utils  # type: ignore[import-untyped]
 from seaborn import heatmap
-from sklearn.decomposition import FastICA
-from sklearn.linear_model import LinearRegression
-from sklearn.neighbors import NearestNeighbors
+from sklearn.decomposition import FastICA  # type: ignore[import-untyped]
+from sklearn.linear_model import LinearRegression  # type: ignore[import-untyped]
+from sklearn.neighbors import NearestNeighbors  # type: ignore[import-untyped]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
+from pertpy._types import CSBase, as_dense, as_frame, as_matrix
 
 if TYPE_CHECKING:
     from anndata import AnnData
     from matplotlib.axes import Axes
     from matplotlib.pyplot import Figure
-    from statsmodels.tools.typing import ArrayLike
+    from statsmodels.tools.typing import ArrayLike  # type: ignore[import-untyped]
 
 
 class Cinemaot:
@@ -95,7 +97,7 @@ class Cinemaot:
 
         transformer = FastICA(n_components=dim, random_state=0, whiten="arbitrary-variance")
         X_transformed = np.array(transformer.fit_transform(adata.obsm[use_rep][:, :dim]), dtype=np.float64)
-        groupvec = (adata.obs[pert_key] == control * 1).values  # control
+        groupvec = np.asarray((as_frame(adata.obs)[pert_key] == control * 1).values)  # control
         xi = np.zeros(dim)
         j = 0
         for source_row in X_transformed.T:
@@ -114,7 +116,7 @@ class Cinemaot:
             sklearn.metrics.pairwise_distances(cf1, cf2)
 
         e = smoothness * sum(xi < thres)
-        geom = PointCloud(cf1, cf2, epsilon=e, batch_size=batch_size)
+        geom = PointCloud(jnp.asarray(cf1), jnp.asarray(cf2), epsilon=e, batch_size=batch_size)
 
         if preweight_label is None:
             ot_prob = linear_problem.LinearProblem(geom, a=None, b=None)
@@ -137,7 +139,7 @@ class Cinemaot:
 
             a = a / np.sum(a)
             b[:] = 1 / cf2.shape[0]
-            ot_prob = linear_problem.LinearProblem(geom, a=a, b=b)
+            ot_prob = linear_problem.LinearProblem(geom, a=jnp.asarray(a), b=jnp.asarray(b))
 
         if solver == "LRSinkhorn":
             if rank is None:
@@ -150,13 +152,14 @@ class Cinemaot:
                 / ot_sink.apply(np.ones_like(X_transformed[adata.obs[pert_key] == control, :].T)).T
             )
 
-            X = adata.X.toarray() if issparse(adata.X) else adata.X
+            adata_X = as_matrix(adata.X)
+            X = to_dense(adata_X)
             te2 = (
                 X[adata.obs[pert_key] != control, :]
                 - ot_sink.apply(X[adata.obs[pert_key] == control, :].T).T
                 / ot_sink.apply(np.ones_like(X[adata.obs[pert_key] == control, :].T)).T
             )
-            if issparse(X):
+            if isinstance(adata_X, CSBase):
                 del X
 
             adata.obsm[cf_rep] = cf
@@ -173,17 +176,19 @@ class Cinemaot:
                 ot_matrix / np.sum(ot_matrix, axis=1)[:, None], X_transformed[adata.obs[pert_key] == control, :]
             )
 
-            X = adata.X.toarray() if issparse(adata.X) else adata.X
+            adata_X = as_matrix(adata.X)
+            X = to_dense(adata_X)
 
             te2 = X[adata.obs[pert_key] != control, :] - np.matmul(
                 ot_matrix / np.sum(ot_matrix, axis=1)[:, None], X[adata.obs[pert_key] == control, :]
             )
-            if issparse(X):
+            if isinstance(adata_X, CSBase):
                 del X
 
             adata.obsm[cf_rep] = cf
-            adata.obsm[cf_rep][adata.obs[pert_key] != control, :] = np.matmul(
-                ot_matrix / np.sum(ot_matrix, axis=1)[:, None], adata.obsm[cf_rep][adata.obs[pert_key] == control, :]
+            cf_matrix = as_dense(adata.obsm[cf_rep])
+            cf_matrix[as_frame(adata.obs)[pert_key] != control, :] = np.matmul(
+                ot_matrix / np.sum(ot_matrix, axis=1)[:, None], cf_matrix[as_frame(adata.obs)[pert_key] == control, :]
             )
 
         TE = sc.AnnData(np.array(te2), obs=adata[adata.obs[pert_key] != control, :].obs.copy(), var=adata.var.copy())
@@ -324,14 +329,11 @@ class Cinemaot:
         sc.pp.neighbors(de, use_rep=de_rep)
         sc.tl.leiden(de, resolution=de_resolution, flavor="igraph")
         if use_raw:
-            if issparse(adata.raw.X):
-                df = pd.DataFrame(adata.raw.X.toarray(), columns=adata.raw.var_names, index=adata.raw.obs_names)
-            else:
-                df = pd.DataFrame(adata.raw.X, columns=adata.raw.var_names, index=adata.raw.obs_names)
-        elif issparse(adata.X):
-            df = pd.DataFrame(adata.X.toarray(), columns=adata.var_names, index=adata.obs_names)
+            counts = to_dense(as_matrix(adata.raw.X))
+            df = pd.DataFrame(counts, columns=adata.raw.var_names, index=adata.raw.obs_names)
         else:
-            df = pd.DataFrame(adata.X, columns=adata.var_names, index=adata.obs_names)
+            counts = to_dense(as_matrix(adata.X))
+            df = pd.DataFrame(counts, columns=adata.var_names, index=adata.obs_names)
 
         if label_list is None:
             label_list = ["ct"]
@@ -339,7 +341,7 @@ class Cinemaot:
             sc.tl.leiden(adata, resolution=cf_resolution, flavor="igraph")
             df["ct"] = adata.obs["leiden"].astype(str)
         df["ptb"] = "control"
-        df.loc[adata.obs[pert_key] != control, "ptb"] = de.obs["leiden"].astype(str)
+        df.loc[np.asarray(as_frame(adata.obs)[pert_key] != control), "ptb"] = as_frame(de.obs)["leiden"].astype(str)
         label_list.append("ptb")
         df = df.groupby(label_list).sum()
         new_index = df.index.map(lambda x: "_".join(map(str, x)))
@@ -375,7 +377,7 @@ class Cinemaot:
             >>> dim = model.get_dim(adata)
         """
         sk = SinkhornKnopp()
-        data = adata.raw.X.toarray() if issparse(adata.raw.X) else adata.raw.X
+        data = to_dense(as_matrix(adata.raw.X))
         vm = (1e-3 + data + c * data * data) / (1 + c)
         sk.fit(vm)
         wm = np.dot(np.dot(np.sqrt(sk._D1), vm), np.sqrt(sk._D2))
@@ -416,10 +418,10 @@ class Cinemaot:
         X_pca1 = adata_.obsm[use_rep][adata_.obs[pert_key] == control, :]
         X_pca2 = adata_.obsm[use_rep][adata_.obs[pert_key] != control, :]
         nbrs = NearestNeighbors(n_neighbors=k, algorithm="ball_tree").fit(X_pca1)
-        mixscape_pca = adata.obsm[use_rep].copy()
+        mixscape_pca = as_dense(adata.obsm[use_rep]).copy()
         mixscapematrix = nbrs.kneighbors_graph(X_pca2).toarray()
-        mixscape_pca[adata_.obs[pert_key] != control, :] = (
-            np.dot(mixscapematrix, mixscape_pca[adata_.obs[pert_key] == control, :]) / k
+        mixscape_pca[as_frame(adata_.obs)[pert_key] != control, :] = (
+            np.dot(mixscapematrix, mixscape_pca[as_frame(adata_.obs)[pert_key] == control, :]) / k
         )
 
         adata_.obsm["X_mpca"] = mixscape_pca
@@ -431,8 +433,9 @@ class Cinemaot:
         ref_label = "noncontrol"
         expr_label = "control"
 
-        adata_.obs["ct"] = ref_label
-        adata_.obs.loc[adata_.obs[pert_key] == control, "ct"] = expr_label
+        obs_ = as_frame(adata_.obs)
+        obs_["ct"] = ref_label
+        obs_.loc[obs_[pert_key] == control, "ct"] = expr_label
         pert_key = "ct"
         z = np.zeros(adata_.shape[0]) + 1
 
@@ -610,20 +613,13 @@ class Cinemaot:
             >>> model = pt.tl.Cinemaot()
             >>> c_effect, s_effect = model.attribution_scatter(adata, pert_key="perturbation", control="No stimulation")
         """
-        cf = adata.obsm[cf_rep]
-        if use_raw:
-            if issparse(adata.X):
-                Y0 = adata.raw.X.toarray()[adata.obs[pert_key] == control, :]
-                Y1 = adata.raw.X.toarray()[adata.obs[pert_key] != control, :]
-            else:
-                Y0 = adata.raw.X[adata.obs[pert_key] == control, :]
-                Y1 = adata.raw.X[adata.obs[pert_key] != control, :]
-        elif issparse(adata.X):
-            Y0 = adata.X.toarray()[adata.obs[pert_key] == control, :]
-            Y1 = adata.X.toarray()[adata.obs[pert_key] != control, :]
-        else:
-            Y0 = adata.X[adata.obs[pert_key] == control, :]
-            Y1 = adata.X[adata.obs[pert_key] != control, :]
+        cf = as_matrix(adata.obsm[cf_rep])
+        obs = as_frame(adata.obs)
+        X = as_matrix(adata.X)
+        source = as_matrix(adata.raw.X) if use_raw else X
+        counts = to_dense(source) if isinstance(X, CSBase) else source
+        Y0 = counts[obs[pert_key] == control, :]
+        Y1 = counts[obs[pert_key] != control, :]
         X0 = cf[adata.obs[pert_key] == control, :]
         X1 = cf[adata.obs[pert_key] != control, :]
         ols0 = LinearRegression()
@@ -656,7 +652,7 @@ class Cinemaot:
         ax: Axes | None = None,
         return_fig: bool = False,
         **kwargs,
-    ) -> Figure | None:
+    ) -> Axes | None:
         """Visualize the CINEMA-OT matching matrix.
 
         Args:
@@ -690,7 +686,7 @@ class Cinemaot:
         """
         adata_ = adata[adata.obs[pert_key] == control]
 
-        df = pd.DataFrame(de.obsm[matching_rep])
+        df = pd.DataFrame(as_dense(de.obsm[matching_rep]))
         if de_label is None:
             de_label = "leiden"
             sc.pp.neighbors(de, use_rep="X_embedding")

--- a/pertpy/tools/_cinemaot.py
+++ b/pertpy/tools/_cinemaot.py
@@ -97,7 +97,7 @@ class Cinemaot:
 
         transformer = FastICA(n_components=dim, random_state=0, whiten="arbitrary-variance")
         X_transformed = np.array(transformer.fit_transform(adata.obsm[use_rep][:, :dim]), dtype=np.float64)
-        groupvec = np.asarray((cast_frame(adata.obs)[pert_key] == control * 1).values)  # control
+        groupvec = np.asarray((adata.obs[pert_key] == control * 1).values)  # control
         xi = np.zeros(dim)
         j = 0
         for source_row in X_transformed.T:
@@ -152,7 +152,7 @@ class Cinemaot:
                 / ot_sink.apply(np.ones_like(X_transformed[adata.obs[pert_key] == control, :].T)).T
             )
 
-            adata_X = cast_matrix(adata.X)
+            adata_X = adata.X
             X = to_dense(adata_X)
             te2 = (
                 X[adata.obs[pert_key] != control, :]
@@ -176,7 +176,7 @@ class Cinemaot:
                 ot_matrix / np.sum(ot_matrix, axis=1)[:, None], X_transformed[adata.obs[pert_key] == control, :]
             )
 
-            adata_X = cast_matrix(adata.X)
+            adata_X = adata.X
             X = to_dense(adata_X)
 
             te2 = X[adata.obs[pert_key] != control, :] - np.matmul(
@@ -187,8 +187,8 @@ class Cinemaot:
 
             adata.obsm[cf_rep] = cf
             cf_matrix = cast_dense(adata.obsm[cf_rep])
-            cf_matrix[cast_frame(adata.obs)[pert_key] != control, :] = np.matmul(
-                ot_matrix / np.sum(ot_matrix, axis=1)[:, None], cf_matrix[cast_frame(adata.obs)[pert_key] == control, :]
+            cf_matrix[adata.obs[pert_key] != control, :] = np.matmul(
+                ot_matrix / np.sum(ot_matrix, axis=1)[:, None], cf_matrix[adata.obs[pert_key] == control, :]
             )
 
         TE = sc.AnnData(np.array(te2), obs=adata[adata.obs[pert_key] != control, :].obs.copy(), var=adata.var.copy())
@@ -329,10 +329,10 @@ class Cinemaot:
         sc.pp.neighbors(de, use_rep=de_rep)
         sc.tl.leiden(de, resolution=de_resolution, flavor="igraph")
         if use_raw:
-            counts = to_dense(cast_matrix(adata.raw.X))
+            counts = to_dense(adata.raw.X)
             df = pd.DataFrame(counts, columns=adata.raw.var_names, index=adata.raw.obs_names)
         else:
-            counts = to_dense(cast_matrix(adata.X))
+            counts = to_dense(adata.X)
             df = pd.DataFrame(counts, columns=adata.var_names, index=adata.obs_names)
 
         if label_list is None:
@@ -341,7 +341,7 @@ class Cinemaot:
             sc.tl.leiden(adata, resolution=cf_resolution, flavor="igraph")
             df["ct"] = adata.obs["leiden"].astype(str)
         df["ptb"] = "control"
-        df.loc[np.asarray(cast_frame(adata.obs)[pert_key] != control), "ptb"] = cast_frame(de.obs)["leiden"].astype(str)
+        df.loc[np.asarray(adata.obs[pert_key] != control), "ptb"] = cast_frame(de.obs)["leiden"].astype(str)
         label_list.append("ptb")
         df = df.groupby(label_list).sum()
         new_index = df.index.map(lambda x: "_".join(map(str, x)))
@@ -377,7 +377,7 @@ class Cinemaot:
             >>> dim = model.get_dim(adata)
         """
         sk = SinkhornKnopp()
-        data = to_dense(cast_matrix(adata.raw.X))
+        data = to_dense(adata.raw.X)
         vm = (1e-3 + data + c * data * data) / (1 + c)
         sk.fit(vm)
         wm = np.dot(np.dot(np.sqrt(sk._D1), vm), np.sqrt(sk._D2))
@@ -420,8 +420,8 @@ class Cinemaot:
         nbrs = NearestNeighbors(n_neighbors=k, algorithm="ball_tree").fit(X_pca1)
         mixscape_pca = cast_dense(adata.obsm[use_rep]).copy()
         mixscapematrix = nbrs.kneighbors_graph(X_pca2).toarray()
-        mixscape_pca[cast_frame(adata_.obs)[pert_key] != control, :] = (
-            np.dot(mixscapematrix, mixscape_pca[cast_frame(adata_.obs)[pert_key] == control, :]) / k
+        mixscape_pca[adata_.obs[pert_key] != control, :] = (
+            np.dot(mixscapematrix, mixscape_pca[adata_.obs[pert_key] == control, :]) / k
         )
 
         adata_.obsm["X_mpca"] = mixscape_pca
@@ -613,10 +613,10 @@ class Cinemaot:
             >>> model = pt.tl.Cinemaot()
             >>> c_effect, s_effect = model.attribution_scatter(adata, pert_key="perturbation", control="No stimulation")
         """
-        cf = cast_matrix(adata.obsm[cf_rep])
-        obs = cast_frame(adata.obs)
+        cf = adata.obsm[cf_rep]
+        obs = adata.obs
         X = cast_matrix(adata.X)
-        source = cast_matrix(adata.raw.X) if use_raw else X
+        source = adata.raw.X if use_raw else X
         counts = to_dense(source) if isinstance(X, CSBase) else source
         Y0 = counts[obs[pert_key] == control, :]
         Y1 = counts[obs[pert_key] != control, :]

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -26,7 +26,7 @@ from scipy.cluster import hierarchy as sp_hierarchy
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
-from pertpy._types import as_dense, as_frame, as_matrix
+from pertpy._types import cast_dense, cast_frame, cast_matrix
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -187,8 +187,8 @@ class CompositionalModel2(ABC):
         dtype = "float64"
 
         # Convert count data to float64 (needed for correct inference)
-        sample_adata.X = as_matrix(sample_adata.X).astype(dtype)
-        X = as_dense(sample_adata.X)
+        sample_adata.X = cast_matrix(sample_adata.X).astype(dtype)
+        X = cast_dense(sample_adata.X)
 
         # Build covariate matrix from R-like formula, save in obsm
         import patsy  # type: ignore[import-untyped]
@@ -236,7 +236,7 @@ class CompositionalModel2(ABC):
         sample_adata.obsm["sample_counts"] = np.sum(X, axis=1)
 
         # Check for relative abundances
-        if np.allclose(as_dense(sample_adata.obsm["sample_counts"]), 1.0):
+        if np.allclose(cast_dense(sample_adata.obsm["sample_counts"]), 1.0):
             warnings.warn(
                 "All samples sum to ~1, suggesting relative abundances were provided. "
                 "scCODA requires absolute cell counts. Results may be meaningless.",
@@ -811,11 +811,11 @@ class CompositionalModel2(ABC):
 
             # Feature-level effects are just node-level effects time ancestor matrix
             effect_df["final_parameter"] = np.matmul(
-                np.kron(np.eye(D, dtype=int), A), np.array(as_frame(node_df)["final_parameter"])
+                np.kron(np.eye(D, dtype=int), A), np.array(cast_frame(node_df)["final_parameter"])
             )
 
         # Get expected sample, log-fold change
-        y_bar = np.mean(np.sum(as_dense(sample_adata.X), axis=1))
+        y_bar = np.mean(np.sum(cast_dense(sample_adata.X), axis=1))
         alpha_par = intercept_df.loc[:, "final_parameter"].astype(float)
         alphas_exp = np.exp(alpha_par)
         alpha_sample = (alphas_exp / np.sum(alphas_exp) * y_bar).values
@@ -888,7 +888,7 @@ class CompositionalModel2(ABC):
         intercept_df = intercept_df.rename(columns={"mean": "final_parameter"})
 
         # Get expected sample
-        y_bar = np.mean(np.sum(as_dense(sample_adata.X), axis=1))
+        y_bar = np.mean(np.sum(cast_dense(sample_adata.X), axis=1))
         alphas_exp = np.exp(intercept_df.loc[:, "final_parameter"].astype(float))
         alpha_sample = (alphas_exp / np.sum(alphas_exp) * y_bar).values
         intercept_df.loc[:, "expected_sample"] = alpha_sample
@@ -1335,7 +1335,7 @@ class CompositionalModel2(ABC):
         if isinstance(data, MuData):
             data = data[modality_key]
 
-        ct_names = as_frame(data.var).index.to_list()
+        ct_names = cast_frame(data.var).index.to_list()
 
         # option to plot one stacked barplot per sample
         if feature_name == "samples":
@@ -1343,10 +1343,10 @@ class CompositionalModel2(ABC):
                 assert set(level_order) == set(data.obs.index), "level order is inconsistent with levels"
                 data = data[level_order]
             self._stackbar(
-                as_dense(data.X),
-                type_names=as_frame(data.var).index.to_list(),
+                cast_dense(data.X),
+                type_names=cast_frame(data.var).index.to_list(),
                 title="samples",
-                level_names=as_frame(data.obs).index.to_list(),
+                level_names=cast_frame(data.obs).index.to_list(),
                 figsize=figsize,
                 dpi=dpi,
                 palette=palette,
@@ -1354,7 +1354,7 @@ class CompositionalModel2(ABC):
             )
         else:
             # Order levels
-            obs = as_frame(data.obs)
+            obs = cast_frame(data.obs)
             levels: list[str]
             if level_order:
                 assert set(level_order) == set(obs[feature_name]), "level order is inconsistent with levels"
@@ -1364,7 +1364,7 @@ class CompositionalModel2(ABC):
             else:
                 levels = pd.unique(obs[feature_name]).tolist()
             n_levels = len(levels)
-            counts = as_dense(data.X)
+            counts = cast_dense(data.X)
             feature_totals = np.zeros([n_levels, counts.shape[1]])
 
             for level in range(n_levels):
@@ -1460,7 +1460,7 @@ class CompositionalModel2(ABC):
         covariate_names_non_zero = [
             covariate_name
             for covariate_name in covariate_names
-            if as_frame(data.varm[f"effect_df_{covariate_name}"])[parameter].any()
+            if cast_frame(data.varm[f"effect_df_{covariate_name}"])[parameter].any()
         ]
         covariate_names_zero = list(set(covariate_names) - set(covariate_names_non_zero))
         if not plot_zero_covariate:
@@ -1468,7 +1468,7 @@ class CompositionalModel2(ABC):
 
         # set up df for plotting
         plot_df = pd.concat(
-            [as_frame(data.varm[f"effect_df_{covariate_name}"])[parameter] for covariate_name in covariate_names],
+            [cast_frame(data.varm[f"effect_df_{covariate_name}"])[parameter] for covariate_name in covariate_names],
             axis=1,
         )
         plot_df.columns = covariate_names
@@ -1568,7 +1568,7 @@ class CompositionalModel2(ABC):
                     palette=colors,
                     ax=ax,
                 )
-            cell_types = as_dense(pd.unique(plot_df["Cell Type"]))
+            cell_types = cast_dense(pd.unique(plot_df["Cell Type"]))
             ax.set_xticks(cell_types)
             ax.set_xticklabels(cell_types, rotation=90)
 
@@ -1648,7 +1648,7 @@ class CompositionalModel2(ABC):
         if isinstance(data, MuData):
             data = data[modality_key]
         colors: str | list[RGBA] | None = (
-            list(palette(range(len(as_frame(data.obs)[feature_name].unique()))))
+            list(palette(range(len(cast_frame(data.obs)[feature_name].unique()))))
             if isinstance(palette, Colormap)
             else palette
         )
@@ -1656,7 +1656,7 @@ class CompositionalModel2(ABC):
             raise ValueError("layout must be either 'long' or 'wide'")
 
         # y scale transformations
-        counts = as_dense(data.X)
+        counts = cast_dense(data.X)
         if y_scale == "relative":
             sample_sums = np.sum(counts, axis=1, keepdims=True)
             X = counts / sample_sums
@@ -1679,7 +1679,7 @@ class CompositionalModel2(ABC):
             raise ValueError("Invalid y_scale transformation")
 
         count_df = pd.DataFrame(X, columns=data.var.index, index=data.obs.index).merge(
-            as_frame(data.obs)[feature_name], left_index=True, right_index=True
+            cast_frame(data.obs)[feature_name], left_index=True, right_index=True
         )
         plot_df = pd.melt(count_df, id_vars=feature_name, var_name="Cell type", value_name=value_name)
         if cell_types is not None:
@@ -1795,7 +1795,7 @@ class CompositionalModel2(ABC):
                     **args_swarmplot,
                 )
 
-            cell_type_ticks = as_dense(pd.unique(plot_df["Cell type"]))
+            cell_type_ticks = cast_dense(pd.unique(plot_df["Cell type"]))
             ax.set_xticks(cell_type_ticks)
             ax.set_xticklabels(cell_type_ticks, rotation=90)
 
@@ -1876,7 +1876,7 @@ class CompositionalModel2(ABC):
         if ax is None:
             _, ax = plt.subplots(figsize=figsize, dpi=dpi)
 
-        counts = as_dense(data.X)
+        counts = cast_dense(data.X)
         rel_abun = counts / np.sum(counts, axis=1, keepdims=True)
 
         percent_zero = np.sum(counts == 0, axis=0) / counts.shape[0]
@@ -2311,7 +2311,7 @@ class CompositionalModel2(ABC):
         if isinstance(palette, Colormap):
             palette = {
                 cluster: palette(i % palette.N)
-                for i, cluster in enumerate(as_frame(data_rna.obs)[cluster_key].unique().tolist())
+                for i, cluster in enumerate(cast_frame(data_rna.obs)[cluster_key].unique().tolist())
             }
         for _, effect in enumerate(effect_names):
             effect_df = data_coda.varm[effect]
@@ -2321,12 +2321,12 @@ class CompositionalModel2(ABC):
             vmin = kwargs["vmin"]
             kwargs.pop("vmin")
         else:
-            vmin = min(as_frame(data_rna.obs)[effect].min() for _, effect in enumerate(effect_names))
+            vmin = min(cast_frame(data_rna.obs)[effect].min() for _, effect in enumerate(effect_names))
         if kwargs.get("vmax"):
             vmax = kwargs["vmax"]
             kwargs.pop("vmax")
         else:
-            vmax = max(as_frame(data_rna.obs)[effect].max() for _, effect in enumerate(effect_names))
+            vmax = max(cast_frame(data_rna.obs)[effect].max() for _, effect in enumerate(effect_names))
 
         fig = sc.pl.umap(
             data_rna,
@@ -2700,11 +2700,11 @@ def from_scanpy(
     covariate_obs = list(set(covariate_obs or []) | set(sample_identifier))
 
     if isinstance(sample_identifier, list):
-        adata.obs = as_frame(adata.obs).copy()
-        adata.obs["scCODA_sample_id"] = as_frame(adata.obs)[sample_identifier].agg("-".join, axis=1)
+        adata.obs = cast_frame(adata.obs).copy()
+        adata.obs["scCODA_sample_id"] = cast_frame(adata.obs)[sample_identifier].agg("-".join, axis=1)
         sample_identifier = "scCODA_sample_id"
 
-    groups = as_frame(adata.obs).value_counts([sample_identifier, cell_type_identifier])
+    groups = cast_frame(adata.obs).value_counts([sample_identifier, cell_type_identifier])
     ct_count_data = groups.unstack(level=cell_type_identifier).fillna(0)
     covariate_df_ = pd.DataFrame(index=ct_count_data.index)
 
@@ -2713,13 +2713,13 @@ def from_scanpy(
         covariate_df_ = pd.concat([covariate_df_, covariate_df_uns], axis=1)
 
     if covariate_obs:
-        unique_check = as_frame(adata.obs).groupby(sample_identifier).nunique()
+        unique_check = cast_frame(adata.obs).groupby(sample_identifier).nunique()
         for c in covariate_obs.copy():
             if unique_check[c].max() != 1:
                 logger.warning(f"Covariate {c} has non-unique values for batch! Skipping...")
                 covariate_obs.remove(c)
         if covariate_obs:
-            covariate_df_obs = as_frame(adata.obs).groupby(sample_identifier).first()[covariate_obs]
+            covariate_df_obs = cast_frame(adata.obs).groupby(sample_identifier).first()[covariate_obs]
             covariate_df_ = pd.concat([covariate_df_, covariate_df_obs], axis=1)
 
     if covariate_df is not None:

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1335,7 +1335,7 @@ class CompositionalModel2(ABC):
         if isinstance(data, MuData):
             data = data[modality_key]
 
-        ct_names = cast_frame(data.var).index.to_list()
+        ct_names = data.var.index.to_list()
 
         # option to plot one stacked barplot per sample
         if feature_name == "samples":
@@ -1344,9 +1344,9 @@ class CompositionalModel2(ABC):
                 data = data[level_order]
             self._stackbar(
                 cast_dense(data.X),
-                type_names=cast_frame(data.var).index.to_list(),
+                type_names=data.var.index.to_list(),
                 title="samples",
-                level_names=cast_frame(data.obs).index.to_list(),
+                level_names=data.obs.index.to_list(),
                 figsize=figsize,
                 dpi=dpi,
                 palette=palette,
@@ -1648,9 +1648,7 @@ class CompositionalModel2(ABC):
         if isinstance(data, MuData):
             data = data[modality_key]
         colors: str | list[RGBA] | None = (
-            list(palette(range(len(cast_frame(data.obs)[feature_name].unique()))))
-            if isinstance(palette, Colormap)
-            else palette
+            list(palette(range(len(data.obs[feature_name].unique())))) if isinstance(palette, Colormap) else palette
         )
         if layout not in {"long", "wide"}:
             raise ValueError("layout must be either 'long' or 'wide'")
@@ -2310,8 +2308,7 @@ class CompositionalModel2(ABC):
         effect_names = cast("list[str]", effect_name)
         if isinstance(palette, Colormap):
             palette = {
-                cluster: palette(i % palette.N)
-                for i, cluster in enumerate(cast_frame(data_rna.obs)[cluster_key].unique().tolist())
+                cluster: palette(i % palette.N) for i, cluster in enumerate(data_rna.obs[cluster_key].unique().tolist())
             }
         for _, effect in enumerate(effect_names):
             effect_df = data_coda.varm[effect]
@@ -2321,12 +2318,12 @@ class CompositionalModel2(ABC):
             vmin = kwargs["vmin"]
             kwargs.pop("vmin")
         else:
-            vmin = min(cast_frame(data_rna.obs)[effect].min() for _, effect in enumerate(effect_names))
+            vmin = min(data_rna.obs[effect].min() for _, effect in enumerate(effect_names))
         if kwargs.get("vmax"):
             vmax = kwargs["vmax"]
             kwargs.pop("vmax")
         else:
-            vmax = max(cast_frame(data_rna.obs)[effect].max() for _, effect in enumerate(effect_names))
+            vmax = max(data_rna.obs[effect].max() for _, effect in enumerate(effect_names))
 
         fig = sc.pl.umap(
             data_rna,

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -3,22 +3,22 @@ from __future__ import annotations
 import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 import seaborn as sns
-from adjustText import adjust_text
+from adjustText import adjust_text  # type: ignore[import-untyped]
 from anndata import AnnData
 from jax import config, random
 from matplotlib import cm, rcParams
 from matplotlib import image as mpimg
 from matplotlib.colors import Colormap
-from mudata import MuData
-from numpyro.infer import HMC, MCMC, NUTS, initialization
+from mudata import MuData  # type: ignore[import-untyped]
+from numpyro.infer import HMC, MCMC, NUTS, initialization  # type: ignore[import-untyped]
 from rich import box, print
 from rich.console import Console
 from rich.table import Table
@@ -26,18 +26,22 @@ from scipy.cluster import hierarchy as sp_hierarchy
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
+from pertpy._types import as_dense, as_frame, as_matrix
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    import numpyro as npy
-    import toytree as tt
-    from ete4 import Tree
+    import numpyro as npy  # type: ignore[import-untyped]
+    import toytree as tt  # type: ignore[import-untyped]
+    from ete4 import Tree  # type: ignore[import-untyped]
     from jax._src.typing import Array
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
+    from seaborn.axisgrid import FacetGrid
 
 config.update("jax_enable_x64", True)
+
+RGBA = tuple[float, float, float, float]
 
 
 class CompositionalModel2(ABC):
@@ -111,7 +115,7 @@ class CompositionalModel2(ABC):
         rather than from ``self.mcmc``, so ``make_arviz`` works on stored MuData objects
         even after the model instance has been reused for other datasets (issue #812).
         """
-        import arviz as az
+        import arviz as az  # type: ignore[import-untyped]
         from numpyro.infer import Predictive
 
         mcmc_state = sample_adata.uns.get("scCODA_params", {}).get("mcmc", {})
@@ -183,10 +187,11 @@ class CompositionalModel2(ABC):
         dtype = "float64"
 
         # Convert count data to float64 (needed for correct inference)
-        sample_adata.X = sample_adata.X.astype(dtype)
+        sample_adata.X = as_matrix(sample_adata.X).astype(dtype)
+        X = as_dense(sample_adata.X)
 
         # Build covariate matrix from R-like formula, save in obsm
-        import patsy
+        import patsy  # type: ignore[import-untyped]
 
         covariate_matrix = patsy.dmatrix(formula, sample_adata.obs)
         covariate_names = covariate_matrix.design_info.column_names[1:]
@@ -197,7 +202,7 @@ class CompositionalModel2(ABC):
         # Invoke instance of the correct model depending on reference cell type
         # Automatic reference selection (dispersion-based)
         if reference_cell_type == "automatic":
-            percent_zero = np.sum(sample_adata.X == 0, axis=0) / sample_adata.X.shape[0]
+            percent_zero = np.sum(X == 0, axis=0) / X.shape[0]
             nonrare_ct = np.where(percent_zero < automatic_reference_absence_threshold)[0]
 
             if len(nonrare_ct) == 0:
@@ -205,7 +210,7 @@ class CompositionalModel2(ABC):
                     "No cell types that have large enough presence! Please increase automatic_reference_absence_threshold"
                 )
 
-            rel_abun = sample_adata.X / np.sum(sample_adata.X, axis=1, keepdims=True)
+            rel_abun = X / np.sum(X, axis=1, keepdims=True)
 
             # select reference
             cell_type_disp = np.var(rel_abun, axis=0) / np.mean(rel_abun, axis=0)
@@ -224,14 +229,14 @@ class CompositionalModel2(ABC):
             raise NameError("Reference index is not a valid cell type name or numerical index!")
 
         # Add pseudocount if zeroes are present.
-        if np.count_nonzero(sample_adata.X) != np.size(sample_adata.X):
+        if np.count_nonzero(X) != np.size(X):
             logger.info("Zero counts encountered in data! Added a pseudocount of 0.5.")
-            sample_adata.X[sample_adata.X == 0] = 0.5
+            X[X == 0] = 0.5
 
-        sample_adata.obsm["sample_counts"] = np.sum(sample_adata.X, axis=1)
+        sample_adata.obsm["sample_counts"] = np.sum(X, axis=1)
 
         # Check for relative abundances
-        if np.allclose(sample_adata.obsm["sample_counts"], 1.0):
+        if np.allclose(as_dense(sample_adata.obsm["sample_counts"]), 1.0):
             warnings.warn(
                 "All samples sum to ~1, suggesting relative abundances were provided. "
                 "scCODA requires absolute cell counts. Results may be meaningless.",
@@ -728,7 +733,7 @@ class CompositionalModel2(ABC):
         model_type: str,
         select_type: str,
         target_fdr: float = 0.05,
-        node_df: pd.DataFrame = None,
+        node_df: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
         """Evaluation of MCMC results for effect parameters. This function is only used within self.summary_prepare.
 
@@ -747,8 +752,9 @@ class CompositionalModel2(ABC):
             pd.DataFrame:  effect DataFrame with inclusion probability, final parameters, expected sample.
         """
         # Data dimensions
-        D = len(effect_df.index.levels[0])
-        K = len(effect_df.index.levels[1])
+        effect_index = cast("pd.MultiIndex", effect_df.index)
+        D = len(effect_index.levels[0])
+        K = len(effect_index.levels[1])
 
         # Effect processing for different models
         # Classic scCODA (spike-and-slab + no tree aggregation)
@@ -805,11 +811,11 @@ class CompositionalModel2(ABC):
 
             # Feature-level effects are just node-level effects time ancestor matrix
             effect_df["final_parameter"] = np.matmul(
-                np.kron(np.eye(D, dtype=int), A), np.array(node_df["final_parameter"])
+                np.kron(np.eye(D, dtype=int), A), np.array(as_frame(node_df)["final_parameter"])
             )
 
         # Get expected sample, log-fold change
-        y_bar = np.mean(np.sum(sample_adata.X, axis=1))
+        y_bar = np.mean(np.sum(as_dense(sample_adata.X), axis=1))
         alpha_par = intercept_df.loc[:, "final_parameter"].astype(float)
         alphas_exp = np.exp(alpha_par)
         alpha_sample = (alphas_exp / np.sum(alphas_exp) * y_bar).values
@@ -856,7 +862,7 @@ class CompositionalModel2(ABC):
             p_t = (theta * l_1 / 2) / ((theta * l_1 / 2) + ((1 - theta) * l_0 / 2))
             return 1 / (l_0 - l_1) * np.log(1 / p_t - 1)
 
-        D = len(node_df.index.levels[0])
+        D = len(cast("pd.MultiIndex", node_df.index).levels[0])
 
         # apply inclusion threshold
         deltas = delta(l_0, l_1, theta)
@@ -882,7 +888,7 @@ class CompositionalModel2(ABC):
         intercept_df = intercept_df.rename(columns={"mean": "final_parameter"})
 
         # Get expected sample
-        y_bar = np.mean(np.sum(sample_adata.X, axis=1))
+        y_bar = np.mean(np.sum(as_dense(sample_adata.X), axis=1))
         alphas_exp = np.exp(intercept_df.loc[:, "final_parameter"].astype(float))
         alpha_sample = (alphas_exp / np.sum(alphas_exp) * y_bar).values
         intercept_df.loc[:, "expected_sample"] = alpha_sample
@@ -1003,7 +1009,7 @@ class CompositionalModel2(ABC):
 
             if model_type == "tree_agg":
                 table = Table("Nodes", box=box.SQUARE, expand=True, highlight=True)
-                for index in node_df.index.levels[0]:
+                for index in cast("pd.MultiIndex", node_df.index).levels[0]:
                     table.add_row(f"Covariate={index}", end_section=True)
                     table.add_row(
                         node_df.loc[index].to_string(justify="center", float_format=lambda _: f"{_:.2f}"),
@@ -1170,7 +1176,9 @@ class CompositionalModel2(ABC):
         for cov in effect_df.index.get_level_values("Covariate"):
             sample_adata.varm[f"effect_df_{cov}"] = effect_df.loc[cov, :]
 
-    def credible_effects(self, data: AnnData | MuData, modality_key: str = "coda", est_fdr: float = None) -> pd.Series:
+    def credible_effects(
+        self, data: AnnData | MuData, modality_key: str = "coda", est_fdr: float | None = None
+    ) -> pd.Series:
         """Decides which effects of the scCODA model are credible based on an adjustable inclusion probability threshold.
 
         Note: Parameter est_fdr has no effect for spike-and-slab LASSO selection method.
@@ -1292,7 +1300,7 @@ class CompositionalModel2(ABC):
         modality_key: str = "coda",
         palette: str | Colormap | None = cm.tab20,
         show_legend: bool | None = True,
-        level_order: list[str] = None,
+        level_order: list[str] | None = None,
         figsize: tuple[float, float] | None = None,
         dpi: int | None = 100,
         return_fig: bool = False,
@@ -1327,7 +1335,7 @@ class CompositionalModel2(ABC):
         if isinstance(data, MuData):
             data = data[modality_key]
 
-        ct_names = data.var.index
+        ct_names = as_frame(data.var).index.to_list()
 
         # option to plot one stacked barplot per sample
         if feature_name == "samples":
@@ -1335,10 +1343,10 @@ class CompositionalModel2(ABC):
                 assert set(level_order) == set(data.obs.index), "level order is inconsistent with levels"
                 data = data[level_order]
             self._stackbar(
-                data.X,
-                type_names=data.var.index,
+                as_dense(data.X),
+                type_names=as_frame(data.var).index.to_list(),
                 title="samples",
-                level_names=data.obs.index,
+                level_names=as_frame(data.obs).index.to_list(),
                 figsize=figsize,
                 dpi=dpi,
                 palette=palette,
@@ -1346,19 +1354,22 @@ class CompositionalModel2(ABC):
             )
         else:
             # Order levels
+            obs = as_frame(data.obs)
+            levels: list[str]
             if level_order:
-                assert set(level_order) == set(data.obs[feature_name]), "level order is inconsistent with levels"
+                assert set(level_order) == set(obs[feature_name]), "level order is inconsistent with levels"
                 levels = level_order
-            elif hasattr(data.obs[feature_name], "cat"):
-                levels = data.obs[feature_name].cat.categories.to_list()
+            elif hasattr(obs[feature_name], "cat"):
+                levels = obs[feature_name].cat.categories.to_list()
             else:
-                levels = pd.unique(data.obs[feature_name])
+                levels = pd.unique(obs[feature_name]).tolist()
             n_levels = len(levels)
-            feature_totals = np.zeros([n_levels, data.X.shape[1]])
+            counts = as_dense(data.X)
+            feature_totals = np.zeros([n_levels, counts.shape[1]])
 
             for level in range(n_levels):
-                l_indices = np.where(data.obs[feature_name] == levels[level])
-                feature_totals[level] = np.sum(data.X[l_indices], axis=0)
+                l_indices = np.where(obs[feature_name] == levels[level])
+                feature_totals[level] = np.sum(counts[l_indices], axis=0)
 
             self._stackbar(
                 feature_totals,
@@ -1388,12 +1399,12 @@ class CompositionalModel2(ABC):
         plot_zero_covariate: bool = True,
         plot_zero_cell_type: bool = False,
         palette: str | Colormap | None = cm.tab20,
-        level_order: list[str] = None,
+        level_order: list[str] | None = None,
         args_barplot: dict | None = None,
         figsize: tuple[float, float] | None = None,
         dpi: int | None = 100,
         return_fig: bool = False,
-    ) -> Figure | None:
+    ) -> Figure | FacetGrid | None:
         """Barplot visualization for effects.
 
         The effect results for each covariate are shown as a group of barplots, with intra--group separation by cell types.
@@ -1449,7 +1460,7 @@ class CompositionalModel2(ABC):
         covariate_names_non_zero = [
             covariate_name
             for covariate_name in covariate_names
-            if data.varm[f"effect_df_{covariate_name}"][parameter].any()
+            if as_frame(data.varm[f"effect_df_{covariate_name}"])[parameter].any()
         ]
         covariate_names_zero = list(set(covariate_names) - set(covariate_names_non_zero))
         if not plot_zero_covariate:
@@ -1457,7 +1468,7 @@ class CompositionalModel2(ABC):
 
         # set up df for plotting
         plot_df = pd.concat(
-            [data.varm[f"effect_df_{covariate_name}"][parameter] for covariate_name in covariate_names],
+            [as_frame(data.varm[f"effect_df_{covariate_name}"])[parameter] for covariate_name in covariate_names],
             axis=1,
         )
         plot_df.columns = covariate_names
@@ -1527,32 +1538,37 @@ class CompositionalModel2(ABC):
         # If not plot as facets, call barplot to plot cell types on the x-axis.
         else:
             _, ax = plt.subplots(figsize=figsize, dpi=dpi)
+            colors: str | list[RGBA] | None
             if len(covariate_names) == 1:
-                if isinstance(palette, Colormap):
-                    palette = np.array(
-                        [palette(i % palette.N) for i in range(len(plot_df["Cell Type"].unique()))]
-                    ).tolist()
+                colors = (
+                    np.array([palette(i % palette.N) for i in range(len(plot_df["Cell Type"].unique()))]).tolist()
+                    if isinstance(palette, Colormap)
+                    else palette
+                )
                 sns.barplot(
                     data=plot_df,
                     x="Cell Type",
                     y="value",
                     hue="x",
-                    palette=palette,
+                    palette=colors,
                     ax=ax,
                 )
                 ax.set_title(covariate_names[0])
             else:
-                if isinstance(palette, Colormap):
-                    palette = np.array([palette(i % palette.N) for i in range(len(covariate_names))]).tolist()
+                colors = (
+                    np.array([palette(i % palette.N) for i in range(len(covariate_names))]).tolist()
+                    if isinstance(palette, Colormap)
+                    else palette
+                )
                 sns.barplot(
                     data=plot_df,
                     x="Cell Type",
                     y="value",
                     hue="Covariate",
-                    palette=palette,
+                    palette=colors,
                     ax=ax,
                 )
-            cell_types = pd.unique(plot_df["Cell Type"])
+            cell_types = as_dense(pd.unique(plot_df["Cell Type"]))
             ax.set_xticks(cell_types)
             ax.set_xticklabels(cell_types, rotation=90)
 
@@ -1577,14 +1593,14 @@ class CompositionalModel2(ABC):
         cell_types: list | None = None,
         args_boxplot: dict | None = None,
         args_swarmplot: dict | None = None,
-        palette: str | Colormap | None = "Blues",
+        palette: str | Colormap | list[RGBA] | None = "Blues",
         show_legend: bool | None = True,
-        level_order: list[str] = None,
+        level_order: list[str] | None = None,
         figsize: tuple[float, float] | None = None,
         dpi: int | None = 100,
         layout: Literal["long", "wide"] = "long",
         return_fig: bool = False,
-    ) -> Figure | None:
+    ) -> Figure | FacetGrid | None:
         """Grouped boxplot visualization.
 
          The cell counts for each cell type are shown as a group of boxplots
@@ -1631,35 +1647,39 @@ class CompositionalModel2(ABC):
             args_swarmplot = {}
         if isinstance(data, MuData):
             data = data[modality_key]
-        if isinstance(palette, Colormap):
-            palette = list(palette(range(len(data.obs[feature_name].unique()))))
+        colors: str | list[RGBA] | None = (
+            list(palette(range(len(as_frame(data.obs)[feature_name].unique()))))
+            if isinstance(palette, Colormap)
+            else palette
+        )
         if layout not in {"long", "wide"}:
             raise ValueError("layout must be either 'long' or 'wide'")
 
         # y scale transformations
+        counts = as_dense(data.X)
         if y_scale == "relative":
-            sample_sums = np.sum(data.X, axis=1, keepdims=True)
-            X = data.X / sample_sums
+            sample_sums = np.sum(counts, axis=1, keepdims=True)
+            X = counts / sample_sums
             value_name = "Proportion"
         # add pseudocount 0.5 if using log scale
         elif y_scale == "log":
-            X = data.X.copy()
+            X = counts.copy()
             X[X == 0] = 0.5
             X = np.log(X)
             value_name = "log(count)"
         elif y_scale == "log10":
-            X = data.X.copy()
+            X = counts.copy()
             X[X == 0] = 0.5
             X = np.log(X)
             value_name = "log10(count)"
         elif y_scale == "count":
-            X = data.X
+            X = counts
             value_name = "count"
         else:
             raise ValueError("Invalid y_scale transformation")
 
         count_df = pd.DataFrame(X, columns=data.var.index, index=data.obs.index).merge(
-            data.obs[feature_name], left_index=True, right_index=True
+            as_frame(data.obs)[feature_name], left_index=True, right_index=True
         )
         plot_df = pd.melt(count_df, id_vars=feature_name, var_name="Cell type", value_name=value_name)
         if cell_types is not None:
@@ -1680,7 +1700,7 @@ class CompositionalModel2(ABC):
         # If plot as facets, create a FacetGrid and map boxplot to it.
         if plot_facets:
             if level_order is None:
-                level_order = pd.unique(plot_df[feature_name])
+                level_order = pd.unique(plot_df[feature_name]).tolist()
 
             K = X.shape[1]
 
@@ -1746,7 +1766,7 @@ class CompositionalModel2(ABC):
                 hue=feature_name,
                 data=plot_df,
                 fliersize=1,
-                palette=palette,
+                palette=colors,
                 ax=ax,
                 **args_boxplot,
             )
@@ -1775,9 +1795,9 @@ class CompositionalModel2(ABC):
                     **args_swarmplot,
                 )
 
-            cell_types = pd.unique(plot_df["Cell type"])
-            ax.set_xticks(cell_types)
-            ax.set_xticklabels(cell_types, rotation=90)
+            cell_type_ticks = as_dense(pd.unique(plot_df["Cell type"]))
+            ax.set_xticks(cell_type_ticks)
+            ax.set_xticklabels(cell_type_ticks, rotation=90)
 
             if show_legend:
                 handles, labels = ax.get_legend_handles_labels()
@@ -1809,9 +1829,9 @@ class CompositionalModel2(ABC):
         data: AnnData | MuData,
         *,
         modality_key: str = "coda",
-        abundant_threshold: float | None = 0.9,
-        default_color: str | None = "Grey",
-        abundant_color: str | None = "Red",
+        abundant_threshold: float = 0.9,
+        default_color: str = "Grey",
+        abundant_color: str = "Red",
         label_cell_types: bool = True,
         figsize: tuple[float, float] | None = None,
         dpi: int | None = 100,
@@ -1856,15 +1876,16 @@ class CompositionalModel2(ABC):
         if ax is None:
             _, ax = plt.subplots(figsize=figsize, dpi=dpi)
 
-        rel_abun = data.X / np.sum(data.X, axis=1, keepdims=True)
+        counts = as_dense(data.X)
+        rel_abun = counts / np.sum(counts, axis=1, keepdims=True)
 
-        percent_zero = np.sum(data.X == 0, axis=0) / data.X.shape[0]
+        percent_zero = np.sum(counts == 0, axis=0) / counts.shape[0]
         nonrare_ct = np.where(percent_zero < 1 - abundant_threshold)[0]
 
         # select reference
         cell_type_disp = np.var(rel_abun, axis=0) / np.mean(rel_abun, axis=0)
 
-        is_abundant = [x in nonrare_ct for x in range(data.X.shape[1])]
+        is_abundant = [x in nonrare_ct for x in range(counts.shape[1])]
 
         # Scatterplot
         plot_df = pd.DataFrame(
@@ -1877,18 +1898,18 @@ class CompositionalModel2(ABC):
         )
 
         if len(np.unique(plot_df["Is abundant"])) > 1:
-            palette = [default_color, abundant_color]
+            colors = [default_color, abundant_color]
         elif np.unique(plot_df["Is abundant"]) == [False]:
-            palette = [default_color]
+            colors = [default_color]
         else:
-            palette = [abundant_color]
+            colors = [abundant_color]
 
         ax = sns.scatterplot(
             data=plot_df,
             x="Presence",
             y="Total dispersion",
             hue="Is abundant",
-            palette=palette,
+            palette=colors,
             ax=ax,
         )
 
@@ -1934,7 +1955,7 @@ class CompositionalModel2(ABC):
         tight_text: bool = False,
         show_scale: bool | None = False,
         units: Literal["px", "mm", "in"] | None = "px",
-        figsize: tuple[float, float] | None = (None, None),
+        figsize: tuple[float | None, float | None] | None = (None, None),
         dpi: int | None = 100,
         save: str | bool = False,
         return_fig: bool = False,
@@ -1977,7 +1998,13 @@ class CompositionalModel2(ABC):
         """
         try:
             from ete4 import Tree
-            from ete4.treeview import CircleFace, NodeStyle, TextFace, TreeStyle, faces
+            from ete4.treeview import (  # type: ignore[import-untyped]
+                CircleFace,
+                NodeStyle,
+                TextFace,
+                TreeStyle,
+                faces,
+            )
         except ImportError:
             raise ImportError(
                 "To use tasccoda please install additional dependencies: `pip install 'pertpy[coda]'`"
@@ -2017,7 +2044,7 @@ class CompositionalModel2(ABC):
         tight_text: bool | None = False,
         show_scale: bool | None = False,
         units: Literal["px", "mm", "in"] | None = "px",
-        figsize: tuple[float, float] | None = (None, None),
+        figsize: tuple[float | None, float | None] | None = (None, None),
         dpi: int | None = 100,
         save: str | bool = False,
         return_fig: bool = False,
@@ -2065,7 +2092,13 @@ class CompositionalModel2(ABC):
         """
         try:
             from ete4 import Tree
-            from ete4.treeview import CircleFace, NodeStyle, TextFace, TreeStyle, faces
+            from ete4.treeview import (  # type: ignore[import-untyped]
+                CircleFace,
+                NodeStyle,
+                TextFace,
+                TreeStyle,
+                faces,
+            )
         except ImportError:
             raise ImportError(
                 "To use tasccoda please install additional dependencies: `pip install 'pertpy[coda]'`"
@@ -2184,7 +2217,7 @@ class CompositionalModel2(ABC):
             plt.subplots_adjust(wspace=0)
 
             if save:
-                plt.savefig(save)
+                plt.savefig(cast("str", save))
             if return_fig:
                 return plt.gcf()
 
@@ -2193,7 +2226,8 @@ class CompositionalModel2(ABC):
                 tree2.render(save, tree_style=tree_style, units=units)
             if return_fig:
                 return tree2, tree_style
-            return tree2.render("%%inline", tree_style=tree_style, units=units, w=figsize[0], h=figsize[1], dpi=dpi)
+            width, height = figsize if figsize is not None else (None, None)
+            return tree2.render("%%inline", tree_style=tree_style, units=units, w=width, h=height, dpi=dpi)
 
         return None
 
@@ -2207,8 +2241,8 @@ class CompositionalModel2(ABC):
         modality_key_1: str = "rna",
         modality_key_2: str = "coda",
         color_map: Colormap | str | None = None,
-        palette: str | Sequence[str] | Colormap | None = None,
-        ax: Axes = None,
+        palette: str | Sequence[str] | Colormap | dict[str, RGBA] | None = None,
+        ax: Axes | None = None,
         return_fig: bool = False,
         **kwargs,
     ) -> Figure | None:
@@ -2273,11 +2307,13 @@ class CompositionalModel2(ABC):
         data_coda = mdata[modality_key_2]
         if isinstance(effect_name, str):
             effect_name = [effect_name]
+        effect_names = cast("list[str]", effect_name)
         if isinstance(palette, Colormap):
             palette = {
-                cluster: palette(i % palette.N) for i, cluster in enumerate(data_rna.obs[cluster_key].unique().tolist())
+                cluster: palette(i % palette.N)
+                for i, cluster in enumerate(as_frame(data_rna.obs)[cluster_key].unique().tolist())
             }
-        for _, effect in enumerate(effect_name):
+        for _, effect in enumerate(effect_names):
             effect_df = data_coda.varm[effect]
             effect_col = "Effect" if "Effect" in effect_df.columns else "Final Parameter"
             data_rna.obs[effect] = [effect_df.loc[f"{c}", effect_col] for c in data_rna.obs[cluster_key]]
@@ -2285,12 +2321,12 @@ class CompositionalModel2(ABC):
             vmin = kwargs["vmin"]
             kwargs.pop("vmin")
         else:
-            vmin = min(data_rna.obs[effect].min() for _, effect in enumerate(effect_name))
+            vmin = min(as_frame(data_rna.obs)[effect].min() for _, effect in enumerate(effect_names))
         if kwargs.get("vmax"):
             vmax = kwargs["vmax"]
             kwargs.pop("vmax")
         else:
-            vmax = max(data_rna.obs[effect].max() for _, effect in enumerate(effect_name))
+            vmax = max(as_frame(data_rna.obs)[effect].max() for _, effect in enumerate(effect_names))
 
         fig = sc.pl.umap(
             data_rna,
@@ -2397,7 +2433,7 @@ def traverse(df_: pd.DataFrame, a: str, i: int, innerl: bool) -> str:
     Adapted from https://stackoverflow.com/questions/15343338/how-to-convert-a-data-frame-to-tree-structure-object-such-as-dendrogram.
     """
     if i + 1 < df_.shape[1]:
-        a_inner = pd.unique(df_.loc[np.where(df_.iloc[:, i] == a)].iloc[:, i + 1])
+        a_inner = pd.unique(df_.loc[np.where(df_.iloc[:, i] == a)[0]].iloc[:, i + 1])
 
         desc = [traverse(df_, b, i + 1, innerl) for b in a_inner]
         il = a if innerl else ""
@@ -2433,8 +2469,8 @@ def df2newick(df: pd.DataFrame, levels: list[str], inner_label: bool = True) -> 
 
 def get_a_2(
     tree: Tree,
-    leaf_order: list[str] = None,
-    node_order: list[str] = None,
+    leaf_order: list[str] | None = None,
+    node_order: list[str] | None = None,
 ) -> tuple[np.ndarray, int]:
     """Calculate ancestor matrix from a ete4 tree.
 
@@ -2484,9 +2520,8 @@ def get_a_2(
         A_ = A_.loc[leaf_order]
     if node_order is not None:
         A_ = A_[node_order]
-    A_ = np.array(A_)
 
-    return A_, n_nodes
+    return np.array(A_), n_nodes
 
 
 def collapse_singularities_2(tree: Tree) -> Tree:
@@ -2537,11 +2572,11 @@ def linkage_to_newick(
 
 def import_tree(
     data: AnnData | MuData,
-    modality_1: str = None,
-    modality_2: str = None,
-    dendrogram_key: str = None,
-    levels_orig: list[str] = None,
-    levels_agg: list[str] = None,
+    modality_1: str | None = None,
+    modality_2: str | None = None,
+    dendrogram_key: str | None = None,
+    levels_orig: list[str] | None = None,
+    levels_agg: list[str] | None = None,
     add_level_name: bool = True,
     key_added: str = "tree",
 ):
@@ -2665,11 +2700,11 @@ def from_scanpy(
     covariate_obs = list(set(covariate_obs or []) | set(sample_identifier))
 
     if isinstance(sample_identifier, list):
-        adata.obs = adata.obs.copy()
-        adata.obs["scCODA_sample_id"] = adata.obs[sample_identifier].agg("-".join, axis=1)
+        adata.obs = as_frame(adata.obs).copy()
+        adata.obs["scCODA_sample_id"] = as_frame(adata.obs)[sample_identifier].agg("-".join, axis=1)
         sample_identifier = "scCODA_sample_id"
 
-    groups = adata.obs.value_counts([sample_identifier, cell_type_identifier])
+    groups = as_frame(adata.obs).value_counts([sample_identifier, cell_type_identifier])
     ct_count_data = groups.unstack(level=cell_type_identifier).fillna(0)
     covariate_df_ = pd.DataFrame(index=ct_count_data.index)
 
@@ -2678,13 +2713,13 @@ def from_scanpy(
         covariate_df_ = pd.concat([covariate_df_, covariate_df_uns], axis=1)
 
     if covariate_obs:
-        unique_check = adata.obs.groupby(sample_identifier).nunique()
+        unique_check = as_frame(adata.obs).groupby(sample_identifier).nunique()
         for c in covariate_obs.copy():
             if unique_check[c].max() != 1:
                 logger.warning(f"Covariate {c} has non-unique values for batch! Skipping...")
                 covariate_obs.remove(c)
         if covariate_obs:
-            covariate_df_obs = adata.obs.groupby(sample_identifier).first()[covariate_obs]
+            covariate_df_obs = as_frame(adata.obs).groupby(sample_identifier).first()[covariate_obs]
             covariate_df_ = pd.concat([covariate_df_, covariate_df_obs], axis=1)
 
     if covariate_df is not None:

--- a/pertpy/tools/_coda/_sccoda.py
+++ b/pertpy/tools/_coda/_sccoda.py
@@ -11,7 +11,7 @@ from jax import config
 from mudata import MuData  # type: ignore[import-untyped]
 
 from pertpy._logger import logger
-from pertpy._types import as_matrix
+from pertpy._types import cast_matrix
 from pertpy.tools._coda._base_coda import CompositionalModel2, from_scanpy
 
 if TYPE_CHECKING:
@@ -195,7 +195,7 @@ class Sccoda(CompositionalModel2):
         """
         # data dimensions
         N, D = sample_adata.obsm["covariate_matrix"].shape
-        P = as_matrix(sample_adata.X).shape[1]
+        P = cast_matrix(sample_adata.X).shape[1]
 
         # Sizes of different parameter matrices
         alpha_size = [P]
@@ -236,7 +236,7 @@ class Sccoda(CompositionalModel2):
         """
         # data dimensions
         N, D = sample_adata.obsm["covariate_matrix"].shape
-        P = as_matrix(sample_adata.X).shape[1]
+        P = cast_matrix(sample_adata.X).shape[1]
 
         # numpyro plates for all dimensions
         covariate_axis = npy.plate("covs", D, dim=-2)

--- a/pertpy/tools/_coda/_sccoda.py
+++ b/pertpy/tools/_coda/_sccoda.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 import jax.numpy as jnp
 import numpy as np
-import numpyro as npy
-import numpyro.distributions as npd
+import numpyro as npy  # type: ignore[import-untyped]
+import numpyro.distributions as npd  # type: ignore[import-untyped]
 from anndata import AnnData
 from jax import config
-from mudata import MuData
+from mudata import MuData  # type: ignore[import-untyped]
 
 from pertpy._logger import logger
+from pertpy._types import as_matrix
 from pertpy.tools._coda._base_coda import CompositionalModel2, from_scanpy
 
 if TYPE_CHECKING:
@@ -35,8 +36,8 @@ class Sccoda(CompositionalModel2):
         adata: AnnData,
         type: Literal["cell_level", "sample_level"],
         generate_sample_level: bool = True,
-        cell_type_identifier: str = None,
-        sample_identifier: str = None,
+        cell_type_identifier: str | None = None,
+        sample_identifier: str | None = None,
         covariate_uns: str | None = None,
         covariate_obs: list[str] | None = None,
         covariate_df: pd.DataFrame | None = None,
@@ -76,6 +77,10 @@ class Sccoda(CompositionalModel2):
         """
         if type == "cell_level":
             if generate_sample_level:
+                if cell_type_identifier is None or sample_identifier is None:
+                    raise ValueError(
+                        "`cell_type_identifier` and `sample_identifier` are required to generate the sample level."
+                    )
                 adata_coda = from_scanpy(
                     adata=adata,
                     cell_type_identifier=cell_type_identifier,
@@ -139,10 +144,8 @@ class Sccoda(CompositionalModel2):
         """
         if isinstance(data, MuData):
             adata = data[modality_key]
-            is_MuData = True
         if isinstance(data, AnnData):
             adata = data
-            is_MuData = False
         adata = super().prepare(adata, formula, reference_cell_type, automatic_reference_absence_threshold)
         # All parameters that are returned for analysis
         adata.uns["scCODA_params"]["param_names"] = [
@@ -160,7 +163,7 @@ class Sccoda(CompositionalModel2):
         adata.uns["scCODA_params"]["model_type"] = "classic"
         adata.uns["scCODA_params"]["select_type"] = "spikeslab"
 
-        if is_MuData:
+        if isinstance(data, MuData):
             data.mod[modality_key] = adata
             return data
         else:
@@ -192,7 +195,7 @@ class Sccoda(CompositionalModel2):
         """
         # data dimensions
         N, D = sample_adata.obsm["covariate_matrix"].shape
-        P = sample_adata.X.shape[1]
+        P = as_matrix(sample_adata.X).shape[1]
 
         # Sizes of different parameter matrices
         alpha_size = [P]
@@ -233,7 +236,7 @@ class Sccoda(CompositionalModel2):
         """
         # data dimensions
         N, D = sample_adata.obsm["covariate_matrix"].shape
-        P = sample_adata.X.shape[1]
+        P = as_matrix(sample_adata.X).shape[1]
 
         # numpyro plates for all dimensions
         covariate_axis = npy.plate("covs", D, dim=-2)
@@ -271,7 +274,7 @@ class Sccoda(CompositionalModel2):
         # Combine intercepts and effects
         with sample_axis:
             concentrations = npy.deterministic(
-                "concentrations", jnp.nan_to_num(jnp.exp(alpha + jnp.matmul(covariates, beta)), 0.0001)
+                "concentrations", jnp.nan_to_num(jnp.exp(alpha + jnp.matmul(covariates, beta)))
             )
 
         # Calculate DM-distributed counts
@@ -386,9 +389,11 @@ class Sccoda(CompositionalModel2):
         """  # noqa: D205, D212
         return super().run_nuts(data, modality_key, num_samples, num_warmup, rng_key, copy, *args, **kwargs)
 
-    run_nuts.__doc__ = CompositionalModel2.run_nuts.__doc__ + run_nuts.__doc__
+    run_nuts.__doc__ = (CompositionalModel2.run_nuts.__doc__ or "") + (run_nuts.__doc__ or "")
 
-    def credible_effects(self, data: AnnData | MuData, modality_key: str = "coda", est_fdr: float = None) -> pd.Series:
+    def credible_effects(
+        self, data: AnnData | MuData, modality_key: str = "coda", est_fdr: float | None = None
+    ) -> pd.Series:
         """
 
         Examples:
@@ -407,7 +412,7 @@ class Sccoda(CompositionalModel2):
         """  # noqa: D205, D212
         return super().credible_effects(data, modality_key, est_fdr)
 
-    credible_effects.__doc__ = CompositionalModel2.credible_effects.__doc__ + credible_effects.__doc__
+    credible_effects.__doc__ = (CompositionalModel2.credible_effects.__doc__ or "") + (credible_effects.__doc__ or "")
 
     def summary(self, data: AnnData | MuData, extended: bool = False, modality_key: str = "coda", *args, **kwargs):
         """
@@ -428,7 +433,7 @@ class Sccoda(CompositionalModel2):
         """  # noqa: D205, D212
         return super().summary(data, extended, modality_key, *args, **kwargs)
 
-    summary.__doc__ = CompositionalModel2.summary.__doc__ + summary.__doc__
+    summary.__doc__ = (CompositionalModel2.summary.__doc__ or "") + (summary.__doc__ or "")
 
     def set_fdr(self, data: AnnData | MuData, est_fdr: float, modality_key: str = "coda", *args, **kwargs):
         """
@@ -449,4 +454,4 @@ class Sccoda(CompositionalModel2):
         """  # noqa: D205, D212
         return super().set_fdr(data, est_fdr, modality_key, *args, **kwargs)
 
-    set_fdr.__doc__ = CompositionalModel2.set_fdr.__doc__ + set_fdr.__doc__
+    set_fdr.__doc__ = (CompositionalModel2.set_fdr.__doc__ or "") + (set_fdr.__doc__ or "")

--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -12,7 +12,7 @@ from jax import config
 from mudata import MuData  # type: ignore[import-untyped]
 
 from pertpy._logger import logger
-from pertpy._types import as_matrix
+from pertpy._types import cast_matrix
 from pertpy.tools._coda._base_coda import (
     CompositionalModel2,
     collapse_singularities,
@@ -328,7 +328,7 @@ class Tasccoda(CompositionalModel2):
             >>> adata = tasccoda.set_init_mcmc_states(rng_key=42, ref_index=[0, 1], sample_adata=mdata["coda"])
         """
         N, D = sample_adata.obsm["covariate_matrix"].shape
-        P = as_matrix(sample_adata.X).shape[1]
+        P = cast_matrix(sample_adata.X).shape[1]
         T = sample_adata.uns["scCODA_params"]["T"]
 
         # Reference nodes must be sorted by index
@@ -393,7 +393,7 @@ class Tasccoda(CompositionalModel2):
         """
         # data dimensions
         N, D = sample_adata.obsm["covariate_matrix"].shape
-        P = as_matrix(sample_adata.X).shape[1]
+        P = cast_matrix(sample_adata.X).shape[1]
         T = sample_adata.uns["scCODA_params"]["T"]
 
         # spike-and-slab LASSO parameters

--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 import jax.numpy as jnp
 import numpy as np
-import numpyro as npy
-import numpyro.distributions as npd
-import toytree as tt
+import numpyro as npy  # type: ignore[import-untyped]
+import numpyro.distributions as npd  # type: ignore[import-untyped]
+import toytree as tt  # type: ignore[import-untyped]
 from anndata import AnnData
 from jax import config
-from mudata import MuData
+from mudata import MuData  # type: ignore[import-untyped]
 
 from pertpy._logger import logger
+from pertpy._types import as_matrix
 from pertpy.tools._coda._base_coda import (
     CompositionalModel2,
     collapse_singularities,
@@ -43,14 +44,14 @@ class Tasccoda(CompositionalModel2):
         self,
         adata: AnnData,
         type: Literal["cell_level", "sample_level"],
-        cell_type_identifier: str = None,
-        sample_identifier: str = None,
+        cell_type_identifier: str | None = None,
+        sample_identifier: str | None = None,
         covariate_uns: str | None = None,
         covariate_obs: list[str] | None = None,
         covariate_df: pd.DataFrame | None = None,
-        dendrogram_key: str = None,
-        levels_orig: list[str] = None,
-        levels_agg: list[str] = None,
+        dendrogram_key: str | None = None,
+        levels_orig: list[str] | None = None,
+        levels_agg: list[str] | None = None,
         add_level_name: bool = True,
         key_added: str = "tree",
         modality_key_1: str = "rna",
@@ -98,6 +99,8 @@ class Tasccoda(CompositionalModel2):
             >>> )
         """
         if type == "cell_level":
+            if cell_type_identifier is None or sample_identifier is None:
+                raise ValueError("`cell_type_identifier` and `sample_identifier` are required for `type='cell_level'`.")
             adata_coda = from_scanpy(
                 adata=adata,
                 cell_type_identifier=cell_type_identifier,
@@ -129,8 +132,8 @@ class Tasccoda(CompositionalModel2):
         formula: str,
         reference_cell_type: str = "automatic",
         automatic_reference_absence_threshold: float = 0.05,
-        tree_key: str = None,
-        pen_args: dict = None,
+        tree_key: str | None = None,
+        pen_args: dict | None = None,
         modality_key: str = "coda",
     ) -> AnnData | MuData:
         """Handles data preprocessing, covariate matrix creation, reference selection, and zero count replacement for tascCODA.
@@ -180,17 +183,15 @@ class Tasccoda(CompositionalModel2):
             pen_args = {"lambda_1": 5}
         if isinstance(data, MuData):
             adata = data[modality_key]
-            is_MuData = True
         if isinstance(data, AnnData):
             adata = data
-            is_MuData = False
         adata = super().prepare(adata, formula, reference_cell_type, automatic_reference_absence_threshold)
 
         if tree_key is None:
             raise ValueError("Please specify the key in .uns that contains the tree structure!")
 
         try:
-            import ete4 as ete
+            import ete4 as ete  # type: ignore[import-untyped]
         except ImportError:
             raise ImportError(
                 "To use tasccoda please install additional dependencies as `pip install 'pertpy[tcoda]'`"
@@ -295,7 +296,7 @@ class Tasccoda(CompositionalModel2):
 
         adata.uns["scCODA_params"]["model_type"] = "tree_agg"
         adata.uns["scCODA_params"]["select_type"] = "sslasso"
-        if is_MuData:
+        if isinstance(data, MuData):
             data.mod[modality_key] = adata
             return data
         else:
@@ -327,7 +328,7 @@ class Tasccoda(CompositionalModel2):
             >>> adata = tasccoda.set_init_mcmc_states(rng_key=42, ref_index=[0, 1], sample_adata=mdata["coda"])
         """
         N, D = sample_adata.obsm["covariate_matrix"].shape
-        P = sample_adata.X.shape[1]
+        P = as_matrix(sample_adata.X).shape[1]
         T = sample_adata.uns["scCODA_params"]["T"]
 
         # Reference nodes must be sorted by index
@@ -392,7 +393,7 @@ class Tasccoda(CompositionalModel2):
         """
         # data dimensions
         N, D = sample_adata.obsm["covariate_matrix"].shape
-        P = sample_adata.X.shape[1]
+        P = as_matrix(sample_adata.X).shape[1]
         T = sample_adata.uns["scCODA_params"]["T"]
 
         # spike-and-slab LASSO parameters
@@ -400,8 +401,8 @@ class Tasccoda(CompositionalModel2):
         lambda_1 = sample_adata.uns["scCODA_params"]["sslasso_pen_args"]["lambda_1_scaled"]
 
         # Reference nodes must be sorted by index
-        ref_index = jnp.sort(ref_index)
-        num_ref_nodes = len(ref_index)
+        ref_nodes = jnp.sort(ref_index)
+        num_ref_nodes = len(ref_nodes)
 
         # numpyro plates for all dimensions
         covariate_axis = npy.plate("covs", D, dim=-2)
@@ -428,7 +429,7 @@ class Tasccoda(CompositionalModel2):
 
         with node_axis, covariate_axis:
             # Include effect 0 for reference nodes
-            ref_inserts = jnp.array([ref_index[i] - i for i in range(num_ref_nodes)])
+            ref_inserts = jnp.array([ref_nodes[i] - i for i in range(num_ref_nodes)])
             b_tilde = jnp.insert(b_tilde, ref_inserts, jnp.zeros(shape=[D, 1]), axis=-1)
             b_tilde = npy.deterministic("b_tilde", b_tilde)
 
@@ -445,7 +446,7 @@ class Tasccoda(CompositionalModel2):
         # Combine intercepts and effects
         with sample_axis:
             concentrations = npy.deterministic(
-                "concentrations", jnp.nan_to_num(jnp.exp(alpha + jnp.matmul(covariates, beta)), 0.0001)
+                "concentrations", jnp.nan_to_num(jnp.exp(alpha + jnp.matmul(covariates, beta)))
             )
 
         # Calculate DM-distributed counts
@@ -566,7 +567,7 @@ class Tasccoda(CompositionalModel2):
         """  # noqa: D205, D212
         return super().run_nuts(data, modality_key, num_samples, num_warmup, rng_key, copy, *args, **kwargs)
 
-    run_nuts.__doc__ = CompositionalModel2.run_nuts.__doc__ + run_nuts.__doc__
+    run_nuts.__doc__ = (CompositionalModel2.run_nuts.__doc__ or "") + (run_nuts.__doc__ or "")
 
     def summary(self, data: AnnData | MuData, extended: bool = False, modality_key: str = "coda", *args, **kwargs):
         """
@@ -588,9 +589,11 @@ class Tasccoda(CompositionalModel2):
         """  # noqa: D205, D212
         return super().summary(data, extended, modality_key, *args, **kwargs)
 
-    summary.__doc__ = CompositionalModel2.summary.__doc__ + summary.__doc__
+    summary.__doc__ = (CompositionalModel2.summary.__doc__ or "") + (summary.__doc__ or "")
 
-    def credible_effects(self, data: AnnData | MuData, modality_key: str = "coda", est_fdr: float = None) -> pd.Series:
+    def credible_effects(
+        self, data: AnnData | MuData, modality_key: str = "coda", est_fdr: float | None = None
+    ) -> pd.Series:
         """
 
         Examples:
@@ -610,7 +613,7 @@ class Tasccoda(CompositionalModel2):
         """  # noqa: D205, D212
         return super().credible_effects(data, modality_key, est_fdr)
 
-    credible_effects.__doc__ = CompositionalModel2.credible_effects.__doc__ + credible_effects.__doc__
+    credible_effects.__doc__ = (CompositionalModel2.credible_effects.__doc__ or "") + (credible_effects.__doc__ or "")
 
     def set_fdr(self, data: AnnData | MuData, est_fdr: float, modality_key: str = "coda", *args, **kwargs):
         """
@@ -632,4 +635,4 @@ class Tasccoda(CompositionalModel2):
         """  # noqa: D205, D212
         return super().set_fdr(data, est_fdr, modality_key, *args, **kwargs)
 
-    set_fdr.__doc__ = CompositionalModel2.set_fdr.__doc__ + set_fdr.__doc__
+    set_fdr.__doc__ = (CompositionalModel2.set_fdr.__doc__ or "") + (set_fdr.__doc__ or "")

--- a/pertpy/tools/_dialogue.py
+++ b/pertpy/tools/_dialogue.py
@@ -12,21 +12,23 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import singledispatch
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 import seaborn as sns
-import statsmodels.formula.api as smf
+import statsmodels.formula.api as smf  # type: ignore[import-untyped]
+from fast_array_utils.conv import to_dense
 from scipy import sparse as sp
 from scipy import stats
 from scipy.optimize import nnls
-from sparsecca import multicca_permute, multicca_pmd
-from statsmodels.stats.multitest import multipletests
+from sparsecca import multicca_permute, multicca_pmd  # type: ignore[import-untyped]
+from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
+from pertpy._types import CSBase, as_dense, as_frame, as_matrix
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -52,9 +54,7 @@ def _pseudobulk_per_sample(
         DataFrame indexed by sample, columns are ``adata.var_names``.
     """
     aggregated = sc.get.aggregate(adata, by=sample_key, func=agg, layer=layer)
-    matrix = aggregated.layers[agg]
-    if sp.issparse(matrix):
-        matrix = matrix.toarray()
+    matrix = to_dense(as_matrix(aggregated.layers[agg]))
     return pd.DataFrame(matrix, index=list(aggregated.obs_names), columns=list(aggregated.var_names))
 
 
@@ -83,7 +83,7 @@ def _column_anova_dense(matrix: np.ndarray, groups: np.ndarray) -> np.ndarray:
 
 
 @_column_anova.register(sp.spmatrix)
-def _column_anova_sparse(matrix: sp.spmatrix, groups: np.ndarray) -> np.ndarray:
+def _column_anova_sparse(matrix: CSBase, groups: np.ndarray) -> np.ndarray:
     return _column_anova_dense(matrix.toarray(), np.asarray(groups))
 
 
@@ -190,7 +190,7 @@ def _partial_spearman_dense(X: np.ndarray, Y: np.ndarray, Z: np.ndarray, *, batc
 
 
 @_partial_spearman.register(sp.spmatrix)
-def _partial_spearman_sparse(X: sp.spmatrix, Y: np.ndarray, Z: np.ndarray, *, batch_size: int = 2048):
+def _partial_spearman_sparse(X: CSBase, Y: np.ndarray, Z: np.ndarray, *, batch_size: int = 2048):
     Ys, design, n, df = _prepare_partial_targets(Y, Z)
     if X.shape[0] != n:
         raise ValueError("X and Y must have the same number of rows")
@@ -304,7 +304,7 @@ def _iterative_nnls(
 
 
 def _hlm_pvalue_per_row(
-    expression: np.ndarray,
+    expression: np.ndarray | pd.DataFrame,
     score: np.ndarray,
     covariates: pd.DataFrame,
     sample_groups: np.ndarray,
@@ -522,7 +522,7 @@ class Dialogue:
             mask = (adata.obs[self.celltype_key] == ct).to_numpy()
             sub = adata[mask].copy()
             ct_views[ct] = sub
-            pcs = sub.obsm[self.feature_space_key][:, : self.n_components]
+            pcs = as_dense(sub.obsm[self.feature_space_key])[:, : self.n_components]
             pb_df = (
                 pd.DataFrame(pcs, columns=[f"PC{i + 1}" for i in range(pcs.shape[1])])
                 .assign(_sample=sub.obs[self.sample_key].astype(str).to_numpy())
@@ -543,8 +543,8 @@ class Dialogue:
         out: dict[str, pd.DataFrame] = {}
         for ct, pb in pseudobulks_full.items():
             view = ct_views[ct]
-            pcs = view.obsm[self.feature_space_key][:, : self.n_components]
-            samples = view.obs[self.sample_key].astype(str).to_numpy()
+            pcs = as_dense(view.obsm[self.feature_space_key])[:, : self.n_components]
+            samples = as_frame(view.obs)[self.sample_key].astype(str).to_numpy()
             counts = pd.Series(samples).value_counts()
             abundant = counts[counts >= self.min_cells_per_sample].index
             row_mask = np.isin(samples, abundant.to_numpy())
@@ -647,7 +647,7 @@ class Dialogue:
     ) -> dict[str, np.ndarray]:
         out = {}
         for ct, scores in cca_scores.items():
-            conf = ct_views[ct].obs[self.cell_quality_key].to_numpy(dtype=np.float64)
+            conf = as_frame(ct_views[ct].obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
             out[ct] = _residualize(scores, conf)
         return out
 
@@ -690,8 +690,8 @@ class Dialogue:
         out: dict[str, dict[str, dict[str, list[str]]]] = {f"MCP{i + 1}": {} for i in range(self.n_programs)}
         for ct, scores in cca_scores.items():
             view = ct_views[ct]
-            X = view.X  # may be sparse; _partial_spearman dispatches and streams
-            cellQ = view.obs[self.cell_quality_key].to_numpy(dtype=np.float64)
+            X = as_matrix(view.X)  # may be sparse; _partial_spearman dispatches and streams
+            cellQ = as_frame(view.obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
             n_genes = view.n_vars
             R, P = _partial_spearman(X, scores, cellQ)
             for program_idx in range(scores.shape[1]):
@@ -765,8 +765,8 @@ class Dialogue:
             ct2_scores = cca_scores[ct2][ct2_cells]
             ct1_samples = ct_views[ct1].obs[self.sample_key].astype(str).to_numpy()[ct1_cells]
             ct2_samples = ct_views[ct2].obs[self.sample_key].astype(str).to_numpy()[ct2_cells]
-            ct1_quality = ct_views[ct1].obs[self.cell_quality_key].to_numpy(dtype=np.float64)[ct1_cells]
-            ct2_quality = ct_views[ct2].obs[self.cell_quality_key].to_numpy(dtype=np.float64)[ct2_cells]
+            ct1_quality = as_frame(ct_views[ct1].obs)[self.cell_quality_key].to_numpy(dtype=np.float64)[ct1_cells]
+            ct2_quality = as_frame(ct_views[ct2].obs)[self.cell_quality_key].to_numpy(dtype=np.float64)[ct2_cells]
             ct1_tme_qc = per_sample_quality[ct2].reindex(ct1_samples).to_numpy()
             ct2_tme_qc = per_sample_quality[ct1].reindex(ct2_samples).to_numpy()
 
@@ -788,7 +788,7 @@ class Dialogue:
                 ct2_genes_to_test = sig2_up + sig2_down
 
                 # ct2's program score vs ct1's pseudobulk expression at ct2's cells (R's p1).
-                ct2_tme_for_ct1_genes = gene_pseudobulks[ct1].loc[ct2_samples, ct1_genes_to_test].to_numpy()
+                ct2_tme_for_ct1_genes = np.asarray(gene_pseudobulks[ct1].loc[list(ct2_samples), ct1_genes_to_test])
                 df_ct1 = self._hlm_block(
                     ct2_scores[:, program_idx],
                     ct2_tme_for_ct1_genes,
@@ -800,7 +800,7 @@ class Dialogue:
                 )
 
                 # ct1's program score vs ct2's pseudobulk expression at ct1's cells (R's p2).
-                ct1_tme_for_ct2_genes = gene_pseudobulks[ct2].loc[ct1_samples, ct2_genes_to_test].to_numpy()
+                ct1_tme_for_ct2_genes = np.asarray(gene_pseudobulks[ct2].loc[list(ct1_samples), ct2_genes_to_test])
                 df_ct2 = self._hlm_block(
                     ct1_scores[:, program_idx],
                     ct1_tme_for_ct2_genes,
@@ -848,7 +848,7 @@ class Dialogue:
         out: dict[str, pd.Series] = {}
         for ct, view in ct_views.items():
             samples = view.obs[self.sample_key].astype(str).to_numpy()
-            quality = view.obs[self.cell_quality_key].to_numpy(dtype=np.float64)
+            quality = as_frame(view.obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
             out[ct] = pd.Series(quality).groupby(samples).mean().rename("qcAv")
         return out
 
@@ -1018,12 +1018,12 @@ class Dialogue:
 
         for ct in celltypes:
             view = ct_views[ct]
-            cellQ = view.obs[self.cell_quality_key].to_numpy(dtype=np.float64)
+            cellQ = as_frame(view.obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
             nnls_scores[ct] = _residualize(nnls_scores[ct], cellQ)
 
         adata.obsm["X_dialogue"] = self._broadcast_per_celltype(adata, nnls_scores, ct_views, n_cols=self.n_programs)
         for p in range(self.n_programs):
-            adata.obs[f"mcp_{p}"] = adata.obsm["X_dialogue"][:, p]
+            adata.obs[f"mcp_{p}"] = as_dense(adata.obsm["X_dialogue"])[:, p]
 
         pair_refined = self._refined_pair_correlations(adata, nnls_scores, ct_views, celltypes)
 
@@ -1057,7 +1057,7 @@ class Dialogue:
                 for gene_name, row in df.iterrows():
                     if not np.isfinite(row["zscore"]):
                         continue
-                    key = (program, gene_name, bool(row["up"]))
+                    key = (program, str(gene_name), bool(row["up"]))
                     gene_records.setdefault(key, {})[colname] = float(row["zscore"])
 
         if not gene_records:
@@ -1080,9 +1080,14 @@ class Dialogue:
 
         records = []
         for (program, gene, up), partners in gene_records.items():
-            row = {"program": program, "gene": gene, "up": up, "programF": f"{program}.{'up' if up else 'down'}"}
-            row.update({col: partners.get(col, np.nan) for col in partner_cols})
-            records.append(row)
+            record: dict[str, object] = {
+                "program": program,
+                "gene": gene,
+                "up": up,
+                "programF": f"{program}.{'up' if up else 'down'}",
+            }
+            record.update({col: partners.get(col, np.nan) for col in partner_cols})
+            records.append(record)
         df = pd.DataFrame(records)
         df.index = [f"{r['programF']}_{r['gene']}" for _, r in df.iterrows()]
 
@@ -1236,7 +1241,7 @@ class Dialogue:
                 )
             conditions = (labels[0], labels[1])
         scores = adata.obsm["X_dialogue"]
-        obs = adata.obs
+        obs = as_frame(adata.obs)
         program_cols = [f"MCP{p + 1}" for p in range(self.n_programs)]
         z_table = pd.DataFrame(np.nan, index=celltypes, columns=program_cols)
         p_table = pd.DataFrame(np.nan, index=celltypes, columns=program_cols)
@@ -1347,10 +1352,10 @@ class Dialogue:
         if not 0 < fraction < 0.5:
             raise ValueError("fraction must be in (0, 0.5)")
         idx = int(program.replace("MCP", "")) - 1
-        scores = adata.obsm["X_dialogue"][:, idx]
+        scores = as_dense(adata.obsm["X_dialogue"])[:, idx]
         out: dict[str, pd.DataFrame] = {}
         for ct in adata.uns["dialogue"]["cell_type_order"]:
-            mask = (adata.obs[self.celltype_key] == ct).to_numpy() & np.isfinite(scores)
+            mask = (as_frame(adata.obs)[self.celltype_key] == ct).to_numpy() & np.isfinite(scores)
             if mask.sum() < int(2 / fraction):
                 continue
             ct_scores = scores[mask]
@@ -1404,7 +1409,7 @@ class Dialogue:
         score_col = f"mcp_{int(program.replace('MCP', '')) - 1}"
         if score_col not in adata.obs.columns:
             raise RuntimeError(f"{score_col!r} not in adata.obs; run refine_scores(adata) first.")
-        df = adata.obs[[self.celltype_key, score_col, condition_key]].copy()
+        df = as_frame(adata.obs)[[self.celltype_key, score_col, condition_key]].copy()
         if conditions is not None:
             df = df[df[condition_key].isin(conditions)]
         else:
@@ -1461,9 +1466,9 @@ class Dialogue:
         if score_col not in adata.obs.columns:
             raise RuntimeError(f"{score_col!r} not in adata.obs; run refine_scores(adata) first.")
         sample_means = (
-            adata.obs.groupby([self.sample_key, self.celltype_key], observed=True)[score_col].mean().unstack()
+            as_frame(adata.obs).groupby([self.sample_key, self.celltype_key], observed=True)[score_col].mean().unstack()
         )
-        sample_color = adata.obs.groupby(self.sample_key, observed=True)[color].first()
+        sample_color = as_frame(adata.obs).groupby(self.sample_key, observed=True)[color].first()
         df = sample_means.copy()
         df[color] = sample_color
         grid = sns.pairplot(df, hue=color, corner=True)
@@ -1528,7 +1533,7 @@ def _select_dense_gene_columns_dense(X: np.ndarray, var_names, gene_names: list[
 
 
 @_select_dense_gene_columns.register(sp.spmatrix)
-def _select_dense_gene_columns_sparse(X: sp.spmatrix, var_names, gene_names: list[str]) -> np.ndarray:
+def _select_dense_gene_columns_sparse(X: CSBase, var_names, gene_names: list[str]) -> np.ndarray:
     lookup = {g: i for i, g in enumerate(var_names)}
     idx = np.array([lookup[g] for g in gene_names], dtype=np.int64)
     return np.asarray(X.tocsc()[:, idx].toarray(), dtype=np.float64)

--- a/pertpy/tools/_dialogue.py
+++ b/pertpy/tools/_dialogue.py
@@ -28,7 +28,7 @@ from sparsecca import multicca_permute, multicca_pmd  # type: ignore[import-unty
 from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
-from pertpy._types import CSBase, as_dense, as_frame, as_matrix
+from pertpy._types import CSBase, cast_dense, cast_frame, cast_matrix
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -54,7 +54,7 @@ def _pseudobulk_per_sample(
         DataFrame indexed by sample, columns are ``adata.var_names``.
     """
     aggregated = sc.get.aggregate(adata, by=sample_key, func=agg, layer=layer)
-    matrix = to_dense(as_matrix(aggregated.layers[agg]))
+    matrix = to_dense(cast_matrix(aggregated.layers[agg]))
     return pd.DataFrame(matrix, index=list(aggregated.obs_names), columns=list(aggregated.var_names))
 
 
@@ -522,7 +522,7 @@ class Dialogue:
             mask = (adata.obs[self.celltype_key] == ct).to_numpy()
             sub = adata[mask].copy()
             ct_views[ct] = sub
-            pcs = as_dense(sub.obsm[self.feature_space_key])[:, : self.n_components]
+            pcs = cast_dense(sub.obsm[self.feature_space_key])[:, : self.n_components]
             pb_df = (
                 pd.DataFrame(pcs, columns=[f"PC{i + 1}" for i in range(pcs.shape[1])])
                 .assign(_sample=sub.obs[self.sample_key].astype(str).to_numpy())
@@ -543,8 +543,8 @@ class Dialogue:
         out: dict[str, pd.DataFrame] = {}
         for ct, pb in pseudobulks_full.items():
             view = ct_views[ct]
-            pcs = as_dense(view.obsm[self.feature_space_key])[:, : self.n_components]
-            samples = as_frame(view.obs)[self.sample_key].astype(str).to_numpy()
+            pcs = cast_dense(view.obsm[self.feature_space_key])[:, : self.n_components]
+            samples = cast_frame(view.obs)[self.sample_key].astype(str).to_numpy()
             counts = pd.Series(samples).value_counts()
             abundant = counts[counts >= self.min_cells_per_sample].index
             row_mask = np.isin(samples, abundant.to_numpy())
@@ -647,7 +647,7 @@ class Dialogue:
     ) -> dict[str, np.ndarray]:
         out = {}
         for ct, scores in cca_scores.items():
-            conf = as_frame(ct_views[ct].obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
+            conf = cast_frame(ct_views[ct].obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
             out[ct] = _residualize(scores, conf)
         return out
 
@@ -690,8 +690,8 @@ class Dialogue:
         out: dict[str, dict[str, dict[str, list[str]]]] = {f"MCP{i + 1}": {} for i in range(self.n_programs)}
         for ct, scores in cca_scores.items():
             view = ct_views[ct]
-            X = as_matrix(view.X)  # may be sparse; _partial_spearman dispatches and streams
-            cellQ = as_frame(view.obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
+            X = cast_matrix(view.X)  # may be sparse; _partial_spearman dispatches and streams
+            cellQ = cast_frame(view.obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
             n_genes = view.n_vars
             R, P = _partial_spearman(X, scores, cellQ)
             for program_idx in range(scores.shape[1]):
@@ -765,8 +765,8 @@ class Dialogue:
             ct2_scores = cca_scores[ct2][ct2_cells]
             ct1_samples = ct_views[ct1].obs[self.sample_key].astype(str).to_numpy()[ct1_cells]
             ct2_samples = ct_views[ct2].obs[self.sample_key].astype(str).to_numpy()[ct2_cells]
-            ct1_quality = as_frame(ct_views[ct1].obs)[self.cell_quality_key].to_numpy(dtype=np.float64)[ct1_cells]
-            ct2_quality = as_frame(ct_views[ct2].obs)[self.cell_quality_key].to_numpy(dtype=np.float64)[ct2_cells]
+            ct1_quality = cast_frame(ct_views[ct1].obs)[self.cell_quality_key].to_numpy(dtype=np.float64)[ct1_cells]
+            ct2_quality = cast_frame(ct_views[ct2].obs)[self.cell_quality_key].to_numpy(dtype=np.float64)[ct2_cells]
             ct1_tme_qc = per_sample_quality[ct2].reindex(ct1_samples).to_numpy()
             ct2_tme_qc = per_sample_quality[ct1].reindex(ct2_samples).to_numpy()
 
@@ -848,7 +848,7 @@ class Dialogue:
         out: dict[str, pd.Series] = {}
         for ct, view in ct_views.items():
             samples = view.obs[self.sample_key].astype(str).to_numpy()
-            quality = as_frame(view.obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
+            quality = cast_frame(view.obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
             out[ct] = pd.Series(quality).groupby(samples).mean().rename("qcAv")
         return out
 
@@ -1018,12 +1018,12 @@ class Dialogue:
 
         for ct in celltypes:
             view = ct_views[ct]
-            cellQ = as_frame(view.obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
+            cellQ = cast_frame(view.obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
             nnls_scores[ct] = _residualize(nnls_scores[ct], cellQ)
 
         adata.obsm["X_dialogue"] = self._broadcast_per_celltype(adata, nnls_scores, ct_views, n_cols=self.n_programs)
         for p in range(self.n_programs):
-            adata.obs[f"mcp_{p}"] = as_dense(adata.obsm["X_dialogue"])[:, p]
+            adata.obs[f"mcp_{p}"] = cast_dense(adata.obsm["X_dialogue"])[:, p]
 
         pair_refined = self._refined_pair_correlations(adata, nnls_scores, ct_views, celltypes)
 
@@ -1241,7 +1241,7 @@ class Dialogue:
                 )
             conditions = (labels[0], labels[1])
         scores = adata.obsm["X_dialogue"]
-        obs = as_frame(adata.obs)
+        obs = cast_frame(adata.obs)
         program_cols = [f"MCP{p + 1}" for p in range(self.n_programs)]
         z_table = pd.DataFrame(np.nan, index=celltypes, columns=program_cols)
         p_table = pd.DataFrame(np.nan, index=celltypes, columns=program_cols)
@@ -1352,10 +1352,10 @@ class Dialogue:
         if not 0 < fraction < 0.5:
             raise ValueError("fraction must be in (0, 0.5)")
         idx = int(program.replace("MCP", "")) - 1
-        scores = as_dense(adata.obsm["X_dialogue"])[:, idx]
+        scores = cast_dense(adata.obsm["X_dialogue"])[:, idx]
         out: dict[str, pd.DataFrame] = {}
         for ct in adata.uns["dialogue"]["cell_type_order"]:
-            mask = (as_frame(adata.obs)[self.celltype_key] == ct).to_numpy() & np.isfinite(scores)
+            mask = (cast_frame(adata.obs)[self.celltype_key] == ct).to_numpy() & np.isfinite(scores)
             if mask.sum() < int(2 / fraction):
                 continue
             ct_scores = scores[mask]
@@ -1409,7 +1409,7 @@ class Dialogue:
         score_col = f"mcp_{int(program.replace('MCP', '')) - 1}"
         if score_col not in adata.obs.columns:
             raise RuntimeError(f"{score_col!r} not in adata.obs; run refine_scores(adata) first.")
-        df = as_frame(adata.obs)[[self.celltype_key, score_col, condition_key]].copy()
+        df = cast_frame(adata.obs)[[self.celltype_key, score_col, condition_key]].copy()
         if conditions is not None:
             df = df[df[condition_key].isin(conditions)]
         else:
@@ -1466,9 +1466,12 @@ class Dialogue:
         if score_col not in adata.obs.columns:
             raise RuntimeError(f"{score_col!r} not in adata.obs; run refine_scores(adata) first.")
         sample_means = (
-            as_frame(adata.obs).groupby([self.sample_key, self.celltype_key], observed=True)[score_col].mean().unstack()
+            cast_frame(adata.obs)
+            .groupby([self.sample_key, self.celltype_key], observed=True)[score_col]
+            .mean()
+            .unstack()
         )
-        sample_color = as_frame(adata.obs).groupby(self.sample_key, observed=True)[color].first()
+        sample_color = cast_frame(adata.obs).groupby(self.sample_key, observed=True)[color].first()
         df = sample_means.copy()
         df[color] = sample_color
         grid = sns.pairplot(df, hue=color, corner=True)

--- a/pertpy/tools/_dialogue.py
+++ b/pertpy/tools/_dialogue.py
@@ -28,7 +28,7 @@ from sparsecca import multicca_permute, multicca_pmd  # type: ignore[import-unty
 from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
-from pertpy._types import CSBase, cast_dense, cast_frame, cast_matrix
+from pertpy._types import CSBase, cast_dense, cast_frame
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -54,7 +54,7 @@ def _pseudobulk_per_sample(
         DataFrame indexed by sample, columns are ``adata.var_names``.
     """
     aggregated = sc.get.aggregate(adata, by=sample_key, func=agg, layer=layer)
-    matrix = to_dense(cast_matrix(aggregated.layers[agg]))
+    matrix = to_dense(aggregated.layers[agg])
     return pd.DataFrame(matrix, index=list(aggregated.obs_names), columns=list(aggregated.var_names))
 
 
@@ -544,7 +544,7 @@ class Dialogue:
         for ct, pb in pseudobulks_full.items():
             view = ct_views[ct]
             pcs = cast_dense(view.obsm[self.feature_space_key])[:, : self.n_components]
-            samples = cast_frame(view.obs)[self.sample_key].astype(str).to_numpy()
+            samples = view.obs[self.sample_key].astype(str).to_numpy()
             counts = pd.Series(samples).value_counts()
             abundant = counts[counts >= self.min_cells_per_sample].index
             row_mask = np.isin(samples, abundant.to_numpy())
@@ -690,7 +690,7 @@ class Dialogue:
         out: dict[str, dict[str, dict[str, list[str]]]] = {f"MCP{i + 1}": {} for i in range(self.n_programs)}
         for ct, scores in cca_scores.items():
             view = ct_views[ct]
-            X = cast_matrix(view.X)  # may be sparse; _partial_spearman dispatches and streams
+            X = view.X  # may be sparse; _partial_spearman dispatches and streams
             cellQ = cast_frame(view.obs)[self.cell_quality_key].to_numpy(dtype=np.float64)
             n_genes = view.n_vars
             R, P = _partial_spearman(X, scores, cellQ)
@@ -1355,7 +1355,7 @@ class Dialogue:
         scores = cast_dense(adata.obsm["X_dialogue"])[:, idx]
         out: dict[str, pd.DataFrame] = {}
         for ct in adata.uns["dialogue"]["cell_type_order"]:
-            mask = (cast_frame(adata.obs)[self.celltype_key] == ct).to_numpy() & np.isfinite(scores)
+            mask = (adata.obs[self.celltype_key] == ct).to_numpy() & np.isfinite(scores)
             if mask.sum() < int(2 / fraction):
                 continue
             ct_scores = scores[mask]

--- a/pertpy/tools/_differential_gene_expression/_base.py
+++ b/pertpy/tools/_differential_gene_expression/_base.py
@@ -4,8 +4,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
 from itertools import zip_longest
 from types import MappingProxyType
+from typing import cast
 
-import adjustText
+import adjustText  # type: ignore[import-untyped]
 import anndata as ad
 import matplotlib.patheffects as PathEffects
 import matplotlib.pyplot as plt
@@ -18,6 +19,7 @@ from scverse_misc import Deprecation, deprecated_arg
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
+from pertpy._types import CSBase, as_dense, as_frame, as_matrix
 from pertpy.tools import PseudobulkSpace
 from pertpy.tools._differential_gene_expression._checks import check_is_numeric_matrix
 
@@ -93,10 +95,10 @@ class MethodBase(ABC):
     @_doc_params(common_plot_args=doc_common_plot_args)
     @deprecated_arg(
         "pval_thresh",
-        Deprecation("1.1.0", "Use `padj_threshold`."),
+        cast("Deprecation", Deprecation("1.1.0", "Use `padj_threshold`.")),
     )
-    @deprecated_arg("pvalue_col", Deprecation("1.1.0", "Use `padj_col`."), stacklevel=2)
-    @deprecated_arg("log2fc_thresh", Deprecation("1.1.0", "Use `log2fc_threshold`."), stacklevel=3)
+    @deprecated_arg("pvalue_col", cast("Deprecation", Deprecation("1.1.0", "Use `padj_col`.")), stacklevel=2)
+    @deprecated_arg("log2fc_thresh", cast("Deprecation", Deprecation("1.1.0", "Use `log2fc_threshold`.")), stacklevel=3)
     def plot_volcano(  # pragma: no cover # noqa: D417
         self,
         data: pd.DataFrame | ad.AnnData,
@@ -107,8 +109,8 @@ class MethodBase(ABC):
         padj_col: str = "adj_p_value",
         symbol_col: str = "variable",
         to_label: int | list[str] = 5,
-        s_curve: bool | None = False,
-        colors: list[str] = None,
+        s_curve: bool = False,
+        colors: list[str] | None = None,
         varm_key: str | None = None,
         color_dict: dict[str, list[str]] | None = None,
         shape_dict: dict[str, list[str]] | None = None,
@@ -126,7 +128,7 @@ class MethodBase(ABC):
         log2fc_thresh: float | None = None,
         pval_thresh: float | None = None,
         pvalue_col: str | None = None,
-        **kwargs: int,
+        **kwargs,
     ) -> Figure | None:
         """Creates a volcano plot from a pandas DataFrame or Anndata.
 
@@ -189,7 +191,7 @@ class MethodBase(ABC):
         if colors is None:
             colors = ["gray", "#D62728", "#1F77B4"]
 
-        def _pval_reciprocal(lfc: float) -> float:
+        def _pval_reciprocal(lfc: float | np.ndarray) -> float | np.ndarray:
             """Function for relating -log10(pvalue) and logfoldchange in a reciprocal.
 
             Used for plotting the S-curve
@@ -209,7 +211,7 @@ class MethodBase(ABC):
             log2fc_col: str,
             nlog10_col: str,
             log2fc_threshold: float,
-            padj_threshold: float = None,
+            padj_threshold: float | None = None,
             s_curve: bool = False,
         ) -> str:
             """Map genes to categorize based on log2fc and pvalue.
@@ -242,9 +244,9 @@ class MethodBase(ABC):
             log2fc_col: str,
             nlog10_col: str,
             log2fc_threshold: float,
-            padj_threshold: float = None,
+            padj_threshold: float | None = None,
             s_curve: bool = False,
-            symbol_col: str = None,
+            symbol_col: str = "variable",
         ) -> str:
             """Map genes to categorize based on log2fc and pvalue.
 
@@ -384,7 +386,7 @@ class MethodBase(ABC):
             shape_col = None
 
         # build palette
-        colors = colors[: len(df.color.unique())]
+        colors = cast("list[str]", colors)[: len(df.color.unique())]
 
         # We want plot highlighted genes on top + at bigger size, split dataframe
         df_highlight = None
@@ -494,9 +496,9 @@ class MethodBase(ABC):
         groupby: str,
         pairedby: str,
         *,
-        var_names: Sequence[str] = None,
+        var_names: Sequence[str] | None = None,
         n_top_vars: int = 15,
-        layer: str = None,
+        layer: str | None = None,
         pvalue_col: str = "adj_p_value",
         symbol_col: str = "variable",
         n_cols: int = 4,
@@ -564,26 +566,30 @@ class MethodBase(ABC):
 
         adata = adata[:, var_names]
 
-        if any(adata.obs[[groupby, pairedby]].value_counts() > 1):
+        if any(as_frame(adata.obs)[[groupby, pairedby]].value_counts() > 1):
             logger.info("Performing pseudobulk for paired samples")
             ps = PseudobulkSpace()
             adata = ps.compute(adata, target_col=groupby, groups_col=pairedby, layer_key=layer, mode="sum")
 
-        X = adata.layers[layer] if layer is not None else adata.X
+        X = as_matrix(adata.layers[layer] if layer is not None else adata.X)
         with contextlib.suppress(AttributeError):
-            X = X.toarray()
+            X = cast("CSBase", X).toarray()
 
         groupby_cols = [pairedby, groupby]
-        df = adata.obs.loc[:, groupby_cols].join(pd.DataFrame(X, index=adata.obs_names, columns=var_names))
+        df = (
+            as_frame(adata.obs)
+            .loc[:, groupby_cols]
+            .join(pd.DataFrame(as_dense(X), index=adata.obs_names, columns=list(var_names)))
+        )
 
         # remove unpaired samples
         paired_samples = set(df[df[groupby] == groups[0]][pairedby]) & set(df[df[groupby] == groups[1]][pairedby])
         df = df[df[pairedby].isin(paired_samples)]
-        removed_samples = adata.obs[pairedby].nunique() - len(df[pairedby].unique())
+        removed_samples = as_frame(adata.obs)[pairedby].nunique() - len(df[pairedby].unique())
         if removed_samples > 0:
             logger.warning(f"{removed_samples} unpaired samples removed")
 
-        pvalues = results_df.set_index(symbol_col).loc[var_names, pvalue_col].values
+        pvalues = results_df.set_index(symbol_col).loc[list(var_names), pvalue_col].values
         df.reset_index(drop=False, inplace=True)
 
         # transform data for seaborn
@@ -669,7 +675,7 @@ class MethodBase(ABC):
         self,
         results_df: pd.DataFrame,
         *,
-        var_names: Sequence[str] = None,
+        var_names: Sequence[str] | None = None,
         n_top_vars: int = 15,
         padj_threshold: float = 0.01,
         padj_col: str = "adj_p_value",
@@ -870,7 +876,7 @@ class LinearModelBase(MethodBase):
         super().__init__(adata, mask=mask, layer=layer)
         self._check_counts()
 
-        from formulaic_contrasts import FormulaicContrasts
+        from formulaic_contrasts import FormulaicContrasts  # type: ignore[import-untyped]
 
         self.formulaic_contrasts = None
         if isinstance(design, str):
@@ -953,10 +959,11 @@ class LinearModelBase(MethodBase):
         Returns:
             A dataframe with the results.
         """
-        if not isinstance(contrasts, dict):
-            contrasts = {None: contrasts}
+        contrast_map: Mapping[str | None, np.ndarray] = (
+            contrasts if isinstance(contrasts, dict) else {None: as_dense(contrasts)}
+        )
         results = []
-        for name, contrast in contrasts.items():
+        for name, contrast in contrast_map.items():
             if np.allclose(np.asarray(contrast, dtype=float), 0):
                 raise ValueError(
                     f"Contrast {name!r} is all zeros, which yields a meaningless test. "

--- a/pertpy/tools/_differential_gene_expression/_base.py
+++ b/pertpy/tools/_differential_gene_expression/_base.py
@@ -19,7 +19,7 @@ from scverse_misc import Deprecation, deprecated_arg
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
-from pertpy._types import CSBase, cast_dense, cast_frame, cast_matrix
+from pertpy._types import CSBase, cast_dense, cast_frame
 from pertpy.tools import PseudobulkSpace
 from pertpy.tools._differential_gene_expression._checks import check_is_numeric_matrix
 
@@ -386,7 +386,7 @@ class MethodBase(ABC):
             shape_col = None
 
         # build palette
-        colors = cast("list[str]", colors)[: len(df.color.unique())]
+        colors = colors[: len(df.color.unique())]
 
         # We want plot highlighted genes on top + at bigger size, split dataframe
         df_highlight = None
@@ -571,7 +571,7 @@ class MethodBase(ABC):
             ps = PseudobulkSpace()
             adata = ps.compute(adata, target_col=groupby, groups_col=pairedby, layer_key=layer, mode="sum")
 
-        X = cast_matrix(adata.layers[layer] if layer is not None else adata.X)
+        X = adata.layers[layer] if layer is not None else adata.X
         with contextlib.suppress(AttributeError):
             X = cast("CSBase", X).toarray()
 
@@ -585,7 +585,7 @@ class MethodBase(ABC):
         # remove unpaired samples
         paired_samples = set(df[df[groupby] == groups[0]][pairedby]) & set(df[df[groupby] == groups[1]][pairedby])
         df = df[df[pairedby].isin(paired_samples)]
-        removed_samples = cast_frame(adata.obs)[pairedby].nunique() - len(df[pairedby].unique())
+        removed_samples = adata.obs[pairedby].nunique() - len(df[pairedby].unique())
         if removed_samples > 0:
             logger.warning(f"{removed_samples} unpaired samples removed")
 

--- a/pertpy/tools/_differential_gene_expression/_base.py
+++ b/pertpy/tools/_differential_gene_expression/_base.py
@@ -19,7 +19,7 @@ from scverse_misc import Deprecation, deprecated_arg
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
-from pertpy._types import CSBase, as_dense, as_frame, as_matrix
+from pertpy._types import CSBase, cast_dense, cast_frame, cast_matrix
 from pertpy.tools import PseudobulkSpace
 from pertpy.tools._differential_gene_expression._checks import check_is_numeric_matrix
 
@@ -566,26 +566,26 @@ class MethodBase(ABC):
 
         adata = adata[:, var_names]
 
-        if any(as_frame(adata.obs)[[groupby, pairedby]].value_counts() > 1):
+        if any(cast_frame(adata.obs)[[groupby, pairedby]].value_counts() > 1):
             logger.info("Performing pseudobulk for paired samples")
             ps = PseudobulkSpace()
             adata = ps.compute(adata, target_col=groupby, groups_col=pairedby, layer_key=layer, mode="sum")
 
-        X = as_matrix(adata.layers[layer] if layer is not None else adata.X)
+        X = cast_matrix(adata.layers[layer] if layer is not None else adata.X)
         with contextlib.suppress(AttributeError):
             X = cast("CSBase", X).toarray()
 
         groupby_cols = [pairedby, groupby]
         df = (
-            as_frame(adata.obs)
+            cast_frame(adata.obs)
             .loc[:, groupby_cols]
-            .join(pd.DataFrame(as_dense(X), index=adata.obs_names, columns=list(var_names)))
+            .join(pd.DataFrame(cast_dense(X), index=adata.obs_names, columns=list(var_names)))
         )
 
         # remove unpaired samples
         paired_samples = set(df[df[groupby] == groups[0]][pairedby]) & set(df[df[groupby] == groups[1]][pairedby])
         df = df[df[pairedby].isin(paired_samples)]
-        removed_samples = as_frame(adata.obs)[pairedby].nunique() - len(df[pairedby].unique())
+        removed_samples = cast_frame(adata.obs)[pairedby].nunique() - len(df[pairedby].unique())
         if removed_samples > 0:
             logger.warning(f"{removed_samples} unpaired samples removed")
 
@@ -960,7 +960,7 @@ class LinearModelBase(MethodBase):
             A dataframe with the results.
         """
         contrast_map: Mapping[str | None, np.ndarray] = (
-            contrasts if isinstance(contrasts, dict) else {None: as_dense(contrasts)}
+            contrasts if isinstance(contrasts, dict) else {None: cast_dense(contrasts)}
         )
         results = []
         for name, contrast in contrast_map.items():

--- a/pertpy/tools/_differential_gene_expression/_checks.py
+++ b/pertpy/tools/_differential_gene_expression/_checks.py
@@ -1,8 +1,9 @@
 import numpy as np
-from scipy.sparse import issparse, spmatrix
+
+from pertpy._types import CSBase
 
 
-def check_is_numeric_matrix(array: np.ndarray | spmatrix) -> None:
+def check_is_numeric_matrix(array: np.ndarray | CSBase) -> None:
     """Check if a matrix is numeric and only contains finite/non-NA values.
 
     Args:
@@ -13,14 +14,14 @@ def check_is_numeric_matrix(array: np.ndarray | spmatrix) -> None:
     """
     if not np.issubdtype(array.dtype, np.number):
         raise ValueError("Counts must be numeric.")
-    if issparse(array):
+    if isinstance(array, CSBase):
         if np.any(~np.isfinite(array.data)):
             raise ValueError("Counts cannot contain negative, NaN or Inf values.")
     elif np.any(~np.isfinite(array)):
         raise ValueError("Counts cannot contain negative, NaN or Inf values.")
 
 
-def check_is_integer_matrix(array: np.ndarray | spmatrix, tolerance: float = 1e-6) -> None:
+def check_is_integer_matrix(array: np.ndarray | CSBase, tolerance: float = 1e-6) -> None:
     """Check if a matrix container integers, or floats that are close to integers.
 
     Args:
@@ -30,10 +31,10 @@ def check_is_integer_matrix(array: np.ndarray | spmatrix, tolerance: float = 1e-
     Raises:
         ValueError: If the matrix contains values that are not close to integers.
     """
-    if issparse(array):
+    if isinstance(array, CSBase):
         if not array.data.dtype.kind == "i" and not np.all(np.abs(array.data - np.round(array.data)) < tolerance):
             raise ValueError("Non-zero elements of the matrix must be close to integer values.")
     elif array.dtype.kind != "i" and not np.all(np.abs(array - np.round(array)) < tolerance):
         raise ValueError("Matrix must be a count matrix.")
-    if (array < 0).sum() > 0:
+    if np.asarray((array < 0).sum()) > 0:
         raise ValueError("Non-zero elements of the matrix must be positive.")

--- a/pertpy/tools/_differential_gene_expression/_edger.py
+++ b/pertpy/tools/_differential_gene_expression/_edger.py
@@ -25,10 +25,13 @@ class EdgeR(LinearModelBase):
             **kwargs: Keyword arguments specific to glmQLFit()
         """
         try:
-            from rpy2 import robjects as ro
-            from rpy2.robjects import numpy2ri, pandas2ri
-            from rpy2.robjects.conversion import get_conversion, localconverter
-            from rpy2.robjects.packages import importr
+            from rpy2 import robjects as ro  # type: ignore[import-untyped,import-not-found]
+            from rpy2.robjects import numpy2ri, pandas2ri  # type: ignore[import-untyped,import-not-found]
+            from rpy2.robjects.conversion import (  # type: ignore[import-untyped,import-not-found]
+                get_conversion,
+                localconverter,
+            )
+            from rpy2.robjects.packages import importr  # type: ignore[import-untyped,import-not-found]
 
         except ImportError:
             raise ImportError("edger requires rpy2 to be installed.") from None
@@ -82,10 +85,13 @@ class EdgeR(LinearModelBase):
         #  Fix mask for .fit()
 
         try:
-            from rpy2 import robjects as ro
-            from rpy2.robjects import numpy2ri, pandas2ri
-            from rpy2.robjects.conversion import get_conversion, localconverter
-            from rpy2.robjects.packages import importr
+            from rpy2 import robjects as ro  # type: ignore[import-untyped,import-not-found]
+            from rpy2.robjects import numpy2ri, pandas2ri  # type: ignore[import-untyped,import-not-found]
+            from rpy2.robjects.conversion import (  # type: ignore[import-untyped,import-not-found]
+                get_conversion,
+                localconverter,
+            )
+            from rpy2.robjects.packages import importr  # type: ignore[import-untyped,import-not-found]
 
         except ImportError:
             raise ImportError("edger requires rpy2 to be installed.") from None

--- a/pertpy/tools/_differential_gene_expression/_pydeseq2.py
+++ b/pertpy/tools/_differential_gene_expression/_pydeseq2.py
@@ -8,9 +8,9 @@ from anndata import AnnData
 from matplotlib.lines import Line2D
 from matplotlib.pyplot import Figure
 from numpy import ndarray
-from pydeseq2.dds import DeseqDataSet
-from pydeseq2.default_inference import DefaultInference
-from pydeseq2.ds import DeseqStats
+from pydeseq2.dds import DeseqDataSet  # type: ignore[import-untyped]
+from pydeseq2.default_inference import DefaultInference  # type: ignore[import-untyped]
+from pydeseq2.ds import DeseqStats  # type: ignore[import-untyped]
 from scipy.sparse import issparse
 
 from pertpy._doc import _doc_params, doc_common_plot_args
@@ -39,7 +39,7 @@ class PyDESeq2(LinearModelBase):
     def _check_counts(self):
         check_is_integer_matrix(self.data)
 
-    def fit(self, **kwargs) -> pd.DataFrame:
+    def fit(self, **kwargs) -> None:
         """Fit dds model using pydeseq2.
 
         Note: this creates its own AnnData object for downstream processing.
@@ -188,7 +188,7 @@ class PyDESeq2(LinearModelBase):
             final_y,
             s=point_size * (20 + 20 * outliers.astype(int)),
             facecolor=np.where(outliers, "none", final_col),
-            edgecolors=np.where(outliers, final_col, "none"),
+            edgecolors=np.where(outliers, final_col, "none").tolist(),
         )
 
         fitted_disp = np.asarray(dds.var["fitted_dispersions"])[sel]

--- a/pertpy/tools/_differential_gene_expression/_simple_tests.py
+++ b/pertpy/tools/_differential_gene_expression/_simple_tests.py
@@ -8,7 +8,7 @@ from types import MappingProxyType
 import numpy as np
 import pandas as pd
 import scipy.stats
-import statsmodels
+import statsmodels  # type: ignore[import-untyped]
 from anndata import AnnData
 from fast_array_utils.conv import to_dense
 from joblib import delayed

--- a/pertpy/tools/_differential_gene_expression/_statsmodels.py
+++ b/pertpy/tools/_differential_gene_expression/_statsmodels.py
@@ -1,13 +1,14 @@
 import numpy as np
 import pandas as pd
-import statsmodels
-import statsmodels.api as sm
+import statsmodels  # type: ignore[import-untyped]
+import statsmodels.api as sm  # type: ignore[import-untyped]
 from fast_array_utils.conv import to_dense
 from joblib import delayed, effective_n_jobs
 from scipy.sparse import issparse
 from tqdm.auto import tqdm
 
 from pertpy._parallel import _MAX_BLOCK_ELEMENTS, _block_slices, _parallelize_with_joblib
+from pertpy._types import CSBase
 
 from ._base import LinearModelBase
 from ._checks import check_is_numeric_matrix
@@ -49,10 +50,10 @@ class Statsmodels(LinearModelBase):
         """
         data = self.data
         # Slicing out variables is significantly more efficient in csc format.
-        if issparse(data):
+        if isinstance(data, CSBase):
             data = data.tocsc()
 
-        n_workers = effective_n_jobs(n_jobs)
+        n_workers = effective_n_jobs(n_jobs if n_jobs is not None else 1)
         blocks = _block_slices(
             self.adata.n_vars,
             # Across processes, larger blocks amortize sending the design matrix.

--- a/pertpy/tools/_distances/_distance_tests.py
+++ b/pertpy/tools/_distances/_distance_tests.py
@@ -8,7 +8,7 @@ from rich.progress import track
 from sklearn.metrics import pairwise_distances  # type: ignore[import-untyped]
 from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
 
-from pertpy._types import cast_frame, cast_matrix
+from pertpy._types import cast_matrix
 
 from ._distances import Distance, Metric
 
@@ -158,8 +158,8 @@ class DistanceTest:
                 if group == contrast:
                     continue
                 # Shuffle the labels of the groups
-                mask = cast_frame(adata.obs)[groupby].isin([group, contrast])
-                labels = np.asarray(cast_frame(adata.obs)[groupby].values)[mask]
+                mask = adata.obs[groupby].isin([group, contrast])
+                labels = np.asarray(adata.obs[groupby].values)[mask]
                 rng = np.random.default_rng()
                 shuffled_labels = rng.permutation(labels)
                 idx = shuffled_labels == group
@@ -247,11 +247,11 @@ class DistanceTest:
         # Precompute the pairwise distances
         precomputed_distances = {}
         for group in groups:
-            subset = adata[cast_frame(adata.obs)[groupby].isin([group, contrast])]
+            subset = adata[adata.obs[groupby].isin([group, contrast])]
             if self.layer_key:
-                cells = cast_matrix(subset.layers[self.layer_key]).copy()
+                cells = subset.layers[self.layer_key].copy()
             elif self.obsm_key is not None:
-                cells = cast_matrix(subset.obsm[self.obsm_key]).copy()
+                cells = subset.obsm[self.obsm_key].copy()
             else:
                 raise ValueError("Either `layer_key` or `obsm_key` must be set.")
             pwd = pairwise_distances(cells, cells, metric=self.distance.cell_wise_metric)
@@ -266,8 +266,8 @@ class DistanceTest:
                 if group == contrast:
                     continue
                 # Shuffle the labels of the groups
-                mask = cast_frame(adata.obs)[groupby].isin([group, contrast])
-                labels = np.asarray(cast_frame(adata.obs)[groupby].values)[mask]
+                mask = adata.obs[groupby].isin([group, contrast])
+                labels = np.asarray(adata.obs[groupby].values)[mask]
                 rng = np.random.default_rng()
                 shuffled_labels = rng.permutation(labels)
                 idx = shuffled_labels == group
@@ -282,8 +282,8 @@ class DistanceTest:
         for group in groups:
             if group == contrast:
                 continue
-            mask = cast_frame(adata.obs)[groupby].isin([group, contrast])
-            labels = np.asarray(cast_frame(adata.obs)[groupby].values)[mask]
+            mask = adata.obs[groupby].isin([group, contrast])
+            labels = np.asarray(adata.obs[groupby].values)[mask]
             idx = labels == group
 
             precomputed_distance = precomputed_distances[group]

--- a/pertpy/tools/_distances/_distance_tests.py
+++ b/pertpy/tools/_distances/_distance_tests.py
@@ -5,8 +5,10 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 from rich.progress import track
-from sklearn.metrics import pairwise_distances
-from statsmodels.stats.multitest import multipletests
+from sklearn.metrics import pairwise_distances  # type: ignore[import-untyped]
+from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
+
+from pertpy._types import as_frame, as_matrix
 
 from ._distances import Distance, Metric
 
@@ -45,8 +47,8 @@ class DistanceTest:
         self,
         metric: Metric,
         n_perms: int = 1000,
-        layer_key: str = None,
-        obsm_key: str = None,
+        layer_key: str | None = None,
+        obsm_key: str | None = None,
         alpha: float = 0.05,
         correction: str = "holm-sidak",
         cell_wise_metric=None,
@@ -143,7 +145,9 @@ class DistanceTest:
         if contrast not in groups:
             raise ValueError(f"Contrast group {contrast} not found in {groupby} of adata.obs.")
         fct = track if show_progressbar else lambda iterable: iterable
-        embedding = adata.obsm[self.obsm_key]
+        if self.obsm_key is None:
+            raise ValueError("`obsm_key` must be set to run a permutation test on an embedding.")
+        embedding = as_matrix(adata.obsm[self.obsm_key])
 
         # Generate the null distribution
         results = []
@@ -154,8 +158,8 @@ class DistanceTest:
                 if group == contrast:
                     continue
                 # Shuffle the labels of the groups
-                mask = adata.obs[groupby].isin([group, contrast])
-                labels = adata.obs[groupby].values[mask]
+                mask = as_frame(adata.obs)[groupby].isin([group, contrast])
+                labels = np.asarray(as_frame(adata.obs)[groupby].values)[mask]
                 rng = np.random.default_rng()
                 shuffled_labels = rng.permutation(labels)
                 idx = shuffled_labels == group
@@ -243,10 +247,13 @@ class DistanceTest:
         # Precompute the pairwise distances
         precomputed_distances = {}
         for group in groups:
+            subset = adata[as_frame(adata.obs)[groupby].isin([group, contrast])]
             if self.layer_key:
-                cells = adata[adata.obs[groupby].isin([group, contrast])].layers[self.layer_key].copy()
+                cells = as_matrix(subset.layers[self.layer_key]).copy()
+            elif self.obsm_key is not None:
+                cells = as_matrix(subset.obsm[self.obsm_key]).copy()
             else:
-                cells = adata[adata.obs[groupby].isin([group, contrast])].obsm[self.obsm_key].copy()
+                raise ValueError("Either `layer_key` or `obsm_key` must be set.")
             pwd = pairwise_distances(cells, cells, metric=self.distance.cell_wise_metric)
             precomputed_distances[group] = pwd
 
@@ -259,8 +266,8 @@ class DistanceTest:
                 if group == contrast:
                     continue
                 # Shuffle the labels of the groups
-                mask = adata.obs[groupby].isin([group, contrast])
-                labels = adata.obs[groupby].values[mask]
+                mask = as_frame(adata.obs)[groupby].isin([group, contrast])
+                labels = np.asarray(as_frame(adata.obs)[groupby].values)[mask]
                 rng = np.random.default_rng()
                 shuffled_labels = rng.permutation(labels)
                 idx = shuffled_labels == group
@@ -275,8 +282,8 @@ class DistanceTest:
         for group in groups:
             if group == contrast:
                 continue
-            mask = adata.obs[groupby].isin([group, contrast])
-            labels = adata.obs[groupby].values[mask]
+            mask = as_frame(adata.obs)[groupby].isin([group, contrast])
+            labels = np.asarray(as_frame(adata.obs)[groupby].values)[mask]
             idx = labels == group
 
             precomputed_distance = precomputed_distances[group]

--- a/pertpy/tools/_distances/_distance_tests.py
+++ b/pertpy/tools/_distances/_distance_tests.py
@@ -8,7 +8,7 @@ from rich.progress import track
 from sklearn.metrics import pairwise_distances  # type: ignore[import-untyped]
 from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
 
-from pertpy._types import as_frame, as_matrix
+from pertpy._types import cast_frame, cast_matrix
 
 from ._distances import Distance, Metric
 
@@ -147,7 +147,7 @@ class DistanceTest:
         fct = track if show_progressbar else lambda iterable: iterable
         if self.obsm_key is None:
             raise ValueError("`obsm_key` must be set to run a permutation test on an embedding.")
-        embedding = as_matrix(adata.obsm[self.obsm_key])
+        embedding = cast_matrix(adata.obsm[self.obsm_key])
 
         # Generate the null distribution
         results = []
@@ -158,8 +158,8 @@ class DistanceTest:
                 if group == contrast:
                     continue
                 # Shuffle the labels of the groups
-                mask = as_frame(adata.obs)[groupby].isin([group, contrast])
-                labels = np.asarray(as_frame(adata.obs)[groupby].values)[mask]
+                mask = cast_frame(adata.obs)[groupby].isin([group, contrast])
+                labels = np.asarray(cast_frame(adata.obs)[groupby].values)[mask]
                 rng = np.random.default_rng()
                 shuffled_labels = rng.permutation(labels)
                 idx = shuffled_labels == group
@@ -247,11 +247,11 @@ class DistanceTest:
         # Precompute the pairwise distances
         precomputed_distances = {}
         for group in groups:
-            subset = adata[as_frame(adata.obs)[groupby].isin([group, contrast])]
+            subset = adata[cast_frame(adata.obs)[groupby].isin([group, contrast])]
             if self.layer_key:
-                cells = as_matrix(subset.layers[self.layer_key]).copy()
+                cells = cast_matrix(subset.layers[self.layer_key]).copy()
             elif self.obsm_key is not None:
-                cells = as_matrix(subset.obsm[self.obsm_key]).copy()
+                cells = cast_matrix(subset.obsm[self.obsm_key]).copy()
             else:
                 raise ValueError("Either `layer_key` or `obsm_key` must be set.")
             pwd = pairwise_distances(cells, cells, metric=self.distance.cell_wise_metric)
@@ -266,8 +266,8 @@ class DistanceTest:
                 if group == contrast:
                     continue
                 # Shuffle the labels of the groups
-                mask = as_frame(adata.obs)[groupby].isin([group, contrast])
-                labels = np.asarray(as_frame(adata.obs)[groupby].values)[mask]
+                mask = cast_frame(adata.obs)[groupby].isin([group, contrast])
+                labels = np.asarray(cast_frame(adata.obs)[groupby].values)[mask]
                 rng = np.random.default_rng()
                 shuffled_labels = rng.permutation(labels)
                 idx = shuffled_labels == group
@@ -282,8 +282,8 @@ class DistanceTest:
         for group in groups:
             if group == contrast:
                 continue
-            mask = as_frame(adata.obs)[groupby].isin([group, contrast])
-            labels = np.asarray(as_frame(adata.obs)[groupby].values)[mask]
+            mask = cast_frame(adata.obs)[groupby].isin([group, contrast])
+            labels = np.asarray(cast_frame(adata.obs)[groupby].values)[mask]
             idx = labels == group
 
             precomputed_distance = precomputed_distances[group]

--- a/pertpy/tools/_distances/_distances.py
+++ b/pertpy/tools/_distances/_distances.py
@@ -401,7 +401,7 @@ class Distance:
             >>> Distance = pt.tools.Distance(metric="edistance")
             >>> pairwise_df = Distance.pairwise(adata, groupby="perturbation")
         """
-        obs = cast_frame(adata.obs)
+        obs = adata.obs
         groups = cast("list[str]", obs[groupby].unique()) if groups is None else groups
         grouping = obs[groupby].copy()
         df = pd.DataFrame(index=groups, columns=groups, dtype=float)
@@ -1358,7 +1358,7 @@ class ClassifierClassProjection(AbstractDistance):
 
         Similar to the parent function, the returned dataframe contains only the specified groups.
         """
-        groups = cast("list[str]", cast_frame(adata.obs)[groupby].unique()) if groups is None else groups
+        groups = cast("list[str]", adata.obs[groupby].unique()) if groups is None else groups
         fct = track if show_progressbar else lambda iterable: iterable
 
         X = adata[adata.obs[groupby] != selected_group].X

--- a/pertpy/tools/_distances/_distances.py
+++ b/pertpy/tools/_distances/_distances.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Literal, NamedTuple
+from typing import TYPE_CHECKING, Literal, NamedTuple, cast
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 import pandas as pd
+from fast_array_utils.conv import to_dense
 from numba import jit, prange
 from ott.geometry.geometry import Geometry
 from ott.geometry.pointcloud import PointCloud
@@ -14,15 +16,16 @@ from ott.problems.linear.linear_problem import LinearProblem
 from ott.solvers.linear.sinkhorn import Sinkhorn
 from pandas import Series
 from rich.progress import track
-from scipy.sparse import issparse
 from scipy.spatial.distance import cosine, mahalanobis
 from scipy.special import gammaln
 from scipy.stats import kendalltau, kstest, pearsonr, spearmanr
-from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import pairwise_distances, r2_score
-from sklearn.metrics.pairwise import polynomial_kernel, rbf_kernel
-from sklearn.neighbors import KernelDensity
-from statsmodels.discrete.discrete_model import NegativeBinomialP
+from sklearn.linear_model import LogisticRegression  # type: ignore[import-untyped]
+from sklearn.metrics import pairwise_distances, r2_score  # type: ignore[import-untyped]
+from sklearn.metrics.pairwise import polynomial_kernel, rbf_kernel  # type: ignore[import-untyped]
+from sklearn.neighbors import KernelDensity  # type: ignore[import-untyped]
+from statsmodels.discrete.discrete_model import NegativeBinomialP  # type: ignore[import-untyped]
+
+from pertpy._types import CSBase, as_dense, as_frame, as_matrix
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -50,7 +53,7 @@ def _euclidean_pairwise_mean_within(X: np.ndarray) -> float:
     total_distance = 0.0
     n_pairs = n_samples * (n_samples - 1) / 2.0
 
-    for i in prange(n_samples):
+    for i in prange(n_samples):  # type: ignore[attr-defined]
         for j in range(i + 1, n_samples):
             total_distance += _euclidean_distance(X[i], X[j])
 
@@ -69,7 +72,7 @@ def _euclidean_pairwise_mean_between(X: np.ndarray, Y: np.ndarray) -> float:
     total_distance = 0.0
     n_pairs = n_samples_X * n_samples_Y
 
-    for i in prange(n_samples_X):
+    for i in prange(n_samples_X):  # type: ignore[attr-defined]
         for j in range(n_samples_Y):
             total_distance += _euclidean_distance(X[i], Y[j])
 
@@ -219,8 +222,8 @@ class Distance:
         self,
         metric: Metric = "edistance",
         agg_fct: Callable = np.mean,
-        layer_key: str = None,
-        obsm_key: str = None,
+        layer_key: str | None = None,
+        obsm_key: str | None = None,
         cell_wise_metric: str = "euclidean",
     ):
         """Initialize Distance class.
@@ -236,7 +239,7 @@ class Distance:
                       Defaults to None, but is set to "X_pca" if not explicitly set internally.
             cell_wise_metric: Metric from scipy.spatial.distance to use for pairwise distances between single cells.
         """
-        metric_fct: AbstractDistance = None
+        metric_fct: AbstractDistance
         self.aggregation_func = agg_fct
         if metric == "edistance":
             metric_fct = Edistance()
@@ -295,8 +298,8 @@ class Distance:
 
     def __call__(
         self,
-        X: np.ndarray,
-        Y: np.ndarray,
+        X: np.ndarray | CSBase,
+        Y: np.ndarray | CSBase,
         **kwargs,
     ) -> float:
         """Compute distance between vectors X and Y.
@@ -317,10 +320,8 @@ class Distance:
             >>> Y = adata.obsm["X_pca"][adata.obs["perturbation"] == "control"]
             >>> D = Distance(X, Y)
         """
-        if issparse(X):
-            X = X.toarray()
-        if issparse(Y):
-            Y = Y.toarray()
+        X = to_dense(X)
+        Y = to_dense(Y)
 
         if len(X) == 0 or len(Y) == 0:
             raise ValueError("Neither X nor Y can be empty.")
@@ -329,8 +330,8 @@ class Distance:
 
     def bootstrap(
         self,
-        X: np.ndarray,
-        Y: np.ndarray,
+        X: np.ndarray | CSBase,
+        Y: np.ndarray | CSBase,
         *,
         n_bootstrap: int = 100,
         random_state: int = 0,
@@ -400,8 +401,9 @@ class Distance:
             >>> Distance = pt.tools.Distance(metric="edistance")
             >>> pairwise_df = Distance.pairwise(adata, groupby="perturbation")
         """
-        groups = adata.obs[groupby].unique() if groups is None else groups
-        grouping = adata.obs[groupby].copy()
+        obs = as_frame(adata.obs)
+        groups = cast("list[str]", obs[groupby].unique()) if groups is None else groups
+        grouping = obs[groupby].copy()
         df = pd.DataFrame(index=groups, columns=groups, dtype=float)
         if bootstrap:
             df_var = pd.DataFrame(index=groups, columns=groups, dtype=float)
@@ -413,27 +415,30 @@ class Distance:
 
         if use_value_cache:
             # Value caching mode: precompute within distances per group and between distances per pair
-            embedding = adata.layers[self.layer_key] if self.layer_key else adata.obsm[self.obsm_key]
+            dense_embedding = cast(
+                "np.ndarray",
+                adata.layers[self.layer_key] if self.layer_key else adata.obsm[cast("str", self.obsm_key)],
+            )
 
             # Precompute within distances for each group
             df_within = pd.Series(index=groups, dtype=float)
             for group in fct(groups):
                 idx_group = grouping == group
-                cells_group = embedding[np.asarray(idx_group)]
+                cells_group = dense_embedding[np.asarray(idx_group)]
                 df_within[group] = self.metric_fct.compute_within_distance(cells_group, **kwargs)
 
             # Precompute between distances for each pair
             df_between = pd.DataFrame(index=groups, columns=groups, dtype=float)
             for index_x, group_x in enumerate(fct(groups)):
                 idx_x = grouping == group_x
-                cells_x = embedding[np.asarray(idx_x)]
+                dense_cells_x = dense_embedding[np.asarray(idx_x)]
                 for group_y in groups[index_x:]:  # type: ignore
                     if group_x == group_y:
                         df_between.loc[group_x, group_y] = 0.0
                     else:
                         idx_y = grouping == group_y
-                        cells_y = embedding[np.asarray(idx_y)]
-                        between = self.metric_fct.compute_between_distance(cells_x, cells_y, **kwargs)
+                        dense_cells_y = dense_embedding[np.asarray(idx_y)]
+                        between = self.metric_fct.compute_between_distance(dense_cells_x, dense_cells_y, **kwargs)
                         df_between.loc[group_x, group_y] = between
                         df_between.loc[group_y, group_x] = between
 
@@ -444,7 +449,10 @@ class Distance:
                         df.loc[group_x, group_y] = 0.0
                     else:
                         dist = self.metric_fct.from_cached_values(
-                            df_within[group_x], df_within[group_y], df_between.loc[group_x, group_y], **kwargs
+                            float(df_within[group_x]),
+                            float(df_within[group_y]),
+                            cast("float", df_between.loc[group_x, group_y]),
+                            **kwargs,
                         )
                         df.loc[group_x, group_y] = dist
 
@@ -453,7 +461,7 @@ class Distance:
             # Precompute the pairwise distances if needed
             if f"{self.obsm_key}_{self.cell_wise_metric}_predistances" not in adata.obsp:
                 self.precompute_distances(adata, n_jobs=n_jobs, **kwargs)
-            pwd = adata.obsp[f"{self.obsm_key}_{self.cell_wise_metric}_predistances"]
+            pwd = as_dense(adata.obsp[f"{self.obsm_key}_{self.cell_wise_metric}_predistances"])
             for index_x, group_x in enumerate(fct(groups)):
                 idx_x = grouping == group_x
                 for group_y in groups[index_x:]:  # type: ignore
@@ -482,7 +490,11 @@ class Distance:
                         df_var.loc[group_x, group_y] = df_var.loc[group_y, group_x] = bootstrap_output.variance
         else:
             # Standard mode: compute distances directly
-            embedding = adata.layers[self.layer_key] if self.layer_key else adata.obsm[self.obsm_key].copy()
+            embedding = (
+                as_matrix(adata.layers[self.layer_key])
+                if self.layer_key
+                else as_matrix(adata.obsm[cast("str", self.obsm_key)]).copy()
+            )
             for index_x, group_x in enumerate(fct(groups)):
                 cells_x = embedding[np.asarray(grouping == group_x)].copy()
                 for group_y in groups[index_x:]:  # type: ignore
@@ -507,7 +519,7 @@ class Distance:
 
         df.index.name = groupby
         df.columns.name = groupby
-        df.name = f"pairwise {self.metric}"
+        df.name = f"pairwise {self.metric}"  # type: ignore[attr-defined]
 
         if not bootstrap:
             return df
@@ -516,7 +528,7 @@ class Distance:
             df_var.index.name = groupby
             df_var.columns.name = groupby
             df_var = df_var.fillna(0)
-            df_var.name = f"pairwise {self.metric} variance"
+            df_var.name = f"pairwise {self.metric} variance"  # type: ignore[attr-defined]
 
             return df, df_var
 
@@ -532,7 +544,7 @@ class Distance:
         show_progressbar: bool = True,
         n_jobs: int = -1,
         **kwargs,
-    ) -> pd.DataFrame | tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> pd.Series | tuple[pd.Series, pd.Series]:
         """Get distances between one selected cell group and the remaining other cell groups.
 
         Args:
@@ -572,8 +584,9 @@ class Distance:
                 **kwargs,
             )
 
-        groups = adata.obs[groupby].unique() if groups is None else groups
-        grouping = adata.obs[groupby].copy()
+        obs = as_frame(adata.obs)
+        groups = cast("list[str]", obs[groupby].unique()) if groups is None else groups
+        grouping = obs[groupby].copy()
         df = pd.Series(index=groups, dtype=float)
         if bootstrap:
             df_var = pd.Series(index=groups, dtype=float)
@@ -585,11 +598,14 @@ class Distance:
 
         if use_value_cache:
             # Value caching mode: precompute within distances per group and between distances per pair
-            embedding = adata.layers[self.layer_key] if self.layer_key else adata.obsm[self.obsm_key]
+            dense_embedding = cast(
+                "np.ndarray",
+                adata.layers[self.layer_key] if self.layer_key else adata.obsm[cast("str", self.obsm_key)],
+            )
 
             # Precompute within distance for selected_group (only need it once)
             idx_selected = grouping == selected_group
-            cells_selected = embedding[np.asarray(idx_selected)]
+            cells_selected = dense_embedding[np.asarray(idx_selected)]
             within_selected = self.metric_fct.compute_within_distance(cells_selected, **kwargs)
 
             # Precompute within distances for each group and between distances to selected_group
@@ -598,13 +614,13 @@ class Distance:
                     df.loc[group_x] = 0.0  # by distance axiom
                 else:
                     idx_x = grouping == group_x
-                    cells_x = embedding[np.asarray(idx_x)]
+                    dense_cells_x = dense_embedding[np.asarray(idx_x)]
 
                     # Compute within distance for this group
-                    within_x = self.metric_fct.compute_within_distance(cells_x, **kwargs)
+                    within_x = self.metric_fct.compute_within_distance(dense_cells_x, **kwargs)
 
                     # Compute between distance to selected_group
-                    between = self.metric_fct.compute_between_distance(cells_x, cells_selected, **kwargs)
+                    between = self.metric_fct.compute_between_distance(dense_cells_x, cells_selected, **kwargs)
 
                     # Compute distance from cached values
                     dist = self.metric_fct.from_cached_values(within_x, within_selected, between, **kwargs)
@@ -615,7 +631,7 @@ class Distance:
             # Precompute the pairwise distances if needed
             if f"{self.obsm_key}_{self.cell_wise_metric}_predistances" not in adata.obsp:
                 self.precompute_distances(adata, n_jobs=n_jobs, **kwargs)
-            pwd = adata.obsp[f"{self.obsm_key}_{self.cell_wise_metric}_predistances"]
+            pwd = as_dense(adata.obsp[f"{self.obsm_key}_{self.cell_wise_metric}_predistances"])
             for group_x in fct(groups):
                 idx_x = grouping == group_x
                 group_y = selected_group
@@ -627,7 +643,7 @@ class Distance:
                     sub_pwd = pwd[idx_x | idx_y, :][:, idx_x | idx_y]
                     sub_idx = grouping[idx_x | idx_y] == group_x
                     if not bootstrap:
-                        dist = self.metric_fct.from_precomputed(sub_pwd, sub_idx, **kwargs)
+                        dist = self.metric_fct.from_precomputed(sub_pwd, as_dense(sub_idx), **kwargs)
                         df.loc[group_x] = dist
                     else:
                         bootstrap_output = self._bootstrap_mode_precomputed(
@@ -641,7 +657,11 @@ class Distance:
                         df_var.loc[group_x] = bootstrap_output.variance
         else:
             # Standard mode: compute distances directly
-            embedding = adata.layers[self.layer_key] if self.layer_key else adata.obsm[self.obsm_key].copy()
+            embedding = (
+                as_matrix(adata.layers[self.layer_key])
+                if self.layer_key
+                else as_matrix(adata.obsm[cast("str", self.obsm_key)]).copy()
+            )
             for group_x in fct(groups):
                 cells_x = embedding[np.asarray(grouping == group_x)].copy()
                 group_y = selected_group
@@ -689,7 +709,7 @@ class Distance:
             >>> distance = pt.tools.Distance(metric="edistance")
             >>> distance.precompute_distances(adata)
         """
-        cells = adata.layers[self.layer_key] if self.layer_key else adata.obsm[self.obsm_key].copy()
+        cells = adata.layers[self.layer_key] if self.layer_key else adata.obsm[cast("str", self.obsm_key)].copy()
         pwd = pairwise_distances(cells, cells, metric=self.cell_wise_metric, n_jobs=n_jobs)
         adata.obsp[f"{self.obsm_key}_{self.cell_wise_metric}_predistances"] = pwd
 
@@ -715,7 +735,7 @@ class Distance:
         if mode == "simple":
             pass  # nothing to be done
         elif mode == "scaled":
-            from sklearn.preprocessing import MinMaxScaler
+            from sklearn.preprocessing import MinMaxScaler  # type: ignore[import-untyped]
 
             scaler = MinMaxScaler().fit(np.vstack((pert, ctrl)) if fit_to_pert_and_ctrl else ctrl)
             pred = scaler.transform(pred)
@@ -738,9 +758,7 @@ class Distance:
             distance = self(X_bootstrapped, Y_bootstrapped, **kwargs)
             distances.append(distance)
 
-        mean = np.mean(distances)
-        variance = np.var(distances)
-        return MeanVar(mean=mean, variance=variance)
+        return MeanVar(mean=float(np.mean(distances)), variance=float(np.var(distances)))
 
     def _bootstrap_mode_precomputed(self, sub_pwd, sub_idx, n_bootstraps=100, random_state=0, **kwargs) -> MeanVar:
         rng = np.random.default_rng(random_state)
@@ -760,9 +778,7 @@ class Distance:
             distance = self.metric_fct.from_precomputed(bootstrap_sub_pwd, bootstrap_sub_idx, **kwargs)
             distances.append(distance)
 
-        mean = np.mean(distances)
-        variance = np.var(distances)
-        return MeanVar(mean=mean, variance=variance)
+        return MeanVar(mean=float(np.mean(distances)), variance=float(np.var(distances)))
 
 
 class AbstractDistance(ABC):
@@ -771,7 +787,7 @@ class AbstractDistance(ABC):
     @abstractmethod
     def __init__(self) -> None:
         super().__init__()
-        self.accepts_precomputed: bool = None
+        self.accepts_precomputed: bool | None = None
 
     @abstractmethod
     def __call__(self, X: np.ndarray, Y: np.ndarray, **kwargs) -> float:
@@ -967,12 +983,12 @@ class WassersteinDistance(AbstractDistance):
     def __call__(self, X: np.ndarray, Y: np.ndarray, **kwargs) -> float:
         X = np.asarray(X, dtype=np.float64)
         Y = np.asarray(Y, dtype=np.float64)
-        geom = PointCloud(X, Y)
+        geom = PointCloud(jnp.asarray(X), jnp.asarray(Y))
         return self.solve_ot_problem(geom, **kwargs)
 
     def from_precomputed(self, P: np.ndarray, idx: np.ndarray, **kwargs) -> float:
         P = np.asarray(P, dtype=np.float64)
-        geom = Geometry(cost_matrix=P[idx, :][:, ~idx])
+        geom = Geometry(cost_matrix=jnp.asarray(P[idx, :][:, ~idx]))
         return self.solve_ot_problem(geom, **kwargs)
 
     def solve_ot_problem(self, geom: Geometry, **kwargs):
@@ -1207,7 +1223,7 @@ class KSTestDistance(AbstractDistance):
         self.accepts_precomputed = False
 
     def __call__(self, X: np.ndarray, Y: np.ndarray, **kwargs) -> float:
-        stats = [abs(kstest(X[:, i], Y[:, i])[0]) for i in range(X.shape[1])]
+        stats = [abs(float(kstest(X[:, i], Y[:, i]).statistic)) for i in range(X.shape[1])]
         return sum(stats) / len(stats)
 
     def from_precomputed(self, P: np.ndarray, idx: np.ndarray, **kwargs) -> float:
@@ -1342,7 +1358,7 @@ class ClassifierClassProjection(AbstractDistance):
 
         Similar to the parent function, the returned dataframe contains only the specified groups.
         """
-        groups = adata.obs[groupby].unique() if groups is None else groups
+        groups = cast("list[str]", as_frame(adata.obs)[groupby].unique()) if groups is None else groups
         fct = track if show_progressbar else lambda iterable: iterable
 
         X = adata[adata.obs[groupby] != selected_group].X

--- a/pertpy/tools/_distances/_distances.py
+++ b/pertpy/tools/_distances/_distances.py
@@ -25,7 +25,7 @@ from sklearn.metrics.pairwise import polynomial_kernel, rbf_kernel  # type: igno
 from sklearn.neighbors import KernelDensity  # type: ignore[import-untyped]
 from statsmodels.discrete.discrete_model import NegativeBinomialP  # type: ignore[import-untyped]
 
-from pertpy._types import CSBase, as_dense, as_frame, as_matrix
+from pertpy._types import CSBase, cast_dense, cast_frame, cast_matrix
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -401,7 +401,7 @@ class Distance:
             >>> Distance = pt.tools.Distance(metric="edistance")
             >>> pairwise_df = Distance.pairwise(adata, groupby="perturbation")
         """
-        obs = as_frame(adata.obs)
+        obs = cast_frame(adata.obs)
         groups = cast("list[str]", obs[groupby].unique()) if groups is None else groups
         grouping = obs[groupby].copy()
         df = pd.DataFrame(index=groups, columns=groups, dtype=float)
@@ -461,7 +461,7 @@ class Distance:
             # Precompute the pairwise distances if needed
             if f"{self.obsm_key}_{self.cell_wise_metric}_predistances" not in adata.obsp:
                 self.precompute_distances(adata, n_jobs=n_jobs, **kwargs)
-            pwd = as_dense(adata.obsp[f"{self.obsm_key}_{self.cell_wise_metric}_predistances"])
+            pwd = cast_dense(adata.obsp[f"{self.obsm_key}_{self.cell_wise_metric}_predistances"])
             for index_x, group_x in enumerate(fct(groups)):
                 idx_x = grouping == group_x
                 for group_y in groups[index_x:]:  # type: ignore
@@ -491,9 +491,9 @@ class Distance:
         else:
             # Standard mode: compute distances directly
             embedding = (
-                as_matrix(adata.layers[self.layer_key])
+                cast_matrix(adata.layers[self.layer_key])
                 if self.layer_key
-                else as_matrix(adata.obsm[cast("str", self.obsm_key)]).copy()
+                else cast_matrix(adata.obsm[cast("str", self.obsm_key)]).copy()
             )
             for index_x, group_x in enumerate(fct(groups)):
                 cells_x = embedding[np.asarray(grouping == group_x)].copy()
@@ -584,7 +584,7 @@ class Distance:
                 **kwargs,
             )
 
-        obs = as_frame(adata.obs)
+        obs = cast_frame(adata.obs)
         groups = cast("list[str]", obs[groupby].unique()) if groups is None else groups
         grouping = obs[groupby].copy()
         df = pd.Series(index=groups, dtype=float)
@@ -631,7 +631,7 @@ class Distance:
             # Precompute the pairwise distances if needed
             if f"{self.obsm_key}_{self.cell_wise_metric}_predistances" not in adata.obsp:
                 self.precompute_distances(adata, n_jobs=n_jobs, **kwargs)
-            pwd = as_dense(adata.obsp[f"{self.obsm_key}_{self.cell_wise_metric}_predistances"])
+            pwd = cast_dense(adata.obsp[f"{self.obsm_key}_{self.cell_wise_metric}_predistances"])
             for group_x in fct(groups):
                 idx_x = grouping == group_x
                 group_y = selected_group
@@ -643,7 +643,7 @@ class Distance:
                     sub_pwd = pwd[idx_x | idx_y, :][:, idx_x | idx_y]
                     sub_idx = grouping[idx_x | idx_y] == group_x
                     if not bootstrap:
-                        dist = self.metric_fct.from_precomputed(sub_pwd, as_dense(sub_idx), **kwargs)
+                        dist = self.metric_fct.from_precomputed(sub_pwd, cast_dense(sub_idx), **kwargs)
                         df.loc[group_x] = dist
                     else:
                         bootstrap_output = self._bootstrap_mode_precomputed(
@@ -658,9 +658,9 @@ class Distance:
         else:
             # Standard mode: compute distances directly
             embedding = (
-                as_matrix(adata.layers[self.layer_key])
+                cast_matrix(adata.layers[self.layer_key])
                 if self.layer_key
-                else as_matrix(adata.obsm[cast("str", self.obsm_key)]).copy()
+                else cast_matrix(adata.obsm[cast("str", self.obsm_key)]).copy()
             )
             for group_x in fct(groups):
                 cells_x = embedding[np.asarray(grouping == group_x)].copy()
@@ -1358,7 +1358,7 @@ class ClassifierClassProjection(AbstractDistance):
 
         Similar to the parent function, the returned dataframe contains only the specified groups.
         """
-        groups = cast("list[str]", as_frame(adata.obs)[groupby].unique()) if groups is None else groups
+        groups = cast("list[str]", cast_frame(adata.obs)[groupby].unique()) if groups is None else groups
         fct = track if show_progressbar else lambda iterable: iterable
 
         X = adata[adata.obs[groupby] != selected_group].X

--- a/pertpy/tools/_enrichment.py
+++ b/pertpy/tools/_enrichment.py
@@ -16,7 +16,7 @@ from scverse_misc import Deprecation, deprecated_arg
 from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
-from pertpy._types import CSBase, as_frame, as_matrix
+from pertpy._types import CSBase, cast_frame, cast_matrix
 from pertpy.metadata import Drug
 
 
@@ -96,7 +96,7 @@ class Enrichment:
         Returns:
             An AnnData object with scores.
         """
-        mtx = as_matrix(adata.layers[layer] if layer is not None else adata.X)
+        mtx = cast_matrix(adata.layers[layer] if layer is not None else adata.X)
 
         target_groups: ChainMap | dict = _prepare_targets(targets=targets, nested=nested, categories=categories)
         full_targets = target_groups.copy()
@@ -384,7 +384,7 @@ class Enrichment:
         var_group_labels: list[str] = []
         start = 0
 
-        enrichment_score_adata = AnnData(adata.uns[f"{key}_score"], obs=as_frame(adata.obs))
+        enrichment_score_adata = AnnData(adata.uns[f"{key}_score"], obs=cast_frame(adata.obs))
         enrichment_score_adata.var_names = adata.uns[f"{key}_variables"]
 
         for group in group_genes:

--- a/pertpy/tools/_enrichment.py
+++ b/pertpy/tools/_enrichment.py
@@ -1,51 +1,52 @@
 from collections import ChainMap
-from collections.abc import Sequence
-from typing import Any, Literal
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, cast
 
-import blitzgsea
+import blitzgsea  # type: ignore[import-untyped]
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from anndata import AnnData
 from matplotlib.axes import Axes
-from scanpy.plotting import DotPlot
-from scanpy.tools._score_genes import _sparse_nanmean
-from scipy.sparse import issparse
+from scanpy.plotting import DotPlot  # type: ignore[import-untyped]
+from scanpy.tools._score_genes import _sparse_nanmean  # type: ignore[import-untyped]
 from scipy.stats import hypergeom
 from scverse_misc import Deprecation, deprecated_arg
-from statsmodels.stats.multitest import multipletests
+from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
+from pertpy._types import CSBase, as_frame, as_matrix
 from pertpy.metadata import Drug
 
 
 def _prepare_targets(
-    targets: dict[str, list[str]] | dict[str, dict[str, list[str]]] = None,
+    targets: Mapping[str, list[str] | dict[str, list[str]]] | None = None,
     nested: bool = False,
-    categories: str | Sequence[str] = None,
+    categories: str | Sequence[str] | None = None,
 ) -> ChainMap | dict:
     if categories is not None:
         categories = [categories] if isinstance(categories, str) else list(categories)
 
+    groups: dict[str, Any]
     if targets is None:
         pt_drug = Drug()
         pt_drug.chembl.set()
-        targets = pt_drug.chembl.dictionary
+        groups = pt_drug.chembl.dictionary
         nested = True
     else:
-        targets = targets.copy()
+        groups = dict(targets)
     if categories is not None:
-        targets = {k: targets[k] for k in categories}  # type: ignore
+        groups = {k: groups[k] for k in categories}
     if nested:
-        targets = dict(ChainMap(*[targets[cat] for cat in targets]))  # type: ignore
+        groups = dict(ChainMap(*[groups[cat] for cat in groups]))
 
-    return targets
+    return groups
 
 
 def _mean(X, names, axis):
     """Helper function to compute a mean of X across an axis, respecting names and possible nans."""
-    if issparse(X):
+    if isinstance(X, CSBase):
         obs_avg = pd.Series(
             np.array(_sparse_nanmean(X, axis=axis)).flatten(),
             index=names,
@@ -59,10 +60,10 @@ class Enrichment:
     def score(
         self,
         adata: AnnData,
-        layer: str = None,
-        targets: dict[str, list[str]] | dict[str, dict[str, list[str]]] = None,
+        layer: str | None = None,
+        targets: dict[str, list[str]] | dict[str, dict[str, list[str]]] | None = None,
         nested: bool = False,
-        categories: Sequence[str] = None,
+        categories: Sequence[str] | None = None,
         method: Literal["mean", "seurat"] = "mean",
         n_bins: int = 25,
         ctrl_size: int = 50,
@@ -95,21 +96,21 @@ class Enrichment:
         Returns:
             An AnnData object with scores.
         """
-        mtx = adata.layers[layer] if layer is not None else adata.X
+        mtx = as_matrix(adata.layers[layer] if layer is not None else adata.X)
 
-        targets = _prepare_targets(targets=targets, nested=nested, categories=categories)  # type: ignore
-        full_targets = targets.copy()
+        target_groups: ChainMap | dict = _prepare_targets(targets=targets, nested=nested, categories=categories)
+        full_targets = target_groups.copy()
 
-        for drug in targets:
-            targets[drug] = np.isin(adata.var_names, targets[drug])
+        for drug in target_groups:
+            target_groups[drug] = np.isin(adata.var_names, target_groups[drug])
 
         # Scoring is done via matrix multiplication of the original cell by gene matrix by a new gene by drug matrix
         # with the entries in the new matrix being the weights of each gene for that group (such as drug)
         # The mean across targets is constant -> prepare weights for that
-        weights = pd.DataFrame(targets, index=adata.var_names)
+        weights = pd.DataFrame(target_groups, index=adata.var_names)
         weights = weights.loc[:, weights.sum() > 0]
         weights = weights / weights.sum()
-        scores = mtx.dot(weights) if issparse(mtx) else np.dot(mtx, weights)
+        scores = mtx.dot(weights) if isinstance(mtx, CSBase) else np.dot(mtx, weights)
 
         if method == "seurat":
             obs_avg = _mean(mtx, names=adata.var_names, axis=0)
@@ -128,10 +129,12 @@ class Enrichment:
             control_gene_weights = pd.DataFrame(control_groups, index=adata.var_names)
             control_gene_weights = control_gene_weights / control_gene_weights.sum()
 
-            control_profiles = mtx.dot(control_gene_weights) if issparse(mtx) else np.dot(mtx, control_gene_weights)
+            control_profiles = (
+                mtx.dot(control_gene_weights) if isinstance(mtx, CSBase) else np.dot(mtx, control_gene_weights)
+            )
             drug_bins = {}
             for drug in weights.columns:
-                bins = np.unique(obs_cut[targets[drug]])
+                bins = np.unique(obs_cut[target_groups[drug]])
                 drug_bins[drug] = np.isin(control_gene_weights.columns, bins)
             drug_weights = pd.DataFrame(drug_bins, index=control_gene_weights.columns)
             drug_weights = drug_weights / drug_weights.sum()
@@ -145,12 +148,12 @@ class Enrichment:
         adata.uns[f"{key_added}_all_genes"] = {"var": pd.DataFrame(columns=["all_genes"]).astype(object)}
 
         for drug in weights.columns:
-            adata.uns[f"{key_added}_genes"]["var"].loc[drug, "genes"] = "|".join(adata.var_names[targets[drug]])
+            adata.uns[f"{key_added}_genes"]["var"].loc[drug, "genes"] = "|".join(adata.var_names[target_groups[drug]])
             adata.uns[f"{key_added}_all_genes"]["var"].loc[drug, "all_genes"] = "|".join(full_targets[drug])
 
     @deprecated_arg(
         "pvals_adj_thresh",
-        Deprecation("1.0.6", "Use `padj_threshold`."),
+        cast("Deprecation", Deprecation("1.0.6", "Use `padj_threshold`.")),
     )
     def hypergeometric(
         self,
@@ -191,17 +194,17 @@ class Enrichment:
             padj_threshold = pvals_adj_thresh
 
         universe = set(adata.var_names)
-        targets = _prepare_targets(targets=targets, nested=nested, categories=categories)  # type: ignore
-        for group in targets:
-            targets[group] = set(targets[group]).intersection(universe)  # type: ignore
+        prepared: ChainMap | dict = _prepare_targets(targets=targets, nested=nested, categories=categories)
+        for group in prepared:
+            prepared[group] = set(prepared[group]).intersection(universe)
         # We remove empty keys since we don't need them
-        targets = {k: v for k, v in targets.items() if v}
+        target_groups = {k: v for k, v in prepared.items() if v}
 
         overrepresentation = {}
         for cluster in adata.uns["rank_genes_groups"]["names"].dtype.names:
             results = pd.DataFrame(
                 1,
-                index=list(targets.keys()),
+                index=list(target_groups.keys()),
                 columns=[
                     "intersection",
                     "gene_group",
@@ -222,8 +225,8 @@ class Enrichment:
             results["pvals"] = results["pvals"].astype(float)
 
             for ind in results.index:
-                gene_group = targets[ind]
-                common = gene_group.intersection(markers)  # type: ignore
+                gene_group = target_groups[ind]
+                common = gene_group.intersection(markers)
                 results.loc[ind, "intersection"] = len(common)
                 results.loc[ind, "gene_group"] = len(gene_group)
                 # need to subtract 1 from the intersection length
@@ -295,11 +298,11 @@ class Enrichment:
         self,
         adata: AnnData,
         *,
-        targets: dict[str, dict[str, list[str]]] = None,
+        targets: dict[str, dict[str, list[str]]] | None = None,
         source: Literal["chembl", "dgidb", "pharmgkb"] = "chembl",
         category_name: str = "interaction_type",
-        categories: Sequence[str] = None,
-        groupby: str = None,
+        categories: Sequence[str] | None = None,
+        groupby: str | None = None,
         key: str = "pertpy_enrichment",
         ax: Axes | None = None,
         return_fig: bool = False,
@@ -370,27 +373,27 @@ class Enrichment:
                 )
         else:
             targets = targets.copy()
+        nested_targets: dict[str, Any] = dict(targets)
         if categories is not None:
-            targets = {k: targets[k] for k in categories}  # type: ignore
+            nested_targets = {k: nested_targets[k] for k in categories}
 
-        for group in targets:
-            targets[group] = list(targets[group].keys())  # type: ignore
+        group_genes: dict[str, list[str]] = {group: list(genes) for group, genes in nested_targets.items()}
 
         var_names: list[str] = []
         var_group_positions: list[tuple[int, int]] = []
         var_group_labels: list[str] = []
         start = 0
 
-        enrichment_score_adata = AnnData(adata.uns[f"{key}_score"], obs=adata.obs)
+        enrichment_score_adata = AnnData(adata.uns[f"{key}_score"], obs=as_frame(adata.obs))
         enrichment_score_adata.var_names = adata.uns[f"{key}_variables"]
 
-        for group in targets:
-            targets[group] = list(  # type: ignore
-                enrichment_score_adata.var_names[np.isin(enrichment_score_adata.var_names, targets[group])]
+        for group in group_genes:
+            group_genes[group] = list(
+                enrichment_score_adata.var_names[np.isin(enrichment_score_adata.var_names, group_genes[group])]
             )
-            if len(targets[group]) == 0:
+            if len(group_genes[group]) == 0:
                 continue
-            var_names = var_names + targets[group]  # type: ignore
+            var_names = var_names + group_genes[group]
             var_group_positions = var_group_positions + [(start, len(var_names) - 1)]
             var_group_labels = var_group_labels + [group]
             start = len(var_names)

--- a/pertpy/tools/_milo.py
+++ b/pertpy/tools/_milo.py
@@ -19,7 +19,7 @@ from scverse_misc import Deprecation, deprecated, deprecated_arg
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
-from pertpy._types import CSBase, as_frame, as_matrix
+from pertpy._types import CSBase, cast_frame, cast_matrix
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
@@ -251,19 +251,19 @@ class Milo:
             adata = data
         if isinstance(adata, AnnData):
             try:
-                nhoods = as_matrix(adata.obsm["nhoods"])
+                nhoods = cast_matrix(adata.obsm["nhoods"])
             except KeyError:
                 logger.error('Cannot find "nhoods" slot in adata.obsm -- please run milopy.make_nhoods(adata)')
                 raise
         # Make nhood abundance matrix
-        sample_dummies = pd.get_dummies(as_frame(adata.obs)[sample_col])
+        sample_dummies = pd.get_dummies(cast_frame(adata.obs)[sample_col])
         all_samples = sample_dummies.columns
         nhood_count_mat = csr_matrix(nhoods).T.dot(csr_matrix(sample_dummies.values))
         sample_obs = pd.DataFrame(index=all_samples)
         sample_adata = AnnData(X=nhood_count_mat.T, obs=sample_obs)
         sample_adata.uns["sample_col"] = sample_col
         # Save nhood index info
-        obs = as_frame(adata.obs)
+        obs = cast_frame(adata.obs)
         sample_adata.var["index_cell"] = adata.obs_names[obs["nhood_ixs_refined"] == 1]
         sample_adata.var["kth_distance"] = obs.loc[obs["nhood_ixs_refined"] == 1, "nhood_kth_distance"].values
 
@@ -688,7 +688,7 @@ class Milo:
                 failures.setdefault(f"pseudobulk failed ({type(e).__name__})", []).append(int(j))
                 continue
             pdata.X = pdata.layers["sum"]
-            pdata_X = as_matrix(pdata.X)
+            pdata_X = cast_matrix(pdata.X)
             if isinstance(pdata_X, CSBase):
                 pdata.X = pdata_X.toarray()
 
@@ -1081,11 +1081,11 @@ class Milo:
             sample_adata: Sample-level AnnData.
         """
         weights = 1.0 / np.asarray(sample_adata.var["kth_distance"], dtype=float)
-        adjp = _weighted_bh(as_frame(sample_adata.var)["PValue"].to_numpy(dtype=float), weights)
+        adjp = _weighted_bh(cast_frame(sample_adata.var)["PValue"].to_numpy(dtype=float), weights)
         sample_adata.var["SpatialFDR"] = adjp
         # Fill missing values with 1 to avoid downstream NaN complications
         # e.g. https://github.com/scverse/pertpy/issues/912
-        sample_adata.var["SpatialFDR"] = as_frame(sample_adata.var)["SpatialFDR"].fillna(1)
+        sample_adata.var["SpatialFDR"] = cast_frame(sample_adata.var)["SpatialFDR"].fillna(1)
 
     @_doc_params(common_plot_args=doc_common_plot_args)
     @deprecated_arg(
@@ -1265,7 +1265,7 @@ class Milo:
                 "please run milo.build_nhood_graph(mdata) first"
             )
 
-        nhood_obs = as_frame(nhood_adata.obs)
+        nhood_obs = cast_frame(nhood_adata.obs)
         nhood_obs["graph_color"] = logfc
         nhood_obs.loc[spatial_fdr > padj_threshold, "graph_color"] = np.nan
         nhood_obs["abs_logFC"] = logfc.abs()
@@ -1783,8 +1783,8 @@ class Milo:
         )
 
         labels = self._group_nhoods_from_adjacency(
-            as_matrix(adata.varp["nhood_connectivities"])[mask, :][:, mask],
-            as_frame(adata.var).loc[mask],
+            cast_matrix(adata.varp["nhood_connectivities"])[mask, :][:, mask],
+            cast_frame(adata.var).loc[mask],
             is_da[mask],
             merge_discord=merge_discord,
             overlap=overlap,
@@ -1829,7 +1829,7 @@ class Milo:
         if len(categories) == 0:
             raise ValueError(f"'{nhood_group_key}' has no non-missing neighbourhood group labels.")
 
-        nhoods = as_matrix(adata.obsm["nhoods"])
+        nhoods = cast_matrix(adata.obsm["nhoods"])
         nhoods = nhoods.tocsr() if isinstance(nhoods, CSBase) else csr_matrix(nhoods)
 
         counts = np.column_stack([np.asarray(nhoods[:, labels == group].sum(axis=1)).ravel() for group in categories])
@@ -1917,8 +1917,8 @@ class Milo:
 
         by = list(dict.fromkeys([sample_col, nhood_group_key, *covariates]))
         pdata = sc.get.aggregate(adata, by=by, func="sum", layer=layer)
-        pdata.X = to_dense(as_matrix(pdata.layers["sum"]))
-        if as_frame(pdata.obs)[nhood_group_key].nunique() < 2:
+        pdata.X = to_dense(cast_matrix(pdata.layers["sum"]))
+        if cast_frame(pdata.obs)[nhood_group_key].nunique() < 2:
             raise ValueError(f"Fewer than two groups in '{nhood_group_key}' after aggregation.")
 
         if var_names is not None:

--- a/pertpy/tools/_milo.py
+++ b/pertpy/tools/_milo.py
@@ -5,19 +5,21 @@ import io
 import random
 import re
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 import seaborn as sns
 from anndata import AnnData
-from mudata import MuData
+from fast_array_utils.conv import to_dense
+from mudata import MuData  # type: ignore[import-untyped]
 from scverse_misc import Deprecation, deprecated, deprecated_arg
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
+from pertpy._types import CSBase, as_frame, as_matrix
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
@@ -27,7 +29,7 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
 from scipy.sparse import coo_matrix, csr_matrix, issparse, spmatrix
-from sklearn.metrics.pairwise import euclidean_distances
+from sklearn.metrics.pairwise import euclidean_distances  # type: ignore[import-untyped]
 
 
 def _weighted_bh(pvalues: np.ndarray, weights: np.ndarray) -> np.ndarray:
@@ -245,31 +247,27 @@ class Milo:
         """
         if isinstance(data, MuData):
             adata = data[feature_key]
-            is_MuData = True
         if isinstance(data, AnnData):
             adata = data
-            is_MuData = False
         if isinstance(adata, AnnData):
             try:
-                nhoods = adata.obsm["nhoods"]
+                nhoods = as_matrix(adata.obsm["nhoods"])
             except KeyError:
                 logger.error('Cannot find "nhoods" slot in adata.obsm -- please run milopy.make_nhoods(adata)')
                 raise
         # Make nhood abundance matrix
-        sample_dummies = pd.get_dummies(adata.obs[sample_col])
+        sample_dummies = pd.get_dummies(as_frame(adata.obs)[sample_col])
         all_samples = sample_dummies.columns
-        sample_dummies = csr_matrix(sample_dummies.values)
-        nhood_count_mat = nhoods.T.dot(sample_dummies)
+        nhood_count_mat = csr_matrix(nhoods).T.dot(csr_matrix(sample_dummies.values))
         sample_obs = pd.DataFrame(index=all_samples)
         sample_adata = AnnData(X=nhood_count_mat.T, obs=sample_obs)
         sample_adata.uns["sample_col"] = sample_col
         # Save nhood index info
-        sample_adata.var["index_cell"] = adata.obs_names[adata.obs["nhood_ixs_refined"] == 1]
-        sample_adata.var["kth_distance"] = adata.obs.loc[
-            adata.obs["nhood_ixs_refined"] == 1, "nhood_kth_distance"
-        ].values
+        obs = as_frame(adata.obs)
+        sample_adata.var["index_cell"] = adata.obs_names[obs["nhood_ixs_refined"] == 1]
+        sample_adata.var["kth_distance"] = obs.loc[obs["nhood_ixs_refined"] == 1, "nhood_kth_distance"].values
 
-        if is_MuData is True:
+        if isinstance(data, MuData):
             data.mod["milo"] = sample_adata
             return data
         else:
@@ -278,10 +276,13 @@ class Milo:
 
     @deprecated_arg(
         "subset_samples",
-        Deprecation(
-            "1.0.7",
-            "subset_samples is buggy in edge cases and will be removed. "
-            "Specify the comparison via `model_contrasts` instead, or subset cells before building the kNN graph.",
+        cast(
+            "Deprecation",
+            Deprecation(
+                "1.0.7",
+                "subset_samples is buggy in edge cases and will be removed. "
+                "Specify the comparison via `model_contrasts` instead, or subset cells before building the kNN graph.",
+            ),
         ),
     )
     def da_nhoods(
@@ -393,10 +394,10 @@ class Milo:
             # Set up rpy2 to run edgeR
             edgeR, limma, stats, base = self._setup_rpy2()
 
-            import rpy2.robjects as ro
+            import rpy2.robjects as ro  # type: ignore[import-untyped,import-not-found]
             from rpy2.robjects import numpy2ri, pandas2ri
-            from rpy2.robjects.conversion import localconverter
-            from rpy2.robjects.vectors import FloatVector
+            from rpy2.robjects.conversion import localconverter  # type: ignore[import-untyped,import-not-found]
+            from rpy2.robjects.vectors import FloatVector  # type: ignore[import-untyped,import-not-found]
 
             # Define model matrix
             if not add_intercept or model_contrasts is not None:
@@ -427,7 +428,7 @@ class Milo:
                     return(colnames(m))
                 }
                 """
-                from rpy2.robjects.packages import STAP
+                from rpy2.robjects.packages import STAP  # type: ignore[import-untyped,import-not-found]
 
                 get_model_cols = STAP(r_str, "get_model_cols")
                 with localconverter(ro.default_converter + numpy2ri.converter + pandas2ri.converter):
@@ -469,8 +470,8 @@ class Milo:
 
             import warnings
 
-            from pydeseq2.dds import DeseqDataSet
-            from pydeseq2.ds import DeseqStats
+            from pydeseq2.dds import DeseqDataSet  # type: ignore[import-untyped]
+            from pydeseq2.ds import DeseqStats  # type: ignore[import-untyped]
 
             warnings.filterwarnings("always", message=".*(alpha).*")
 
@@ -599,8 +600,6 @@ class Milo:
             ...     mdata, design="~label", column="label", baseline="control", group_to_compare="treated"
             ... )
         """
-        from scipy.sparse import issparse
-
         try:
             sample_adata = mdata["milo"]
         except KeyError:
@@ -656,7 +655,7 @@ class Milo:
 
             model_cls: type = PyDESeq2
         elif solver == "statsmodels":
-            import statsmodels.api as sm  # type: ignore[no-redef]
+            import statsmodels.api as sm  # type: ignore[no-redef,import-untyped]
 
             from pertpy.tools._differential_gene_expression._statsmodels import Statsmodels
 
@@ -689,8 +688,9 @@ class Milo:
                 failures.setdefault(f"pseudobulk failed ({type(e).__name__})", []).append(int(j))
                 continue
             pdata.X = pdata.layers["sum"]
-            if issparse(pdata.X):
-                pdata.X = pdata.X.toarray()
+            pdata_X = as_matrix(pdata.X)
+            if isinstance(pdata_X, CSBase):
+                pdata.X = pdata_X.toarray()
 
             for cov in covariates:
                 pdata.obs[cov] = pdata.obs[sample_col].map(sample_obs_map[cov]).astype("category")
@@ -739,7 +739,7 @@ class Milo:
             )
 
         # Backfill BH across genes for solvers that did not provide it
-        from statsmodels.stats.multitest import multipletests
+        from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
 
         for j in range(n_nhoods_total):
             if not test_performed[j]:
@@ -1081,16 +1081,16 @@ class Milo:
             sample_adata: Sample-level AnnData.
         """
         weights = 1.0 / np.asarray(sample_adata.var["kth_distance"], dtype=float)
-        adjp = _weighted_bh(sample_adata.var["PValue"].to_numpy(dtype=float), weights)
+        adjp = _weighted_bh(as_frame(sample_adata.var)["PValue"].to_numpy(dtype=float), weights)
         sample_adata.var["SpatialFDR"] = adjp
         # Fill missing values with 1 to avoid downstream NaN complications
         # e.g. https://github.com/scverse/pertpy/issues/912
-        sample_adata.var["SpatialFDR"] = sample_adata.var["SpatialFDR"].fillna(1)
+        sample_adata.var["SpatialFDR"] = as_frame(sample_adata.var)["SpatialFDR"].fillna(1)
 
     @_doc_params(common_plot_args=doc_common_plot_args)
     @deprecated_arg(
         "alpha",
-        Deprecation("1.1.0", "Use `padj_threshold`."),
+        cast("Deprecation", Deprecation("1.1.0", "Use `padj_threshold`.")),
     )
     def plot_nhood_graph(  # pragma: no cover # noqa: D417
         self,
@@ -1265,14 +1265,15 @@ class Milo:
                 "please run milo.build_nhood_graph(mdata) first"
             )
 
-        nhood_adata.obs["graph_color"] = logfc
-        nhood_adata.obs.loc[spatial_fdr > padj_threshold, "graph_color"] = np.nan
-        nhood_adata.obs["abs_logFC"] = logfc.abs()
-        nhood_adata.obs.loc[nhood_adata.obs["abs_logFC"] < min_logFC, "graph_color"] = np.nan
+        nhood_obs = as_frame(nhood_adata.obs)
+        nhood_obs["graph_color"] = logfc
+        nhood_obs.loc[spatial_fdr > padj_threshold, "graph_color"] = np.nan
+        nhood_obs["abs_logFC"] = logfc.abs()
+        nhood_obs.loc[nhood_obs["abs_logFC"] < min_logFC, "graph_color"] = np.nan
 
         # Plotting order - extreme logFC on top
-        nhood_adata.obs.loc[nhood_adata.obs["graph_color"].isna(), "abs_logFC"] = np.nan
-        ordered = nhood_adata.obs.sort_values("abs_logFC", na_position="first").index
+        nhood_obs.loc[nhood_obs["graph_color"].isna(), "abs_logFC"] = np.nan
+        ordered = nhood_obs.sort_values("abs_logFC", na_position="first").index
         nhood_adata = nhood_adata[ordered]
 
         vmax = np.max([nhood_adata.obs["graph_color"].max(), abs(nhood_adata.obs["graph_color"].min())])
@@ -1437,7 +1438,7 @@ class Milo:
     @_doc_params(common_plot_args=doc_common_plot_args)
     @deprecated_arg(
         "alpha",
-        Deprecation("1.1.0", "Use `padj_threshold`."),
+        cast("Deprecation", Deprecation("1.1.0", "Use `padj_threshold`.")),
     )
     def plot_da_beeswarm(  # pragma: no cover # noqa: D417
         self,
@@ -1446,7 +1447,7 @@ class Milo:
         feature_key: str | None = "rna",
         anno_col: str = "nhood_annotation",
         padj_threshold: float = 0.1,
-        subset_nhoods: list[str] = None,
+        subset_nhoods: list[str] | None = None,
         palette: str | Sequence[str] | dict[str, str] | None = None,
         return_fig: bool = False,
         alpha: float | None = None,
@@ -1577,7 +1578,7 @@ class Milo:
         mdata: MuData,
         test_var: str,
         *,
-        subset_nhoods: list[str] = None,
+        subset_nhoods: list[str] | None = None,
         log_counts: bool = False,
         return_fig: bool = False,
         ax=None,
@@ -1674,7 +1675,7 @@ class Milo:
 
     def _group_nhoods_from_adjacency(
         self,
-        adjacency: spmatrix,
+        adjacency: np.ndarray | CSBase,
         da_res: pd.DataFrame,
         is_da: np.ndarray,
         *,
@@ -1694,8 +1695,8 @@ class Milo:
                 "`group_nhoods` requires the optional GPL-licensed package 'igraph'. Install it with: pip install igraph"
             )
 
-        adjacency = adjacency.tocsr() if issparse(adjacency) else csr_matrix(adjacency)
-        edges = adjacency.tocoo()
+        connectivities = adjacency.tocsr() if isinstance(adjacency, CSBase) else csr_matrix(adjacency)
+        edges = connectivities.tocoo()
         rows, cols, data = edges.row, edges.col, edges.data
 
         logfc = da_res["logFC"].to_numpy()
@@ -1708,11 +1709,9 @@ class Milo:
         if max_lfc_delta is not None:
             keep &= np.abs(logfc[rows] - logfc[cols]) <= max_lfc_delta
 
-        n = adjacency.shape[0]
+        n = connectivities.shape[0]
         pruned = coo_matrix((data[keep], (rows[keep], cols[keep])), shape=(n, n))
-        pruned = (pruned > 0).astype(int).tocsr()
-
-        graph = sc._utils.get_igraph_from_adjacency(pruned, directed=False)
+        graph = sc._utils.get_igraph_from_adjacency((pruned > 0).astype(int).tocsr(), directed=False)
         return np.array(graph.community_multilevel(weights=None).membership, dtype=str)
 
     def group_nhoods(
@@ -1784,8 +1783,8 @@ class Milo:
         )
 
         labels = self._group_nhoods_from_adjacency(
-            adata.varp["nhood_connectivities"][mask, :][:, mask],
-            adata.var.loc[mask],
+            as_matrix(adata.varp["nhood_connectivities"])[mask, :][:, mask],
+            as_frame(adata.var).loc[mask],
             is_da[mask],
             merge_discord=merge_discord,
             overlap=overlap,
@@ -1830,8 +1829,8 @@ class Milo:
         if len(categories) == 0:
             raise ValueError(f"'{nhood_group_key}' has no non-missing neighbourhood group labels.")
 
-        nhoods = adata.obsm["nhoods"]
-        nhoods = nhoods.tocsr() if issparse(nhoods) else csr_matrix(nhoods)
+        nhoods = as_matrix(adata.obsm["nhoods"])
+        nhoods = nhoods.tocsr() if isinstance(nhoods, CSBase) else csr_matrix(nhoods)
 
         counts = np.column_stack([np.asarray(nhoods[:, labels == group].sum(axis=1)).ravel() for group in categories])
         total = counts.sum(axis=1)
@@ -1918,10 +1917,8 @@ class Milo:
 
         by = list(dict.fromkeys([sample_col, nhood_group_key, *covariates]))
         pdata = sc.get.aggregate(adata, by=by, func="sum", layer=layer)
-        pdata.X = pdata.layers["sum"]
-        if issparse(pdata.X):
-            pdata.X = pdata.X.toarray()
-        if pdata.obs[nhood_group_key].nunique() < 2:
+        pdata.X = to_dense(as_matrix(pdata.layers["sum"]))
+        if as_frame(pdata.obs)[nhood_group_key].nunique() < 2:
             raise ValueError(f"Fewer than two groups in '{nhood_group_key}' after aggregation.")
 
         if var_names is not None:
@@ -1954,7 +1951,7 @@ class Milo:
                 res = model.test_contrasts(model.contrast(column=column, baseline=ref, group_to_compare=alt))
             return res[["variable", "log_fc", "p_value", "adj_p_value"]].reset_index(drop=True)
 
-        if two_group:
+        if baseline is not None and group_to_compare is not None:
             return _contrast(pdata, nhood_group_key, baseline, group_to_compare)
 
         results = []

--- a/pertpy/tools/_milo.py
+++ b/pertpy/tools/_milo.py
@@ -251,19 +251,19 @@ class Milo:
             adata = data
         if isinstance(adata, AnnData):
             try:
-                nhoods = cast_matrix(adata.obsm["nhoods"])
+                nhoods = adata.obsm["nhoods"]
             except KeyError:
                 logger.error('Cannot find "nhoods" slot in adata.obsm -- please run milopy.make_nhoods(adata)')
                 raise
         # Make nhood abundance matrix
-        sample_dummies = pd.get_dummies(cast_frame(adata.obs)[sample_col])
+        sample_dummies = pd.get_dummies(adata.obs[sample_col])
         all_samples = sample_dummies.columns
         nhood_count_mat = csr_matrix(nhoods).T.dot(csr_matrix(sample_dummies.values))
         sample_obs = pd.DataFrame(index=all_samples)
         sample_adata = AnnData(X=nhood_count_mat.T, obs=sample_obs)
         sample_adata.uns["sample_col"] = sample_col
         # Save nhood index info
-        obs = cast_frame(adata.obs)
+        obs = adata.obs
         sample_adata.var["index_cell"] = adata.obs_names[obs["nhood_ixs_refined"] == 1]
         sample_adata.var["kth_distance"] = obs.loc[obs["nhood_ixs_refined"] == 1, "nhood_kth_distance"].values
 
@@ -688,7 +688,7 @@ class Milo:
                 failures.setdefault(f"pseudobulk failed ({type(e).__name__})", []).append(int(j))
                 continue
             pdata.X = pdata.layers["sum"]
-            pdata_X = cast_matrix(pdata.X)
+            pdata_X = pdata.X
             if isinstance(pdata_X, CSBase):
                 pdata.X = pdata_X.toarray()
 
@@ -1829,7 +1829,7 @@ class Milo:
         if len(categories) == 0:
             raise ValueError(f"'{nhood_group_key}' has no non-missing neighbourhood group labels.")
 
-        nhoods = cast_matrix(adata.obsm["nhoods"])
+        nhoods = adata.obsm["nhoods"]
         nhoods = nhoods.tocsr() if isinstance(nhoods, CSBase) else csr_matrix(nhoods)
 
         counts = np.column_stack([np.asarray(nhoods[:, labels == group].sum(axis=1)).ravel() for group in categories])
@@ -1917,8 +1917,8 @@ class Milo:
 
         by = list(dict.fromkeys([sample_col, nhood_group_key, *covariates]))
         pdata = sc.get.aggregate(adata, by=by, func="sum", layer=layer)
-        pdata.X = to_dense(cast_matrix(pdata.layers["sum"]))
-        if cast_frame(pdata.obs)[nhood_group_key].nunique() < 2:
+        pdata.X = to_dense(pdata.layers["sum"])
+        if pdata.obs[nhood_group_key].nunique() < 2:
             raise ValueError(f"Fewer than two groups in '{nhood_group_key}' after aggregation.")
 
         if var_names is not None:

--- a/pertpy/tools/_perturbation_efficacy/_base.py
+++ b/pertpy/tools/_perturbation_efficacy/_base.py
@@ -10,7 +10,7 @@ from pandas.errors import PerformanceWarning
 from scanpy.tools._utils import _choose_representation  # type: ignore[import-untyped]
 from scipy.sparse import csr_array, csr_matrix, lil_matrix, sparray
 
-from pertpy._types import CSBase, as_dense, as_matrix
+from pertpy._types import CSBase, cast_dense, cast_matrix
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -95,11 +95,11 @@ class PerturbationEfficacyAnalyzer:
         # pynndescent and the LIL workflow below only support legacy scipy sparse matrices, so a sparse array
         # input is computed on as a csr_matrix and converted back to a sparse array at the end.
         input_is_sparray = isinstance(adata.X, sparray)
-        X = csr_matrix(as_matrix(adata.X)) if input_is_sparray else as_matrix(adata.X)
+        X = csr_matrix(cast_matrix(adata.X)) if input_is_sparray else cast_matrix(adata.X)
         adata.layers["X_pert"] = X.copy()
 
         # Work with LIL for efficient indexing but don't store it in AnnData as LIL is not supported anymore
-        X_pert = as_matrix(adata.layers["X_pert"])
+        X_pert = cast_matrix(adata.layers["X_pert"])
         X_pert_lil = X_pert.tolil() if isinstance(X_pert, CSBase) else X_pert
 
         control_mask = adata.obs[pert_key] == control
@@ -119,7 +119,7 @@ class PerturbationEfficacyAnalyzer:
                 split_obs = adata.obs[split_by]
                 split_masks = [split_obs == cat for cat in split_obs.unique()]
 
-            representation = as_matrix(_choose_representation(adata, use_rep=use_rep, n_pcs=n_pcs))
+            representation = cast_matrix(_choose_representation(adata, use_rep=use_rep, n_pcs=n_pcs))
             if isinstance(representation, sparray):
                 representation = csr_matrix(representation)
             if n_dims is not None and n_dims < representation.shape[1]:
@@ -160,7 +160,7 @@ class PerturbationEfficacyAnalyzer:
                         batch = np.ravel(indices[select])
                         split_batch = split_indices[select]
                         size = size - i
-                        means_batch = as_dense(X_control[batch])
+                        means_batch = cast_dense(X_control[batch])
                         batch_reshaped = means_batch.reshape(size, n_neighbors, -1)
                         means_batch, _ = mean_var(batch_reshaped, axis=1)
                         X_pert_lil[split_batch] = np.log1p(means_batch) - X_pert_lil[split_batch]

--- a/pertpy/tools/_perturbation_efficacy/_base.py
+++ b/pertpy/tools/_perturbation_efficacy/_base.py
@@ -4,13 +4,16 @@ import warnings
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from fast_array_utils.stats import mean, mean_var
 from pandas.errors import PerformanceWarning
-from scanpy.tools._utils import _choose_representation
-from scipy.sparse import csr_array, csr_matrix, issparse, sparray
+from scanpy.tools._utils import _choose_representation  # type: ignore[import-untyped]
+from scipy.sparse import csr_array, csr_matrix, lil_matrix, sparray
+
+from pertpy._types import CSBase, as_dense, as_matrix
 
 if TYPE_CHECKING:
+    import pandas as pd
     from anndata import AnnData
 
 
@@ -92,11 +95,12 @@ class PerturbationEfficacyAnalyzer:
         # pynndescent and the LIL workflow below only support legacy scipy sparse matrices, so a sparse array
         # input is computed on as a csr_matrix and converted back to a sparse array at the end.
         input_is_sparray = isinstance(adata.X, sparray)
-        X = csr_matrix(adata.X) if input_is_sparray else adata.X
+        X = csr_matrix(as_matrix(adata.X)) if input_is_sparray else as_matrix(adata.X)
         adata.layers["X_pert"] = X.copy()
 
         # Work with LIL for efficient indexing but don't store it in AnnData as LIL is not supported anymore
-        X_pert_lil = adata.layers["X_pert"].tolil() if issparse(adata.layers["X_pert"]) else adata.layers["X_pert"]
+        X_pert = as_matrix(adata.layers["X_pert"])
+        X_pert_lil = X_pert.tolil() if isinstance(X_pert, CSBase) else X_pert
 
         control_mask = adata.obs[pert_key] == control
 
@@ -115,13 +119,13 @@ class PerturbationEfficacyAnalyzer:
                 split_obs = adata.obs[split_by]
                 split_masks = [split_obs == cat for cat in split_obs.unique()]
 
-            representation = _choose_representation(adata, use_rep=use_rep, n_pcs=n_pcs)
+            representation = as_matrix(_choose_representation(adata, use_rep=use_rep, n_pcs=n_pcs))
             if isinstance(representation, sparray):
                 representation = csr_matrix(representation)
             if n_dims is not None and n_dims < representation.shape[1]:
                 representation = representation[:, :n_dims]
 
-            from pynndescent import NNDescent
+            from pynndescent import NNDescent  # type: ignore[import-untyped]
 
             for split_mask in split_masks:
                 control_mask_split = control_mask & split_mask
@@ -130,7 +134,10 @@ class PerturbationEfficacyAnalyzer:
                 eps = kwargs.pop("epsilon", 0.1)
                 nn_index = NNDescent(R_control, **kwargs)
                 indices, _ = nn_index.query(R_split, k=n_neighbors, epsilon=eps)
-                X_control = np.expm1(X[np.asarray(control_mask_split)])
+                X_split_control = X[np.asarray(control_mask_split)]
+                X_control = (
+                    X_split_control.expm1() if isinstance(X_split_control, CSBase) else np.expm1(X_split_control)
+                )
                 n_split = split_mask.sum()
                 n_control = X_control.shape[0]
 
@@ -153,16 +160,16 @@ class PerturbationEfficacyAnalyzer:
                         batch = np.ravel(indices[select])
                         split_batch = split_indices[select]
                         size = size - i
-                        means_batch = X_control[batch]
+                        means_batch = as_dense(X_control[batch])
                         batch_reshaped = means_batch.reshape(size, n_neighbors, -1)
                         means_batch, _ = mean_var(batch_reshaped, axis=1)
                         X_pert_lil[split_batch] = np.log1p(means_batch) - X_pert_lil[split_batch]
 
-        if issparse(X_pert_lil):
+        if isinstance(X_pert_lil, np.ndarray):
+            adata.layers["X_pert"] = X_pert_lil
+        else:
             x_pert = X_pert_lil.tocsr()
             adata.layers["X_pert"] = csr_array(x_pert) if input_is_sparray else x_pert
-        else:
-            adata.layers["X_pert"] = X_pert_lil
 
         if copy:
             return adata
@@ -171,11 +178,11 @@ class PerturbationEfficacyAnalyzer:
         self,
         adata: AnnData,
         *,
-        split_masks: list[np.ndarray],
+        split_masks: list[np.ndarray | pd.Series],
         categories: list[str],
         pert_key: str,
         control: str,
-        layer: str,
+        layer: str | None,
         pval_cutoff: float,
         min_de_genes: float,
         logfc_threshold: float,

--- a/pertpy/tools/_perturbation_efficacy/_mixscale.py
+++ b/pertpy/tools/_perturbation_efficacy/_mixscale.py
@@ -11,7 +11,7 @@ from fast_array_utils.conv import to_dense
 from pandas.errors import PerformanceWarning
 from scipy.sparse import sparray
 
-from pertpy._types import CSBase, as_frame, as_matrix
+from pertpy._types import CSBase, cast_frame, cast_matrix
 from pertpy.tools._perturbation_efficacy._base import PerturbationEfficacyAnalyzer
 
 if TYPE_CHECKING:
@@ -248,7 +248,7 @@ class Mixscale(PerturbationEfficacyAnalyzer):
 
         Zero-centering necessarily densifies the (cells x DE-gene) submatrix, exactly as Seurat's `ScaleData` and :meth:`~pertpy.tools.Mixscape.mixscape` do.
         """
-        dat = to_dense(as_matrix(dat))
+        dat = to_dense(cast_matrix(dat))
         dat = dat.astype(np.float64, copy=False)
         mean = dat.mean(axis=0)
         std = dat.std(axis=0, ddof=1)
@@ -283,7 +283,7 @@ class Mixscale(PerturbationEfficacyAnalyzer):
         """
         var_names = set(adata.var_names)
         gene_targets = set(adata.obs[pert_key]).difference([control])
-        nt_cells = adata.obs_names[np.asarray(as_frame(adata.obs)[pert_key] == control)]
+        nt_cells = adata.obs_names[np.asarray(cast_frame(adata.obs)[pert_key] == control)]
         markers: dict[str, np.ndarray] = {}
 
         for gene in gene_targets:
@@ -310,7 +310,7 @@ class Mixscale(PerturbationEfficacyAnalyzer):
 
                 if fine_mode:
                     pooled: list[str] = []
-                    guide_labels = as_frame(adata.obs).loc[guide_cells, fine_mode_labels]
+                    guide_labels = cast_frame(adata.obs).loc[guide_cells, fine_mode_labels]
                     for guide in guide_labels.unique():
                         guide_subset = guide_cells[guide_labels == guide]
                         for g in self._de_for_pair(

--- a/pertpy/tools/_perturbation_efficacy/_mixscale.py
+++ b/pertpy/tools/_perturbation_efficacy/_mixscale.py
@@ -11,7 +11,7 @@ from fast_array_utils.conv import to_dense
 from pandas.errors import PerformanceWarning
 from scipy.sparse import sparray
 
-from pertpy._types import CSBase, cast_frame, cast_matrix
+from pertpy._types import CSBase, cast_frame
 from pertpy.tools._perturbation_efficacy._base import PerturbationEfficacyAnalyzer
 
 if TYPE_CHECKING:
@@ -248,7 +248,7 @@ class Mixscale(PerturbationEfficacyAnalyzer):
 
         Zero-centering necessarily densifies the (cells x DE-gene) submatrix, exactly as Seurat's `ScaleData` and :meth:`~pertpy.tools.Mixscape.mixscape` do.
         """
-        dat = to_dense(cast_matrix(dat))
+        dat = to_dense(dat)
         dat = dat.astype(np.float64, copy=False)
         mean = dat.mean(axis=0)
         std = dat.std(axis=0, ddof=1)
@@ -283,7 +283,7 @@ class Mixscale(PerturbationEfficacyAnalyzer):
         """
         var_names = set(adata.var_names)
         gene_targets = set(adata.obs[pert_key]).difference([control])
-        nt_cells = adata.obs_names[np.asarray(cast_frame(adata.obs)[pert_key] == control)]
+        nt_cells = adata.obs_names[np.asarray(adata.obs[pert_key] == control)]
         markers: dict[str, np.ndarray] = {}
 
         for gene in gene_targets:

--- a/pertpy/tools/_perturbation_efficacy/_mixscale.py
+++ b/pertpy/tools/_perturbation_efficacy/_mixscale.py
@@ -6,10 +6,12 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
+from fast_array_utils.conv import to_dense
 from pandas.errors import PerformanceWarning
-from scipy.sparse import issparse, sparray
+from scipy.sparse import sparray
 
+from pertpy._types import CSBase, as_frame, as_matrix
 from pertpy.tools._perturbation_efficacy._base import PerturbationEfficacyAnalyzer
 
 if TYPE_CHECKING:
@@ -37,17 +39,17 @@ def _leave_one_out_numerators(matrix: np.ndarray, numerator: np.ndarray, directi
 
 
 @_subset_column_mean.register(sparray)
-def _(matrix, row_mask: np.ndarray) -> np.ndarray:
+def _(matrix: CSBase, row_mask: np.ndarray) -> np.ndarray:  # type: ignore[misc]
     return np.asarray(matrix[row_mask].mean(axis=0)).ravel()
 
 
 @_project.register(sparray)
-def _(matrix, direction: np.ndarray) -> np.ndarray:
+def _(matrix: sparray, direction: np.ndarray) -> np.ndarray:  # type: ignore[misc]
     return np.asarray(matrix @ direction).ravel()
 
 
 @_leave_one_out_numerators.register(sparray)
-def _(matrix, numerator: np.ndarray, direction: np.ndarray) -> np.ndarray:
+def _(matrix: CSBase, numerator: np.ndarray, direction: np.ndarray) -> np.ndarray:  # type: ignore[misc]
     return numerator[:, None] - matrix.multiply(direction[None, :]).toarray()
 
 
@@ -246,7 +248,7 @@ class Mixscale(PerturbationEfficacyAnalyzer):
 
         Zero-centering necessarily densifies the (cells x DE-gene) submatrix, exactly as Seurat's `ScaleData` and :meth:`~pertpy.tools.Mixscape.mixscape` do.
         """
-        dat = dat.toarray() if issparse(dat) else np.asarray(dat, dtype=np.float64)
+        dat = to_dense(as_matrix(dat))
         dat = dat.astype(np.float64, copy=False)
         mean = dat.mean(axis=0)
         std = dat.std(axis=0, ddof=1)
@@ -281,7 +283,7 @@ class Mixscale(PerturbationEfficacyAnalyzer):
         """
         var_names = set(adata.var_names)
         gene_targets = set(adata.obs[pert_key]).difference([control])
-        nt_cells = adata.obs_names[adata.obs[pert_key] == control]
+        nt_cells = adata.obs_names[np.asarray(as_frame(adata.obs)[pert_key] == control)]
         markers: dict[str, np.ndarray] = {}
 
         for gene in gene_targets:
@@ -308,8 +310,9 @@ class Mixscale(PerturbationEfficacyAnalyzer):
 
                 if fine_mode:
                     pooled: list[str] = []
-                    for guide in adata.obs.loc[guide_cells, fine_mode_labels].unique():
-                        guide_subset = guide_cells[adata.obs.loc[guide_cells, fine_mode_labels] == guide]
+                    guide_labels = as_frame(adata.obs).loc[guide_cells, fine_mode_labels]
+                    for guide in guide_labels.unique():
+                        guide_subset = guide_cells[guide_labels == guide]
                         for g in self._de_for_pair(
                             adata,
                             guide_subset,

--- a/pertpy/tools/_perturbation_efficacy/_mixscape.py
+++ b/pertpy/tools/_perturbation_efficacy/_mixscape.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 import copy
 import warnings
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 import seaborn as sns
 from pandas.errors import PerformanceWarning
 from scanpy import get
-from scanpy._utils import check_use_raw, sanitize_anndata
-from scanpy.plotting import _utils
+from scanpy._utils import check_use_raw, sanitize_anndata  # type: ignore[import-untyped]
+from scanpy.plotting import _utils  # type: ignore[import-untyped]
 from scipy.sparse import spmatrix
-from sklearn.mixture import GaussianMixture
+from sklearn.mixture import GaussianMixture  # type: ignore[import-untyped]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
+from pertpy._types import CSBase, as_dense, as_frame, as_matrix
 from pertpy.tools._perturbation_efficacy._base import PerturbationEfficacyAnalyzer
 
 if TYPE_CHECKING:
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.colors import Colormap
     from matplotlib.pyplot import Figure
+    from seaborn.axisgrid import FacetGrid
 
 
 class Mixscape(PerturbationEfficacyAnalyzer):
@@ -38,19 +40,19 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         pert_key: str,
         control: str,
         *,
-        new_class_name: str | None = "mixscape_class",
+        new_class_name: str = "mixscape_class",
         layer: str | None = None,
-        min_de_genes: int | None = 5,
-        logfc_threshold: float | None = 0.25,
+        min_de_genes: int = 5,
+        logfc_threshold: float = 0.25,
         de_layer: str | None = None,
-        test_method: str | None = "wilcoxon",
-        iter_num: int | None = 10,
-        scale: bool | None = True,
+        test_method: str = "wilcoxon",
+        iter_num: int = 10,
+        scale: bool = True,
         split_by: str | None = None,
-        pval_cutoff: float | None = 5e-2,
-        perturbation_type: str | None = "KO",
+        pval_cutoff: float = 5e-2,
+        perturbation_type: str = "KO",
         random_state: int | None = 0,
-        copy: bool | None = False,
+        copy: bool = False,
         **gmmkwargs,
     ):
         """Identify perturbed and non-perturbed gRNA expressing cells that accounts for multiple treatments/conditions/chemical perturbations.
@@ -102,12 +104,14 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         if copy:
             adata = adata.copy()
 
+        obs = as_frame(adata.obs)
+        split_masks: list[np.ndarray | pd.Series]
         if split_by is None:
             split_masks = [np.full(adata.n_obs, True, dtype=bool)]
             categories = ["all"]
         else:
-            split_obs = adata.obs[split_by]
-            categories = split_obs.unique()
+            split_obs = obs[split_by]
+            categories = list(split_obs.unique())
             split_masks = [split_obs == category for category in categories]
 
         perturbation_markers = self._get_perturbation_markers(
@@ -125,19 +129,19 @@ class Mixscape(PerturbationEfficacyAnalyzer):
 
         adata_comp = adata
         if layer is not None:
-            X = adata_comp.layers[layer]
+            X = as_matrix(adata_comp.layers[layer])
         else:
             try:
-                X = adata_comp.layers["X_pert"]
+                X = as_matrix(adata_comp.layers["X_pert"])
             except KeyError:
                 raise KeyError(
                     "No 'X_pert' found in .layers! Please run perturbation_signature first to calculate perturbation signature!"
                 ) from None
 
         # initialize return variables
-        adata.obs[f"{new_class_name}_p_{perturbation_type.lower()}"] = 0
-        adata.obs[new_class_name] = adata.obs[pert_key].astype(str)
-        adata.obs[f"{new_class_name}_global"] = np.empty(
+        obs[f"{new_class_name}_p_{perturbation_type.lower()}"] = 0
+        obs[new_class_name] = obs[pert_key].astype(str)
+        obs[f"{new_class_name}_global"] = np.empty(
             [
                 adata.n_obs,
             ],
@@ -145,19 +149,19 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         )
         gv_list: dict[str, dict] = {}
 
-        adata.obs[f"{new_class_name}_p_{perturbation_type.lower()}"] = 0.0
+        obs[f"{new_class_name}_p_{perturbation_type.lower()}"] = 0.0
         for split, split_mask in enumerate(split_masks):
             category = categories[split]
             gene_targets = list(set(adata[split_mask].obs[pert_key]).difference([control]))
             for gene in gene_targets:
                 post_prob = 0
-                orig_guide_cells = (adata.obs[pert_key] == gene) & split_mask
+                orig_guide_cells = (obs[pert_key] == gene) & split_mask
                 orig_guide_cells_index = list(orig_guide_cells.index[orig_guide_cells])
-                nt_cells = (adata.obs[pert_key] == control) & split_mask
+                nt_cells = (obs[pert_key] == control) & split_mask
                 all_cells = orig_guide_cells | nt_cells
 
                 if len(perturbation_markers[(category, gene)]) == 0:
-                    adata.obs.loc[orig_guide_cells, new_class_name] = f"{gene} NP"
+                    obs.loc[orig_guide_cells, new_class_name] = f"{gene} NP"
 
                 else:
                     de_genes = perturbation_markers[(category, gene)]
@@ -173,14 +177,14 @@ class Mixscape(PerturbationEfficacyAnalyzer):
 
                     converged = False
                     n_iter = 0
-                    old_classes = adata.obs[new_class_name][all_cells]
+                    old_classes = obs[new_class_name][all_cells]
 
                     nt_cells_dat_idx = all_cells[all_cells].index.get_indexer(nt_cells[nt_cells].index)
                     nt_cells_mean = np.mean(dat[nt_cells_dat_idx], axis=0)
 
                     while not converged and n_iter < iter_num:
                         # Get all cells in current split&Gene
-                        guide_cells = (adata.obs[new_class_name] == gene) & split_mask
+                        guide_cells = (obs[new_class_name] == gene) & split_mask
 
                         # get average value for each gene over all selected cells
                         # all cells in current split&Gene minus all NT cells in current split
@@ -191,9 +195,9 @@ class Mixscape(PerturbationEfficacyAnalyzer):
 
                         # project cells onto the perturbation vector
                         if isinstance(dat, spmatrix):
-                            pvec = dat.dot(vec) / np.dot(vec, vec)
+                            pvec = cast("CSBase", dat).dot(vec) / np.dot(vec, vec)
                         else:
-                            pvec = np.dot(dat, vec) / np.dot(vec, vec)
+                            pvec = np.dot(as_dense(dat), vec) / np.dot(vec, vec)
                         pvec = pd.Series(np.asarray(pvec).flatten(), index=list(all_cells.index[all_cells]))
 
                         if n_iter == 0:
@@ -224,25 +228,23 @@ class Mixscape(PerturbationEfficacyAnalyzer):
 
                         # based on the posterior probability, assign cells to the two classes
                         ko_mask = post_prob > 0.5
-                        adata.obs.loc[np.array(orig_guide_cells_index)[ko_mask], new_class_name] = gene
-                        adata.obs.loc[np.array(orig_guide_cells_index)[~ko_mask], new_class_name] = f"{gene} NP"
+                        obs.loc[np.array(orig_guide_cells_index)[ko_mask], new_class_name] = gene
+                        obs.loc[np.array(orig_guide_cells_index)[~ko_mask], new_class_name] = f"{gene} NP"
 
-                        if sum(adata.obs[new_class_name][split_mask] == gene) < min_de_genes:
-                            adata.obs.loc[guide_cells, new_class_name] = "NP"
+                        if sum(obs[new_class_name][split_mask] == gene) < min_de_genes:
+                            obs.loc[guide_cells, new_class_name] = "NP"
                             converged = True
-                        current_classes = adata.obs[new_class_name][all_cells]
+                        current_classes = obs[new_class_name][all_cells]
                         if (current_classes == old_classes).all():
                             converged = True
                         old_classes = current_classes
 
                         n_iter += 1
 
-                    adata.obs.loc[(adata.obs[new_class_name] == gene) & split_mask, new_class_name] = (
-                        f"{gene} {perturbation_type}"
-                    )
+                    obs.loc[(obs[new_class_name] == gene) & split_mask, new_class_name] = f"{gene} {perturbation_type}"
 
-                adata.obs[f"{new_class_name}_global"] = [a.split(" ")[-1] for a in adata.obs[new_class_name]]
-                adata.obs.loc[orig_guide_cells_index, f"{new_class_name}_p_{perturbation_type.lower()}"] = post_prob
+                obs[f"{new_class_name}_global"] = [a.split(" ")[-1] for a in obs[new_class_name]]
+                obs.loc[orig_guide_cells_index, f"{new_class_name}_p_{perturbation_type.lower()}"] = post_prob
         adata.uns["mixscape"] = gv_list
 
         if copy:
@@ -254,16 +256,16 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         pert_key: str,
         control: str,
         *,
-        mixscape_class_global: str | None = "mixscape_class_global",
+        mixscape_class_global: str = "mixscape_class_global",
         layer: str | None = None,
         n_comps: int | None = 10,
-        min_de_genes: int | None = 5,
-        logfc_threshold: float | None = 0.25,
-        test_method: str | None = "wilcoxon",
+        min_de_genes: int = 5,
+        logfc_threshold: float = 0.25,
+        test_method: str = "wilcoxon",
         split_by: str | None = None,
-        pval_cutoff: float | None = 5e-2,
-        perturbation_type: str | None = "KO",
-        copy: bool | None = False,
+        pval_cutoff: float = 5e-2,
+        perturbation_type: str = "KO",
+        copy: bool = False,
     ):
         """Linear Discriminant Analysis on pooled CRISPR screen data. Requires `pt.tl.mixscape()` to be run first.
 
@@ -301,16 +303,17 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         """
         if copy:
             adata = adata.copy()
-        from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
+        from sklearn.discriminant_analysis import LinearDiscriminantAnalysis  # type: ignore[import-untyped]
 
         if mixscape_class_global not in adata.obs:
             raise ValueError("Please run `pt.tl.mixscape` first.")
+        split_masks: list[np.ndarray | pd.Series]
         if split_by is None:
             split_masks = [np.full(adata.n_obs, True, dtype=bool)]
             categories = ["all"]
         else:
-            split_obs = adata.obs[split_by]
-            categories = split_obs.unique()
+            split_obs = as_frame(adata.obs)[split_by]
+            categories = list(split_obs.unique())
             split_masks = [split_obs == category for category in categories]
 
         # determine gene sets across all splits/groups through differential gene expression
@@ -329,7 +332,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         adata_subset = adata[
             (adata.obs[mixscape_class_global] == perturbation_type) | (adata.obs[mixscape_class_global] == control)
         ]
-        X = adata_subset.X - adata_subset.X.mean(0)
+        X = as_matrix(adata_subset.X) - as_matrix(adata_subset.X).mean(0)
         projected_pcs: dict[str, np.ndarray] = {}
         # performs PCA on each mixscape class separately and projects each subspace onto all cells in the data.
         for _, (key, value) in enumerate(perturbation_markers.items()):
@@ -368,7 +371,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         axis_title_size: int = 8,
         legend_title_size: int = 8,
         legend_text_size: int = 8,
-        legend_bbox_to_anchor: tuple[float, float] = None,
+        legend_bbox_to_anchor: tuple[float, float] | None = None,
         figsize: tuple[float, float] = (25, 25),
         return_fig: bool = False,
     ) -> Figure | None:
@@ -404,7 +407,8 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         """
         if mixscape_class_global not in adata.obs:
             raise ValueError("Please run the `mixscape` function first.")
-        count = pd.crosstab(index=adata.obs[mixscape_class_global], columns=adata.obs[guide_rna_column])
+        obs = as_frame(adata.obs)
+        count = pd.crosstab(index=obs[mixscape_class_global], columns=obs[guide_rna_column])
         all_cells_percentage = pd.melt(count / count.sum(), ignore_index=False).reset_index()
         KO_cells_percentage = all_cells_percentage[all_cells_percentage[mixscape_class_global] == "KO"]
         KO_cells_percentage = KO_cells_percentage.sort_values("value", ascending=False)
@@ -546,8 +550,8 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         *,
         mixscape_class: str = "mixscape_class",
         color: str = "orange",
-        palette: dict[str, str] = None,
-        split_by: str = None,
+        palette: dict[str, str] | None = None,
+        split_by: str | None = None,
         before_mixscape: bool = False,
         perturbation_type: str = "KO",
         return_fig: bool = False,
@@ -590,7 +594,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         """
         if "mixscape" not in adata.uns:
             raise ValueError("Please run the `mixscape` function first.")
-        perturbation_score = None
+        perturbation_score: pd.DataFrame | None = None
         for key in adata.uns["mixscape"][target_gene]:
             perturbation_score_temp = adata.uns["mixscape"][target_gene][key]
             perturbation_score_temp["name"] = key
@@ -598,14 +602,17 @@ class Mixscape(PerturbationEfficacyAnalyzer):
                 perturbation_score = copy.deepcopy(perturbation_score_temp)
             else:
                 perturbation_score = pd.concat([perturbation_score, perturbation_score_temp])
-        perturbation_score["mix"] = adata.obs[mixscape_class][perturbation_score.index]
+        perturbation_score = as_frame(perturbation_score)
+        perturbation_score["mix"] = as_frame(adata.obs)[mixscape_class][perturbation_score.index]
         gd = list(set(perturbation_score[pert_key]).difference({target_gene}))[0]
 
         # If before_mixscape is True, split densities based on original target gene classification
         if before_mixscape is True:
             palette = {gd: "#7d7d7d", target_gene: color}
             plot_dens = sns.kdeplot(data=perturbation_score, x="pvec", hue=pert_key, fill=False, common_norm=False)
-            top_r = max(plot_dens.get_lines()[cond].get_data()[1].max() for cond in range(len(plot_dens.get_lines())))
+            top_r = max(
+                as_dense(plot_dens.get_lines()[cond].get_data()[1]).max() for cond in range(len(plot_dens.get_lines()))
+            )
             plt.close()
             perturbation_score["y_jitter"] = perturbation_score["pvec"]
             rng = np.random.default_rng()
@@ -647,7 +654,9 @@ class Mixscape(PerturbationEfficacyAnalyzer):
             if palette is None:
                 palette = {gd: "#7d7d7d", f"{target_gene} NP": "#c9c9c9", f"{target_gene} {perturbation_type}": color}
             plot_dens = sns.kdeplot(data=perturbation_score, x="pvec", hue=pert_key, fill=False, common_norm=False)
-            top_r = max(plot_dens.get_lines()[i].get_data()[1].max() for i in range(len(plot_dens.get_lines())))
+            top_r = max(
+                as_dense(plot_dens.get_lines()[i].get_data()[1]).max() for i in range(len(plot_dens.get_lines()))
+            )
             plt.close()
             perturbation_score["y_jitter"] = perturbation_score["pvec"]
             rng = np.random.default_rng()
@@ -723,12 +732,12 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         order: Sequence[str] | None = None,
         multi_panel: bool | None = None,
         xlabel: str = "",
-        ylabel: str | Sequence[str] | None = None,
+        ylabel: str | Sequence[str | None] | None = None,
         rotation: float | None = None,
         ax: Axes | None = None,
         return_fig: bool = False,
         **kwargs,
-    ) -> Axes | Figure | None:
+    ) -> Axes | Figure | FacetGrid | list[Axes] | None:
         """Violin plot using mixscape results.
 
         Requires `pt.tl.mixscape` to be run first.
@@ -765,12 +774,13 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         Preview:
             .. image:: /_static/docstring_previews/mixscape_violin.png
         """
+        mixscape_class_mask: np.ndarray | pd.Series
         if isinstance(target_gene_idents, str):
-            mixscape_class_mask = adata.obs[groupby] == target_gene_idents
+            mixscape_class_mask = as_frame(adata.obs)[groupby] == target_gene_idents
         elif isinstance(target_gene_idents, list):
             mixscape_class_mask = np.full_like(adata.obs[groupby], False, dtype=bool)
             for ident in target_gene_idents:
-                mixscape_class_mask |= adata.obs[groupby] == ident
+                mixscape_class_mask |= as_frame(adata.obs)[groupby] == ident
         adata = adata[mixscape_class_mask]
 
         sanitize_anndata(adata)
@@ -860,7 +870,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
                     y=y,
                     data=obs_tidy,
                     order=order,
-                    orient="vertical",
+                    orient="vertical",  # type: ignore[arg-type]
                     density_norm=scale,
                     ax=ax,
                     hue=hue,
@@ -914,7 +924,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         mixscape_class: str = "mixscape_class",
         mixscape_class_global: str = "mixscape_class_global",
         perturbation_type: str | None = "KO",
-        lda_key: str | None = "mixscape_lda",
+        lda_key: str = "mixscape_lda",
         n_components: int | None = None,
         color_map: Colormap | str | None = None,
         palette: str | Sequence[str] | None = None,
@@ -984,8 +994,8 @@ class MixscapeGaussianMixture(GaussianMixture):
     def __init__(
         self,
         n_components: int,
-        fixed_means: Sequence[float] | None = None,
-        fixed_covariances: Sequence[float] | None = None,
+        fixed_means: Sequence[float | None] | None = None,
+        fixed_covariances: Sequence[float | None] | None = None,
         **kwargs,
     ):
         """Custom Gaussian Mixture Model where means and covariances can be fixed for specific components.
@@ -1000,15 +1010,15 @@ class MixscapeGaussianMixture(GaussianMixture):
         self.fixed_means = fixed_means
         self.fixed_covariances = fixed_covariances
 
-        self.fixed_mean_indices = []
-        self.fixed_mean_values = []
+        self.fixed_mean_indices: list[int] = []
+        self.fixed_mean_values: np.ndarray | list[float] = []
         if fixed_means is not None:
             self.fixed_mean_indices = [i for i, m in enumerate(fixed_means) if m is not None]
             if self.fixed_mean_indices:
                 self.fixed_mean_values = np.array([fixed_means[i] for i in self.fixed_mean_indices])
 
-        self.fixed_cov_indices = []
-        self.fixed_cov_values = []
+        self.fixed_cov_indices: list[int] = []
+        self.fixed_cov_values: np.ndarray | list[float] = []
         if fixed_covariances is not None:
             self.fixed_cov_indices = [i for i, c in enumerate(fixed_covariances) if c is not None]
             if self.fixed_cov_indices:

--- a/pertpy/tools/_perturbation_efficacy/_mixscape.py
+++ b/pertpy/tools/_perturbation_efficacy/_mixscape.py
@@ -129,7 +129,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
 
         adata_comp = adata
         if layer is not None:
-            X = cast_matrix(adata_comp.layers[layer])
+            X = adata_comp.layers[layer]
         else:
             try:
                 X = cast_matrix(adata_comp.layers["X_pert"])
@@ -781,7 +781,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         elif isinstance(target_gene_idents, list):
             mixscape_class_mask = np.full_like(adata.obs[groupby], False, dtype=bool)
             for ident in target_gene_idents:
-                mixscape_class_mask |= cast_frame(adata.obs)[groupby] == ident
+                mixscape_class_mask |= adata.obs[groupby] == ident
         adata = adata[mixscape_class_mask]
 
         sanitize_anndata(adata)

--- a/pertpy/tools/_perturbation_efficacy/_mixscape.py
+++ b/pertpy/tools/_perturbation_efficacy/_mixscape.py
@@ -18,7 +18,7 @@ from scipy.sparse import spmatrix
 from sklearn.mixture import GaussianMixture  # type: ignore[import-untyped]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
-from pertpy._types import CSBase, as_dense, as_frame, as_matrix
+from pertpy._types import CSBase, cast_dense, cast_frame, cast_matrix
 from pertpy.tools._perturbation_efficacy._base import PerturbationEfficacyAnalyzer
 
 if TYPE_CHECKING:
@@ -104,7 +104,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         if copy:
             adata = adata.copy()
 
-        obs = as_frame(adata.obs)
+        obs = cast_frame(adata.obs)
         split_masks: list[np.ndarray | pd.Series]
         if split_by is None:
             split_masks = [np.full(adata.n_obs, True, dtype=bool)]
@@ -129,10 +129,10 @@ class Mixscape(PerturbationEfficacyAnalyzer):
 
         adata_comp = adata
         if layer is not None:
-            X = as_matrix(adata_comp.layers[layer])
+            X = cast_matrix(adata_comp.layers[layer])
         else:
             try:
-                X = as_matrix(adata_comp.layers["X_pert"])
+                X = cast_matrix(adata_comp.layers["X_pert"])
             except KeyError:
                 raise KeyError(
                     "No 'X_pert' found in .layers! Please run perturbation_signature first to calculate perturbation signature!"
@@ -197,7 +197,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
                         if isinstance(dat, spmatrix):
                             pvec = cast("CSBase", dat).dot(vec) / np.dot(vec, vec)
                         else:
-                            pvec = np.dot(as_dense(dat), vec) / np.dot(vec, vec)
+                            pvec = np.dot(cast_dense(dat), vec) / np.dot(vec, vec)
                         pvec = pd.Series(np.asarray(pvec).flatten(), index=list(all_cells.index[all_cells]))
 
                         if n_iter == 0:
@@ -312,7 +312,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
             split_masks = [np.full(adata.n_obs, True, dtype=bool)]
             categories = ["all"]
         else:
-            split_obs = as_frame(adata.obs)[split_by]
+            split_obs = cast_frame(adata.obs)[split_by]
             categories = list(split_obs.unique())
             split_masks = [split_obs == category for category in categories]
 
@@ -332,7 +332,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         adata_subset = adata[
             (adata.obs[mixscape_class_global] == perturbation_type) | (adata.obs[mixscape_class_global] == control)
         ]
-        X = as_matrix(adata_subset.X) - as_matrix(adata_subset.X).mean(0)
+        X = cast_matrix(adata_subset.X) - cast_matrix(adata_subset.X).mean(0)
         projected_pcs: dict[str, np.ndarray] = {}
         # performs PCA on each mixscape class separately and projects each subspace onto all cells in the data.
         for _, (key, value) in enumerate(perturbation_markers.items()):
@@ -407,7 +407,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         """
         if mixscape_class_global not in adata.obs:
             raise ValueError("Please run the `mixscape` function first.")
-        obs = as_frame(adata.obs)
+        obs = cast_frame(adata.obs)
         count = pd.crosstab(index=obs[mixscape_class_global], columns=obs[guide_rna_column])
         all_cells_percentage = pd.melt(count / count.sum(), ignore_index=False).reset_index()
         KO_cells_percentage = all_cells_percentage[all_cells_percentage[mixscape_class_global] == "KO"]
@@ -602,8 +602,8 @@ class Mixscape(PerturbationEfficacyAnalyzer):
                 perturbation_score = copy.deepcopy(perturbation_score_temp)
             else:
                 perturbation_score = pd.concat([perturbation_score, perturbation_score_temp])
-        perturbation_score = as_frame(perturbation_score)
-        perturbation_score["mix"] = as_frame(adata.obs)[mixscape_class][perturbation_score.index]
+        perturbation_score = cast_frame(perturbation_score)
+        perturbation_score["mix"] = cast_frame(adata.obs)[mixscape_class][perturbation_score.index]
         gd = list(set(perturbation_score[pert_key]).difference({target_gene}))[0]
 
         # If before_mixscape is True, split densities based on original target gene classification
@@ -611,7 +611,8 @@ class Mixscape(PerturbationEfficacyAnalyzer):
             palette = {gd: "#7d7d7d", target_gene: color}
             plot_dens = sns.kdeplot(data=perturbation_score, x="pvec", hue=pert_key, fill=False, common_norm=False)
             top_r = max(
-                as_dense(plot_dens.get_lines()[cond].get_data()[1]).max() for cond in range(len(plot_dens.get_lines()))
+                cast_dense(plot_dens.get_lines()[cond].get_data()[1]).max()
+                for cond in range(len(plot_dens.get_lines()))
             )
             plt.close()
             perturbation_score["y_jitter"] = perturbation_score["pvec"]
@@ -655,7 +656,7 @@ class Mixscape(PerturbationEfficacyAnalyzer):
                 palette = {gd: "#7d7d7d", f"{target_gene} NP": "#c9c9c9", f"{target_gene} {perturbation_type}": color}
             plot_dens = sns.kdeplot(data=perturbation_score, x="pvec", hue=pert_key, fill=False, common_norm=False)
             top_r = max(
-                as_dense(plot_dens.get_lines()[i].get_data()[1]).max() for i in range(len(plot_dens.get_lines()))
+                cast_dense(plot_dens.get_lines()[i].get_data()[1]).max() for i in range(len(plot_dens.get_lines()))
             )
             plt.close()
             perturbation_score["y_jitter"] = perturbation_score["pvec"]
@@ -776,11 +777,11 @@ class Mixscape(PerturbationEfficacyAnalyzer):
         """
         mixscape_class_mask: np.ndarray | pd.Series
         if isinstance(target_gene_idents, str):
-            mixscape_class_mask = as_frame(adata.obs)[groupby] == target_gene_idents
+            mixscape_class_mask = cast_frame(adata.obs)[groupby] == target_gene_idents
         elif isinstance(target_gene_idents, list):
             mixscape_class_mask = np.full_like(adata.obs[groupby], False, dtype=bool)
             for ident in target_gene_idents:
-                mixscape_class_mask |= as_frame(adata.obs)[groupby] == ident
+                mixscape_class_mask |= cast_frame(adata.obs)[groupby] == ident
         adata = adata[mixscape_class_mask]
 
         sanitize_anndata(adata)

--- a/pertpy/tools/_perturbation_space/_clustering.py
+++ b/pertpy/tools/_perturbation_space/_clustering.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 from sklearn.metrics import pairwise_distances  # type: ignore[import-untyped]
 
-from pertpy._types import cast_frame
 from pertpy.tools._perturbation_space._perturbation_space import PerturbationSpace, _resolve_matrix
 
 if TYPE_CHECKING:
@@ -53,7 +52,7 @@ class ClusteringSpace(PerturbationSpace):
         """
         if metrics is None:
             metrics = ["nmi", "ari", "asw"]
-        true_labels = cast_frame(adata.obs)[true_label_col].to_numpy()
+        true_labels = adata.obs[true_label_col].to_numpy()
 
         results: dict[str, float] = {}
         for metric in metrics:
@@ -65,16 +64,14 @@ class ClusteringSpace(PerturbationSpace):
 
                 results["nmi"] = nmi(
                     true_labels=true_labels,
-                    predicted_labels=cast_frame(adata.obs)[cluster_col].to_numpy(),
+                    predicted_labels=adata.obs[cluster_col].to_numpy(),
                     average_method=kwargs["average_method"],
                 )
 
             elif metric == "ari":
                 from pertpy.tools._perturbation_space._metrics import ari
 
-                results["ari"] = ari(
-                    true_labels=true_labels, predicted_labels=cast_frame(adata.obs)[cluster_col].to_numpy()
-                )
+                results["ari"] = ari(true_labels=true_labels, predicted_labels=adata.obs[cluster_col].to_numpy())
 
             elif metric == "asw":
                 from pertpy.tools._perturbation_space._metrics import asw

--- a/pertpy/tools/_perturbation_space/_clustering.py
+++ b/pertpy/tools/_perturbation_space/_clustering.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from sklearn.metrics import pairwise_distances  # type: ignore[import-untyped]
 
-from pertpy._types import as_frame
+from pertpy._types import cast_frame
 from pertpy.tools._perturbation_space._perturbation_space import PerturbationSpace, _resolve_matrix
 
 if TYPE_CHECKING:
@@ -53,7 +53,7 @@ class ClusteringSpace(PerturbationSpace):
         """
         if metrics is None:
             metrics = ["nmi", "ari", "asw"]
-        true_labels = as_frame(adata.obs)[true_label_col].to_numpy()
+        true_labels = cast_frame(adata.obs)[true_label_col].to_numpy()
 
         results: dict[str, float] = {}
         for metric in metrics:
@@ -65,7 +65,7 @@ class ClusteringSpace(PerturbationSpace):
 
                 results["nmi"] = nmi(
                     true_labels=true_labels,
-                    predicted_labels=as_frame(adata.obs)[cluster_col].to_numpy(),
+                    predicted_labels=cast_frame(adata.obs)[cluster_col].to_numpy(),
                     average_method=kwargs["average_method"],
                 )
 
@@ -73,7 +73,7 @@ class ClusteringSpace(PerturbationSpace):
                 from pertpy.tools._perturbation_space._metrics import ari
 
                 results["ari"] = ari(
-                    true_labels=true_labels, predicted_labels=as_frame(adata.obs)[cluster_col].to_numpy()
+                    true_labels=true_labels, predicted_labels=cast_frame(adata.obs)[cluster_col].to_numpy()
                 )
 
             elif metric == "asw":

--- a/pertpy/tools/_perturbation_space/_clustering.py
+++ b/pertpy/tools/_perturbation_space/_clustering.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sklearn.metrics import pairwise_distances
+from sklearn.metrics import pairwise_distances  # type: ignore[import-untyped]
 
+from pertpy._types import as_frame
 from pertpy.tools._perturbation_space._perturbation_space import PerturbationSpace, _resolve_matrix
 
 if TYPE_CHECKING:
@@ -20,7 +21,7 @@ class ClusteringSpace(PerturbationSpace):
         adata: AnnData,
         true_label_col: str,
         cluster_col: str,
-        metrics: Iterable[str] = None,
+        metrics: Iterable[str] | None = None,
         *,
         layer_key: str | None = None,
         embedding_key: str | None = None,
@@ -52,7 +53,7 @@ class ClusteringSpace(PerturbationSpace):
         """
         if metrics is None:
             metrics = ["nmi", "ari", "asw"]
-        true_labels = adata.obs[true_label_col]
+        true_labels = as_frame(adata.obs)[true_label_col].to_numpy()
 
         results: dict[str, float] = {}
         for metric in metrics:
@@ -64,14 +65,16 @@ class ClusteringSpace(PerturbationSpace):
 
                 results["nmi"] = nmi(
                     true_labels=true_labels,
-                    predicted_labels=adata.obs[cluster_col],
+                    predicted_labels=as_frame(adata.obs)[cluster_col].to_numpy(),
                     average_method=kwargs["average_method"],
                 )
 
             elif metric == "ari":
                 from pertpy.tools._perturbation_space._metrics import ari
 
-                results["ari"] = ari(true_labels=true_labels, predicted_labels=adata.obs[cluster_col])
+                results["ari"] = ari(
+                    true_labels=true_labels, predicted_labels=as_frame(adata.obs)[cluster_col].to_numpy()
+                )
 
             elif metric == "asw":
                 from pertpy.tools._perturbation_space._metrics import asw

--- a/pertpy/tools/_perturbation_space/_comparison.py
+++ b/pertpy/tools/_perturbation_space/_comparison.py
@@ -1,10 +1,11 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
-from scipy.sparse import issparse
 from scipy.sparse import vstack as sp_vstack
-from sklearn.base import ClassifierMixin
-from sklearn.linear_model import LogisticRegression
+from sklearn.base import ClassifierMixin  # type: ignore[import-untyped]
+from sklearn.linear_model import LogisticRegression  # type: ignore[import-untyped]
+
+from pertpy._types import CSBase
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -35,7 +36,7 @@ class PerturbationComparison:
         if clf is None:
             clf = LogisticRegression()
         n_x = real.shape[0]
-        data = sp_vstack((real, control)) if issparse(real) else np.vstack((real, control))
+        data = sp_vstack((real, control)) if isinstance(real, CSBase) else np.vstack((real, control))
         labels = np.concatenate([np.full(real.shape[0], "comp"), np.full(control.shape[0], "ctrl")])
 
         clf.fit(data, labels)
@@ -78,23 +79,22 @@ class PerturbationComparison:
         n_y = simulated.shape[0]
 
         if control is None:
-            index_data = sp_vstack((simulated, real)) if issparse(real) else np.vstack((simulated, real))
+            index_data = sp_vstack((simulated, real)) if isinstance(real, CSBase) else np.vstack((simulated, real))
         else:
             datas = (simulated, real, control) if use_simulated_for_knn else (real, control)
-            index_data = sp_vstack(datas) if issparse(real) else np.vstack(datas)
+            index_data = sp_vstack(datas) if isinstance(real, CSBase) else np.vstack(datas)
 
         y_in_index = use_simulated_for_knn or control is None
-        c_in_index = control is not None
         label_groups = ["comp"]
         labels: NDArray[np.str_] = np.full(index_data.shape[0], "comp")
         if y_in_index:
             labels[:n_y] = "siml"
             label_groups.append("siml")
-        if c_in_index:
+        if control is not None:
             labels[-control.shape[0] :] = "ctrl"
             label_groups.append("ctrl")
 
-        from pynndescent import NNDescent
+        from pynndescent import NNDescent  # type: ignore[import-untyped]
 
         index = NNDescent(
             index_data,

--- a/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
@@ -6,17 +6,18 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import numpy as np
-import optax
+import optax  # type: ignore[import-untyped]
 import pandas as pd
 import scipy
 from anndata import AnnData
 from fast_array_utils.conv import to_dense
 from flax.training import train_state
 from jax import random
-from sklearn.linear_model import LogisticRegression
-from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import OneHotEncoder
+from sklearn.linear_model import LogisticRegression  # type: ignore[import-untyped]
+from sklearn.model_selection import train_test_split  # type: ignore[import-untyped]
+from sklearn.preprocessing import OneHotEncoder  # type: ignore[import-untyped]
 
+from pertpy._types import CSBase, as_dense, as_frame, as_matrix
 from pertpy.tools._perturbation_space._perturbation_space import (
     PerturbationSpace,
     _carry_constant_obs,
@@ -78,13 +79,13 @@ class LRClassifierSpace(PerturbationSpace):
             raise ValueError(f"Column {target_col!r} does not exist in the .obs attribute.")
 
         if layer_key is not None:
-            regression_data = adata.layers[layer_key]
+            regression_data = as_matrix(adata.layers[layer_key])
         elif embedding_key is not None:
-            regression_data = adata.obsm[embedding_key]
+            regression_data = as_matrix(adata.obsm[embedding_key])
         else:
-            regression_data = adata.X
+            regression_data = as_matrix(adata.X)
 
-        regression_labels = adata.obs[target_col]
+        regression_labels = as_frame(adata.obs)[target_col]
         random_state = _sklearn_random_state(random_state)
         regression_model = LogisticRegression(max_iter=max_iter, class_weight="balanced", random_state=random_state)
 
@@ -105,8 +106,8 @@ class LRClassifierSpace(PerturbationSpace):
         pert_adata.obs[target_col] = pd.Categorical(perturbations)
         pert_adata.obs["classifier_score"] = scores
 
-        _carry_constant_obs(pert_adata, adata.obs, target_col)
-        pert_adata.obs[target_col] = pert_adata.obs[target_col].astype("category")
+        _carry_constant_obs(pert_adata, as_frame(adata.obs), target_col)
+        pert_adata.obs[target_col] = as_frame(pert_adata.obs)[target_col].astype("category")
 
         return pert_adata
 
@@ -233,24 +234,24 @@ class JAXDataset:
             label_col: key with the perturbation labels.
             layer_key: key of the layer to be used as data, otherwise .X.
         """
-        self.data = adata.layers[layer_key] if layer_key else adata.X
+        data = as_matrix(adata.layers[layer_key] if layer_key else adata.X)
 
+        labels: np.ndarray
         if target_col in adata.obs.columns:
-            self.labels = adata.obs[target_col].values
+            labels = np.asarray(as_frame(adata.obs)[target_col].values)
         elif target_col in adata.obsm:
-            self.labels = adata.obsm[target_col]
+            labels = as_dense(adata.obsm[target_col])
         else:
             raise ValueError(f"Target column {target_col} not found in obs or obsm")
 
-        self.pert_labels = adata.obs[label_col].values
+        self.pert_labels = as_frame(adata.obs)[label_col].values
 
         # Keep sparse data sparse and densify only the requested batch to avoid materializing the full dense matrix.
-        self.is_sparse = scipy.sparse.issparse(self.data)
-        if self.is_sparse:
-            self.data = self.data.tocsr()
-        else:
-            self.data = jnp.array(np.asarray(self.data), dtype=jnp.float32)
-        self.labels = jnp.array(self.labels, dtype=jnp.float32)
+        self.is_sparse = isinstance(data, CSBase)
+        self.data: CSBase | jax.Array = (
+            data.tocsr() if isinstance(data, CSBase) else jnp.array(np.asarray(data), dtype=jnp.float32)
+        )
+        self.labels = jnp.array(labels, dtype=jnp.float32)
 
     def __len__(self):
         return self.data.shape[0]
@@ -258,10 +259,11 @@ class JAXDataset:
     def get_batch(self, indices: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray, list]:
         """Returns a batch of samples and corresponding perturbations applied (labels)."""
         idx = np.asarray(indices)
-        if self.is_sparse:
-            batch_data = jnp.array(to_dense(self.data[idx]), dtype=jnp.float32)
+        data = self.data
+        if isinstance(data, CSBase):
+            batch_data = jnp.array(to_dense(data[idx]), dtype=jnp.float32)
         else:
-            batch_data = self.data[jnp.asarray(idx)]
+            batch_data = data[jnp.asarray(idx)]
         batch_labels = self.labels[jnp.asarray(idx)]
         batch_pert_labels = [self.pert_labels[i] for i in idx]
         return batch_data, batch_labels, batch_pert_labels
@@ -364,9 +366,9 @@ class MLPClassifierSpace(PerturbationSpace):
             hidden_dim = [512]
 
         if embedding_key is not None:
-            work = AnnData(X=adata.obsm[embedding_key])
-            work.obs_names = adata.obs_names
-            work.obs = adata.obs.copy()
+            work = AnnData(X=as_dense(adata.obsm[embedding_key]))
+            work.obs_names = adata.obs_names.tolist()
+            work.obs = as_frame(adata.obs).copy()
             adata = work
             layer_key = None
         else:
@@ -411,7 +413,7 @@ class MLPClassifierSpace(PerturbationSpace):
         state = create_train_state(init_rng, model, (adata.n_vars,), lr)
 
         # Create weighted sampling for class imbalance
-        weights = 1.0 / (1.0 + jnp.sum(train_dataset.labels, axis=1))
+        weights = 1.0 / (1.0 + jnp.sum(jnp.asarray(train_dataset.labels), axis=1))
         weights = weights / jnp.sum(weights)
 
         n_batches_per_epoch = len(train_dataset) // batch_size
@@ -419,7 +421,7 @@ class MLPClassifierSpace(PerturbationSpace):
             len(train_dataset), train_rng, batch_size, max_epochs * n_batches_per_epoch, weights
         )
 
-        best_val_loss = float("inf")
+        best_val_loss: float | jax.Array = float("inf")
         patience_counter = 0
 
         for epoch in range(max_epochs):
@@ -482,10 +484,10 @@ class MLPClassifierSpace(PerturbationSpace):
         aggregated = cell_embeddings.groupby(target_col, observed=True).mean()
 
         pert_adata = AnnData(X=aggregated.to_numpy(dtype=np.float32))
-        pert_adata.obs_names = aggregated.index.astype(str)
+        pert_adata.obs_names = aggregated.index.astype(str).tolist()
         pert_adata.obs[target_col] = pd.Categorical(aggregated.index.astype(str))
 
-        _carry_constant_obs(pert_adata, adata.obs, target_col)
-        pert_adata.obs[target_col] = pert_adata.obs[target_col].astype("category")
+        _carry_constant_obs(pert_adata, as_frame(adata.obs), target_col)
+        pert_adata.obs[target_col] = as_frame(pert_adata.obs)[target_col].astype("category")
 
         return pert_adata

--- a/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
@@ -17,7 +17,7 @@ from sklearn.linear_model import LogisticRegression  # type: ignore[import-untyp
 from sklearn.model_selection import train_test_split  # type: ignore[import-untyped]
 from sklearn.preprocessing import OneHotEncoder  # type: ignore[import-untyped]
 
-from pertpy._types import CSBase, as_dense, as_frame, as_matrix
+from pertpy._types import CSBase, cast_dense, cast_frame, cast_matrix
 from pertpy.tools._perturbation_space._perturbation_space import (
     PerturbationSpace,
     _carry_constant_obs,
@@ -79,13 +79,13 @@ class LRClassifierSpace(PerturbationSpace):
             raise ValueError(f"Column {target_col!r} does not exist in the .obs attribute.")
 
         if layer_key is not None:
-            regression_data = as_matrix(adata.layers[layer_key])
+            regression_data = cast_matrix(adata.layers[layer_key])
         elif embedding_key is not None:
-            regression_data = as_matrix(adata.obsm[embedding_key])
+            regression_data = cast_matrix(adata.obsm[embedding_key])
         else:
-            regression_data = as_matrix(adata.X)
+            regression_data = cast_matrix(adata.X)
 
-        regression_labels = as_frame(adata.obs)[target_col]
+        regression_labels = cast_frame(adata.obs)[target_col]
         random_state = _sklearn_random_state(random_state)
         regression_model = LogisticRegression(max_iter=max_iter, class_weight="balanced", random_state=random_state)
 
@@ -106,8 +106,8 @@ class LRClassifierSpace(PerturbationSpace):
         pert_adata.obs[target_col] = pd.Categorical(perturbations)
         pert_adata.obs["classifier_score"] = scores
 
-        _carry_constant_obs(pert_adata, as_frame(adata.obs), target_col)
-        pert_adata.obs[target_col] = as_frame(pert_adata.obs)[target_col].astype("category")
+        _carry_constant_obs(pert_adata, cast_frame(adata.obs), target_col)
+        pert_adata.obs[target_col] = cast_frame(pert_adata.obs)[target_col].astype("category")
 
         return pert_adata
 
@@ -234,17 +234,17 @@ class JAXDataset:
             label_col: key with the perturbation labels.
             layer_key: key of the layer to be used as data, otherwise .X.
         """
-        data = as_matrix(adata.layers[layer_key] if layer_key else adata.X)
+        data = cast_matrix(adata.layers[layer_key] if layer_key else adata.X)
 
         labels: np.ndarray
         if target_col in adata.obs.columns:
-            labels = np.asarray(as_frame(adata.obs)[target_col].values)
+            labels = np.asarray(cast_frame(adata.obs)[target_col].values)
         elif target_col in adata.obsm:
-            labels = as_dense(adata.obsm[target_col])
+            labels = cast_dense(adata.obsm[target_col])
         else:
             raise ValueError(f"Target column {target_col} not found in obs or obsm")
 
-        self.pert_labels = as_frame(adata.obs)[label_col].values
+        self.pert_labels = cast_frame(adata.obs)[label_col].values
 
         # Keep sparse data sparse and densify only the requested batch to avoid materializing the full dense matrix.
         self.is_sparse = isinstance(data, CSBase)
@@ -366,9 +366,9 @@ class MLPClassifierSpace(PerturbationSpace):
             hidden_dim = [512]
 
         if embedding_key is not None:
-            work = AnnData(X=as_dense(adata.obsm[embedding_key]))
+            work = AnnData(X=cast_dense(adata.obsm[embedding_key]))
             work.obs_names = adata.obs_names.tolist()
-            work.obs = as_frame(adata.obs).copy()
+            work.obs = cast_frame(adata.obs).copy()
             adata = work
             layer_key = None
         else:
@@ -487,7 +487,7 @@ class MLPClassifierSpace(PerturbationSpace):
         pert_adata.obs_names = aggregated.index.astype(str).tolist()
         pert_adata.obs[target_col] = pd.Categorical(aggregated.index.astype(str))
 
-        _carry_constant_obs(pert_adata, as_frame(adata.obs), target_col)
-        pert_adata.obs[target_col] = as_frame(pert_adata.obs)[target_col].astype("category")
+        _carry_constant_obs(pert_adata, cast_frame(adata.obs), target_col)
+        pert_adata.obs[target_col] = cast_frame(pert_adata.obs)[target_col].astype("category")
 
         return pert_adata

--- a/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
@@ -79,13 +79,13 @@ class LRClassifierSpace(PerturbationSpace):
             raise ValueError(f"Column {target_col!r} does not exist in the .obs attribute.")
 
         if layer_key is not None:
-            regression_data = cast_matrix(adata.layers[layer_key])
+            regression_data = adata.layers[layer_key]
         elif embedding_key is not None:
-            regression_data = cast_matrix(adata.obsm[embedding_key])
+            regression_data = adata.obsm[embedding_key]
         else:
             regression_data = cast_matrix(adata.X)
 
-        regression_labels = cast_frame(adata.obs)[target_col]
+        regression_labels = adata.obs[target_col]
         random_state = _sklearn_random_state(random_state)
         regression_model = LogisticRegression(max_iter=max_iter, class_weight="balanced", random_state=random_state)
 
@@ -234,17 +234,17 @@ class JAXDataset:
             label_col: key with the perturbation labels.
             layer_key: key of the layer to be used as data, otherwise .X.
         """
-        data = cast_matrix(adata.layers[layer_key] if layer_key else adata.X)
+        data = adata.layers[layer_key] if layer_key else adata.X
 
         labels: np.ndarray
         if target_col in adata.obs.columns:
-            labels = np.asarray(cast_frame(adata.obs)[target_col].values)
+            labels = np.asarray(adata.obs[target_col].values)
         elif target_col in adata.obsm:
             labels = cast_dense(adata.obsm[target_col])
         else:
             raise ValueError(f"Target column {target_col} not found in obs or obsm")
 
-        self.pert_labels = cast_frame(adata.obs)[label_col].values
+        self.pert_labels = adata.obs[label_col].values
 
         # Keep sparse data sparse and densify only the requested batch to avoid materializing the full dense matrix.
         self.is_sparse = isinstance(data, CSBase)
@@ -366,7 +366,7 @@ class MLPClassifierSpace(PerturbationSpace):
             hidden_dim = [512]
 
         if embedding_key is not None:
-            work = AnnData(X=cast_dense(adata.obsm[embedding_key]))
+            work = AnnData(X=adata.obsm[embedding_key])
             work.obs_names = adata.obs_names.tolist()
             work.obs = cast_frame(adata.obs).copy()
             adata = work

--- a/pertpy/tools/_perturbation_space/_metrics.py
+++ b/pertpy/tools/_perturbation_space/_metrics.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
-from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score, silhouette_score
+from sklearn.metrics import (  # type: ignore[import-untyped]
+    adjusted_rand_score,
+    normalized_mutual_info_score,
+    silhouette_score,
+)
 
 if TYPE_CHECKING:
     import numpy as np
@@ -50,8 +54,8 @@ def asw(
     pairwise_distances: ArrayLike,
     labels: ArrayLike,
     metric: str = "euclidean",
-    sample_size: int = None,
-    random_state: int = None,
+    sample_size: int | None = None,
+    random_state: int | None = None,
     **kwargs,
 ) -> float:
     """Computes the average-width silhouette score.

--- a/pertpy/tools/_perturbation_space/_perturbation_space.py
+++ b/pertpy/tools/_perturbation_space/_perturbation_space.py
@@ -10,6 +10,7 @@ from anndata import AnnData
 from scipy.stats import entropy
 
 from pertpy._logger import logger
+from pertpy._types import as_dense, as_frame
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -48,9 +49,12 @@ def _constant_obs_per_group(obs: pd.DataFrame, target_col: str) -> pd.DataFrame:
 
     Columns that vary within any group are dropped so the result can be safely mapped back onto a perturbation-level AnnData.
     """
-    grouped = obs.groupby(target_col, observed=True).agg(
-        lambda values: next(iter(set(values))) if len(set(values)) == 1 else np.nan
-    )
+
+    def _unique_or_nan(values: pd.Series) -> object:
+        unique = set(values)
+        return next(iter(unique)) if len(unique) == 1 else np.nan
+
+    grouped = obs.groupby(target_col, observed=True).agg(_unique_or_nan)
     return grouped.loc[:, ~grouped.isna().any()]
 
 
@@ -175,32 +179,32 @@ class PerturbationSpace:
 
         if layer_key:
             adata.layers[new_layer_key] = _subtract_control_mean(
-                adata.layers[layer_key], control_mask, group_masks, name=new_layer_key
+                as_dense(adata.layers[layer_key]), control_mask, group_masks, name=new_layer_key
             )
 
         if embedding_key:
             adata.obsm[new_embedding_key] = _subtract_control_mean(
-                adata.obsm[embedding_key], control_mask, group_masks, name=new_embedding_key
+                as_dense(adata.obsm[embedding_key]), control_mask, group_masks, name=new_embedding_key
             )
 
         if (not layer_key and not embedding_key) or all_data:
             adata.X = _subtract_control_mean(np.asarray(adata.X), control_mask, group_masks, name="X")
 
         if all_data:
-            for local_layer_key in list(adata.layers.keys()):
+            for local_layer_key in [key for key in adata.layers.keys() if isinstance(key, str)]:  # noqa: SIM118
                 if local_layer_key in {layer_key, new_layer_key}:
                     continue
                 new_key = local_layer_key + "_control_diff"
                 adata.layers[new_key] = _subtract_control_mean(
-                    adata.layers[local_layer_key], control_mask, group_masks, name=new_key
+                    as_dense(adata.layers[local_layer_key]), control_mask, group_masks, name=new_key
                 )
 
-            for local_embedding_key in list(adata.obsm.keys()):
+            for local_embedding_key in [key for key in adata.obsm if isinstance(key, str)]:
                 if local_embedding_key in {embedding_key, new_embedding_key}:
                     continue
                 new_key = local_embedding_key + "_control_diff"
                 adata.obsm[new_key] = _subtract_control_mean(
-                    adata.obsm[local_embedding_key], control_mask, group_masks, name=new_key
+                    as_dense(adata.obsm[local_embedding_key]), control_mask, group_masks, name=new_key
                 )
 
         self.control_diff_computed = True
@@ -212,7 +216,7 @@ class PerturbationSpace:
         adata: AnnData,
         *,
         perturbations: Iterable[str],
-        op: Callable[[np.ndarray, np.ndarray], np.ndarray],
+        op: Callable[[np.ndarray, np.ndarray], None],
         reference_key: str,
         new_pert_name: str,
         ensure_consistency: bool,
@@ -242,7 +246,7 @@ class PerturbationSpace:
         # sc.get.aggregate can leave a `None`-keyed layer behind (the pre-aggregation .X);
         # PseudobulkSpace.compute strips it but defensively re-strip here so callers passing
         # a hand-built AnnData don't crash inside the string ops below.
-        layer_keys = [k for k in adata.layers if isinstance(k, str)]
+        layer_keys = [k for k in adata.layers.keys() if isinstance(k, str)]  # noqa: SIM118
         obsm_keys = [k for k in adata.obsm if isinstance(k, str)]
         rename_back = (
             {
@@ -279,8 +283,8 @@ class PerturbationSpace:
 
         new_perturbation = AnnData(X=new_X)
         new_index = adata.obs_names.append(pd.Index([new_pert_name]))
-        new_perturbation.obs_names = new_index
-        new_perturbation.obs = adata.obs.reindex(new_index)
+        new_perturbation.obs_names = new_index.tolist()
+        new_perturbation.obs = as_frame(adata.obs).reindex(new_index)
 
         for key, value in new_layers.items():
             new_perturbation.layers[key] = value
@@ -425,12 +429,13 @@ class PerturbationSpace:
         if neighbors_key not in adata.uns:
             raise ValueError(f"Key {neighbors_key} not found in adata.uns. Please run `sc.pp.neighbors` first.")
 
-        labels = adata.obs[target_column].astype(str)
+        obs = as_frame(adata.obs)
+        labels = obs[target_column].astype(str)
         target_cells = labels == target_val
 
         connectivities = adata.obsp[adata.uns[neighbors_key]["connectivities_key"]]
         # convert labels to an incidence matrix
-        one_hot_encoded_labels = adata.obs[target_column].astype(str).str.get_dummies()
+        one_hot_encoded_labels = labels.str.get_dummies()
         # convert to distance-weighted neighborhood incidence matrix
         weighted_label_occurence = pd.DataFrame(
             (one_hot_encoded_labels.values.T * connectivities).T,
@@ -439,8 +444,8 @@ class PerturbationSpace:
         )
         # choose best label for each target cell
         best_labels = weighted_label_occurence.drop(target_val, axis=1)[target_cells].idxmax(axis=1)
-        adata.obs[target_column] = labels
-        adata.obs.loc[target_cells, target_column] = best_labels
+        obs[target_column] = labels
+        obs.loc[target_cells, target_column] = best_labels
 
         # calculate uncertainty
         uncertainty = np.zeros(adata.n_obs)
@@ -496,7 +501,7 @@ class PerturbationSpace:
         if layer_key is None and embedding_key is None and "distances" in adata.obsp:
             distances = np.asarray(adata.obsp["distances"])[query_idx]
         else:
-            from sklearn.metrics import pairwise_distances
+            from sklearn.metrics import pairwise_distances  # type: ignore[import-untyped]
 
             coords = _resolve_matrix(adata, layer_key=layer_key, embedding_key=embedding_key)
             distances = pairwise_distances(coords[[query_idx]], coords, metric=metric)[0]
@@ -614,8 +619,9 @@ class PerturbationSpace:
         from pertpy.tools._distances._distances import Distance
 
         sep = "\x1f"
-        is_control = (adata.obs[target_col] == reference_key).to_numpy()
-        group = adata.obs[target_col].astype(str).str.cat(adata.obs[dose_col].astype(str), sep=sep)
+        obs = as_frame(adata.obs)
+        is_control = (obs[target_col] == reference_key).to_numpy()
+        group = obs[target_col].astype(str).str.cat(obs[dose_col].astype(str), sep=sep)
         group = group.mask(is_control, reference_key)
         grouped = adata.copy()
         grouped.obs["_dose_group"] = pd.Categorical(group)
@@ -684,7 +690,7 @@ class PerturbationSpace:
         if layer_key is None and embedding_key is None and "distances" in adata.obsp:
             distances = np.asarray(adata.obsp["distances"])
         else:
-            from sklearn.metrics import pairwise_distances
+            from sklearn.metrics import pairwise_distances  # type: ignore[import-untyped]
 
             coords = _resolve_matrix(adata, layer_key=layer_key, embedding_key=embedding_key)
             distances = pairwise_distances(coords, metric=metric)

--- a/pertpy/tools/_perturbation_space/_perturbation_space.py
+++ b/pertpy/tools/_perturbation_space/_perturbation_space.py
@@ -10,7 +10,7 @@ from anndata import AnnData
 from scipy.stats import entropy
 
 from pertpy._logger import logger
-from pertpy._types import as_dense, as_frame
+from pertpy._types import cast_dense, cast_frame
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -179,12 +179,12 @@ class PerturbationSpace:
 
         if layer_key:
             adata.layers[new_layer_key] = _subtract_control_mean(
-                as_dense(adata.layers[layer_key]), control_mask, group_masks, name=new_layer_key
+                cast_dense(adata.layers[layer_key]), control_mask, group_masks, name=new_layer_key
             )
 
         if embedding_key:
             adata.obsm[new_embedding_key] = _subtract_control_mean(
-                as_dense(adata.obsm[embedding_key]), control_mask, group_masks, name=new_embedding_key
+                cast_dense(adata.obsm[embedding_key]), control_mask, group_masks, name=new_embedding_key
             )
 
         if (not layer_key and not embedding_key) or all_data:
@@ -196,7 +196,7 @@ class PerturbationSpace:
                     continue
                 new_key = local_layer_key + "_control_diff"
                 adata.layers[new_key] = _subtract_control_mean(
-                    as_dense(adata.layers[local_layer_key]), control_mask, group_masks, name=new_key
+                    cast_dense(adata.layers[local_layer_key]), control_mask, group_masks, name=new_key
                 )
 
             for local_embedding_key in [key for key in adata.obsm if isinstance(key, str)]:
@@ -204,7 +204,7 @@ class PerturbationSpace:
                     continue
                 new_key = local_embedding_key + "_control_diff"
                 adata.obsm[new_key] = _subtract_control_mean(
-                    as_dense(adata.obsm[local_embedding_key]), control_mask, group_masks, name=new_key
+                    cast_dense(adata.obsm[local_embedding_key]), control_mask, group_masks, name=new_key
                 )
 
         self.control_diff_computed = True
@@ -284,7 +284,7 @@ class PerturbationSpace:
         new_perturbation = AnnData(X=new_X)
         new_index = adata.obs_names.append(pd.Index([new_pert_name]))
         new_perturbation.obs_names = new_index.tolist()
-        new_perturbation.obs = as_frame(adata.obs).reindex(new_index)
+        new_perturbation.obs = cast_frame(adata.obs).reindex(new_index)
 
         for key, value in new_layers.items():
             new_perturbation.layers[key] = value
@@ -429,7 +429,7 @@ class PerturbationSpace:
         if neighbors_key not in adata.uns:
             raise ValueError(f"Key {neighbors_key} not found in adata.uns. Please run `sc.pp.neighbors` first.")
 
-        obs = as_frame(adata.obs)
+        obs = cast_frame(adata.obs)
         labels = obs[target_column].astype(str)
         target_cells = labels == target_val
 
@@ -619,7 +619,7 @@ class PerturbationSpace:
         from pertpy.tools._distances._distances import Distance
 
         sep = "\x1f"
-        obs = as_frame(adata.obs)
+        obs = cast_frame(adata.obs)
         is_control = (obs[target_col] == reference_key).to_numpy()
         group = obs[target_col].astype(str).str.cat(obs[dose_col].astype(str), sep=sep)
         group = group.mask(is_control, reference_key)

--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -9,7 +9,7 @@ from anndata import AnnData
 from sklearn.cluster import HDBSCAN, KMeans  # type: ignore[import-untyped]
 
 from pertpy._logger import logger
-from pertpy._types import cast_dense, cast_frame
+from pertpy._types import cast_frame
 from pertpy.tools._perturbation_space._clustering import ClusteringSpace
 from pertpy.tools._perturbation_space._perturbation_space import (
     PerturbationSpace,
@@ -134,7 +134,7 @@ class PseudobulkSpace(PerturbationSpace):
         if embedding_key is not None:
             if embedding_key not in adata.obsm:
                 raise ValueError(f"Embedding {embedding_key!r} does not exist in the .obsm attribute.")
-            adata_emb = AnnData(X=cast_dense(adata.obsm[embedding_key]))
+            adata_emb = AnnData(X=adata.obsm[embedding_key])
             adata_emb.obs_names = adata.obs_names.tolist()
             adata_emb.obs = cast_frame(adata.obs).copy()
             adata = adata_emb

--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -4,11 +4,12 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from anndata import AnnData
-from sklearn.cluster import HDBSCAN, KMeans
+from sklearn.cluster import HDBSCAN, KMeans  # type: ignore[import-untyped]
 
 from pertpy._logger import logger
+from pertpy._types import as_dense, as_frame
 from pertpy.tools._perturbation_space._clustering import ClusteringSpace
 from pertpy.tools._perturbation_space._perturbation_space import (
     PerturbationSpace,
@@ -64,8 +65,8 @@ class CentroidSpace(PerturbationSpace):
 
         coords = _resolve_matrix(adata, layer_key=layer_key, embedding_key=embedding_key)
 
-        groups = adata.obs.groupby(target_col, observed=True)
-        index = list(groups.groups.keys())
+        groups = as_frame(adata.obs).groupby(target_col, observed=True)
+        index = [str(key) for key in groups.groups]
         X = np.empty((len(index), coords.shape[1]), dtype=coords.dtype)
         for pert_index, (_, group_data) in enumerate(groups):
             row_idx = adata.obs_names.get_indexer(group_data.index)
@@ -82,9 +83,9 @@ class CentroidSpace(PerturbationSpace):
             ps_adata.obsm[embedding_key] = X
 
         if keep_obs:
-            _carry_constant_obs(ps_adata, adata.obs, target_col)
+            _carry_constant_obs(ps_adata, as_frame(adata.obs), target_col)
 
-        ps_adata.obs[target_col] = ps_adata.obs[target_col].astype("category")
+        ps_adata.obs[target_col] = as_frame(ps_adata.obs)[target_col].astype("category")
 
         return ps_adata
 
@@ -133,15 +134,15 @@ class PseudobulkSpace(PerturbationSpace):
         if embedding_key is not None:
             if embedding_key not in adata.obsm:
                 raise ValueError(f"Embedding {embedding_key!r} does not exist in the .obsm attribute.")
-            adata_emb = AnnData(X=adata.obsm[embedding_key])
-            adata_emb.obs_names = adata.obs_names
-            adata_emb.obs = adata.obs.copy()
+            adata_emb = AnnData(X=as_dense(adata.obsm[embedding_key]))
+            adata_emb.obs_names = adata.obs_names.tolist()
+            adata_emb.obs = as_frame(adata.obs).copy()
             adata = adata_emb
         else:
             adata = adata.copy()
-        adata.obs[target_col] = adata.obs[target_col].astype("category")
+        adata.obs[target_col] = as_frame(adata.obs)[target_col].astype("category")
         grouping_cols = [target_col] if groups_col is None else [target_col, groups_col]
-        original_obs = adata.obs.copy()
+        original_obs = as_frame(adata.obs).copy()
         ps_adata = sc.get.aggregate(adata, by=grouping_cols, func=mode, layer=layer_key)
 
         if None in ps_adata.layers:
@@ -215,7 +216,7 @@ class DistanceSpace(PerturbationSpace):
         if isinstance(df, tuple):
             df = df[0]
 
-        index = df.index.astype(str)
+        index = df.index.astype(str).tolist()
         matrix = df.to_numpy(dtype=float)
         ps_adata = AnnData(X=matrix)
         ps_adata.obs_names = index
@@ -223,8 +224,8 @@ class DistanceSpace(PerturbationSpace):
         ps_adata.obsp["distances"] = matrix
         ps_adata.obs[target_col] = pd.Categorical(df.index)
 
-        _carry_constant_obs(ps_adata, adata.obs, target_col)
-        ps_adata.obs[target_col] = ps_adata.obs[target_col].astype("category")
+        _carry_constant_obs(ps_adata, as_frame(adata.obs), target_col)
+        ps_adata.obs[target_col] = as_frame(ps_adata.obs)[target_col].astype("category")
 
         return ps_adata
 
@@ -282,11 +283,11 @@ class EmbeddingSpace(PerturbationSpace):
 
         emb_df = emb_df.loc[keep]
         ps_adata = AnnData(X=emb_df.to_numpy(dtype=float))
-        ps_adata.obs_names = keep
+        ps_adata.obs_names = keep.tolist()
         ps_adata.obs[target_col] = pd.Categorical(keep)
 
-        _carry_constant_obs(ps_adata, adata.obs, target_col)
-        ps_adata.obs[target_col] = ps_adata.obs[target_col].astype("category")
+        _carry_constant_obs(ps_adata, as_frame(adata.obs), target_col)
+        ps_adata.obs[target_col] = as_frame(ps_adata.obs)[target_col].astype("category")
 
         return ps_adata
 

--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -9,7 +9,7 @@ from anndata import AnnData
 from sklearn.cluster import HDBSCAN, KMeans  # type: ignore[import-untyped]
 
 from pertpy._logger import logger
-from pertpy._types import as_dense, as_frame
+from pertpy._types import cast_dense, cast_frame
 from pertpy.tools._perturbation_space._clustering import ClusteringSpace
 from pertpy.tools._perturbation_space._perturbation_space import (
     PerturbationSpace,
@@ -65,7 +65,7 @@ class CentroidSpace(PerturbationSpace):
 
         coords = _resolve_matrix(adata, layer_key=layer_key, embedding_key=embedding_key)
 
-        groups = as_frame(adata.obs).groupby(target_col, observed=True)
+        groups = cast_frame(adata.obs).groupby(target_col, observed=True)
         index = [str(key) for key in groups.groups]
         X = np.empty((len(index), coords.shape[1]), dtype=coords.dtype)
         for pert_index, (_, group_data) in enumerate(groups):
@@ -83,9 +83,9 @@ class CentroidSpace(PerturbationSpace):
             ps_adata.obsm[embedding_key] = X
 
         if keep_obs:
-            _carry_constant_obs(ps_adata, as_frame(adata.obs), target_col)
+            _carry_constant_obs(ps_adata, cast_frame(adata.obs), target_col)
 
-        ps_adata.obs[target_col] = as_frame(ps_adata.obs)[target_col].astype("category")
+        ps_adata.obs[target_col] = cast_frame(ps_adata.obs)[target_col].astype("category")
 
         return ps_adata
 
@@ -134,15 +134,15 @@ class PseudobulkSpace(PerturbationSpace):
         if embedding_key is not None:
             if embedding_key not in adata.obsm:
                 raise ValueError(f"Embedding {embedding_key!r} does not exist in the .obsm attribute.")
-            adata_emb = AnnData(X=as_dense(adata.obsm[embedding_key]))
+            adata_emb = AnnData(X=cast_dense(adata.obsm[embedding_key]))
             adata_emb.obs_names = adata.obs_names.tolist()
-            adata_emb.obs = as_frame(adata.obs).copy()
+            adata_emb.obs = cast_frame(adata.obs).copy()
             adata = adata_emb
         else:
             adata = adata.copy()
-        adata.obs[target_col] = as_frame(adata.obs)[target_col].astype("category")
+        adata.obs[target_col] = cast_frame(adata.obs)[target_col].astype("category")
         grouping_cols = [target_col] if groups_col is None else [target_col, groups_col]
-        original_obs = as_frame(adata.obs).copy()
+        original_obs = cast_frame(adata.obs).copy()
         ps_adata = sc.get.aggregate(adata, by=grouping_cols, func=mode, layer=layer_key)
 
         if None in ps_adata.layers:
@@ -224,8 +224,8 @@ class DistanceSpace(PerturbationSpace):
         ps_adata.obsp["distances"] = matrix
         ps_adata.obs[target_col] = pd.Categorical(df.index)
 
-        _carry_constant_obs(ps_adata, as_frame(adata.obs), target_col)
-        ps_adata.obs[target_col] = as_frame(ps_adata.obs)[target_col].astype("category")
+        _carry_constant_obs(ps_adata, cast_frame(adata.obs), target_col)
+        ps_adata.obs[target_col] = cast_frame(ps_adata.obs)[target_col].astype("category")
 
         return ps_adata
 
@@ -286,8 +286,8 @@ class EmbeddingSpace(PerturbationSpace):
         ps_adata.obs_names = keep.tolist()
         ps_adata.obs[target_col] = pd.Categorical(keep)
 
-        _carry_constant_obs(ps_adata, as_frame(adata.obs), target_col)
-        ps_adata.obs[target_col] = as_frame(ps_adata.obs)[target_col].astype("category")
+        _carry_constant_obs(ps_adata, cast_frame(adata.obs), target_col)
+        ps_adata.obs[target_col] = cast_frame(ps_adata.obs)[target_col].astype("category")
 
         return ps_adata
 

--- a/pertpy/tools/_scgen/_base_components.py
+++ b/pertpy/tools/_scgen/_base_components.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 from flax import linen as nn
 
 if TYPE_CHECKING:
+    import jax
     import jaxlib
 
 
@@ -23,7 +24,7 @@ class FlaxEncoder(nn.Module):
     var_eps: float = 1e-4
 
     @nn.compact
-    def __call__(self, x: jnp.ndarray, training: bool | None = None) -> tuple[float, float]:
+    def __call__(self, x: jnp.ndarray, training: bool | None = None) -> tuple[jax.Array, jax.Array]:
         """Forward pass.
 
         Args:

--- a/pertpy/tools/_scgen/_jax.py
+++ b/pertpy/tools/_scgen/_jax.py
@@ -105,7 +105,7 @@ def _parse_jax_device(
     return jax.devices(_accelerator)[device_idx]
 
 
-def flax_configure(cls: nn.Module) -> Callable:
+def flax_configure[ModuleT: nn.Module](cls: type[ModuleT]) -> type[ModuleT]:
     """Decorator to raise an error if a boolean `training` param is missing in the call."""
     original_init = cls.__init__
 
@@ -116,7 +116,7 @@ def flax_configure(cls: nn.Module) -> Callable:
         if not isinstance(self.training, bool):
             raise ValueError("Custom sublclasses must have a training parameter.")
 
-    cls.__init__ = init
+    cls.__init__ = init  # type: ignore[method-assign]
     return cls
 
 

--- a/pertpy/tools/_scgen/_scgen.py
+++ b/pertpy/tools/_scgen/_scgen.py
@@ -20,7 +20,7 @@ from scvi.utils import setup_anndata_dsp  # type: ignore[import-untyped,import-n
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
-from pertpy._types import as_frame, as_matrix
+from pertpy._types import cast_frame, cast_matrix
 
 from ._jax import JaxTrainingMixin
 from ._scgenvae import JaxSCGENVAE
@@ -221,7 +221,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
         batch_key = self.adata_manager.get_state_registry(REGISTRY_KEYS.BATCH_KEY).original_key
 
         adata_latent = AnnData(latent_all)
-        adata_latent.obs = as_frame(adata.obs).copy(deep=True)
+        adata_latent.obs = cast_frame(adata.obs).copy(deep=True)
         unique_cell_types = np.unique(adata_latent.obs[cell_label_key])
         shared_ct = []
         not_shared_ct = []
@@ -255,11 +255,11 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
 
         all_shared_ann = ad.concat(shared_ct, label="concat_batch", index_unique=None)
         if "concat_batch" in all_shared_ann.obs.columns:
-            del as_frame(all_shared_ann.obs)["concat_batch"]
+            del cast_frame(all_shared_ann.obs)["concat_batch"]
         if len(not_shared_ct) < 1:
             corrected = AnnData(
                 np.array(self.module.as_bound().generative(all_shared_ann.X)["px"]),
-                obs=as_frame(all_shared_ann.obs),
+                obs=cast_frame(all_shared_ann.obs),
             )
             corrected.var_names = adata.var_names.tolist()
             corrected = corrected[adata.obs_names].copy()
@@ -267,7 +267,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
                 adata_raw = AnnData(X=adata.raw.X, var=adata.raw.var)
                 adata_raw.obs_names = adata.obs_names.tolist()
                 corrected.raw = adata_raw
-            corrected.obsm["latent"] = as_matrix(all_shared_ann.X)
+            corrected.obsm["latent"] = cast_matrix(all_shared_ann.X)
             corrected.obsm["corrected_latent"] = self.get_latent_representation(corrected)
             return corrected
         else:
@@ -276,10 +276,10 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
                 [all_shared_ann, all_not_shared_ann], label="concat_batch", index_unique=None
             )
             if "concat_batch" in all_corrected_data.obs.columns:
-                del as_frame(all_corrected_data.obs)["concat_batch"]
+                del cast_frame(all_corrected_data.obs)["concat_batch"]
             corrected = AnnData(
                 np.array(self.module.as_bound().generative(all_corrected_data.X)["px"]),
-                obs=as_frame(all_corrected_data.obs),
+                obs=cast_frame(all_corrected_data.obs),
             )
             corrected.var_names = adata.var_names.tolist()
             corrected = corrected[adata.obs_names].copy()
@@ -287,7 +287,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
                 adata_raw = AnnData(X=adata.raw.X, var=adata.raw.var)
                 adata_raw.obs_names = adata.obs_names.tolist()
                 corrected.raw = adata_raw
-            corrected.obsm["latent"] = as_matrix(all_corrected_data.X)
+            corrected.obsm["latent"] = cast_matrix(all_corrected_data.X)
             corrected.obsm["corrected_latent"] = self.get_latent_representation(corrected)
 
             return corrected

--- a/pertpy/tools/_scgen/_scgen.py
+++ b/pertpy/tools/_scgen/_scgen.py
@@ -271,16 +271,11 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
             corrected.obsm["corrected_latent"] = self.get_latent_representation(corrected)
             return corrected
         else:
-            all_not_shared_ann = AnnData.concatenate(  # type: ignore[attr-defined]
-                *not_shared_ct, batch_key="concat_batch", index_unique=None
+            all_not_shared_ann = ad.concat(not_shared_ct, label="concat_batch", index_unique=None)
+            all_corrected_data = ad.concat(
+                [all_shared_ann, all_not_shared_ann], label="concat_batch", index_unique=None
             )
-            all_corrected_data = AnnData.concatenate(  # type: ignore[attr-defined]
-                all_shared_ann,
-                all_not_shared_ann,
-                batch_key="concat_batch",
-                index_unique=None,
-            )
-            if "concat_batch" in all_shared_ann.obs.columns:
+            if "concat_batch" in all_corrected_data.obs.columns:
                 del as_frame(all_corrected_data.obs)["concat_batch"]
             corrected = AnnData(
                 np.array(self.module.as_bound().generative(all_corrected_data.X)["px"]),

--- a/pertpy/tools/_scgen/_scgen.py
+++ b/pertpy/tools/_scgen/_scgen.py
@@ -1,25 +1,26 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import anndata as ad
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import scanpy as sc
-from adjustText import adjust_text
+import scanpy as sc  # type: ignore[import-untyped]
+from adjustText import adjust_text  # type: ignore[import-untyped]
 from anndata import AnnData
 from jax import Array
 from scipy import stats
-from scvi import REGISTRY_KEYS
-from scvi.data import AnnDataManager
-from scvi.data.fields import CategoricalObsField, LayerField
-from scvi.model.base import BaseModelClass
-from scvi.utils import setup_anndata_dsp
+from scvi import REGISTRY_KEYS  # type: ignore[import-untyped,import-not-found]
+from scvi.data import AnnDataManager  # type: ignore[import-untyped,import-not-found]
+from scvi.data.fields import CategoricalObsField, LayerField  # type: ignore[import-untyped,import-not-found]
+from scvi.model.base import BaseModelClass  # type: ignore[import-untyped,import-not-found]
+from scvi.utils import setup_anndata_dsp  # type: ignore[import-untyped,import-not-found]
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
+from pertpy._types import as_frame, as_matrix
 
 from ._jax import JaxTrainingMixin
 from ._scgenvae import JaxSCGENVAE
@@ -220,7 +221,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
         batch_key = self.adata_manager.get_state_registry(REGISTRY_KEYS.BATCH_KEY).original_key
 
         adata_latent = AnnData(latent_all)
-        adata_latent.obs = adata.obs.copy(deep=True)
+        adata_latent.obs = as_frame(adata.obs).copy(deep=True)
         unique_cell_types = np.unique(adata_latent.obs[cell_label_key])
         shared_ct = []
         not_shared_ct = []
@@ -254,42 +255,44 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
 
         all_shared_ann = ad.concat(shared_ct, label="concat_batch", index_unique=None)
         if "concat_batch" in all_shared_ann.obs.columns:
-            del all_shared_ann.obs["concat_batch"]
+            del as_frame(all_shared_ann.obs)["concat_batch"]
         if len(not_shared_ct) < 1:
             corrected = AnnData(
                 np.array(self.module.as_bound().generative(all_shared_ann.X)["px"]),
-                obs=all_shared_ann.obs,
+                obs=as_frame(all_shared_ann.obs),
             )
             corrected.var_names = adata.var_names.tolist()
             corrected = corrected[adata.obs_names].copy()
             if adata.raw is not None:
                 adata_raw = AnnData(X=adata.raw.X, var=adata.raw.var)
-                adata_raw.obs_names = adata.obs_names
+                adata_raw.obs_names = adata.obs_names.tolist()
                 corrected.raw = adata_raw
-            corrected.obsm["latent"] = all_shared_ann.X
+            corrected.obsm["latent"] = as_matrix(all_shared_ann.X)
             corrected.obsm["corrected_latent"] = self.get_latent_representation(corrected)
             return corrected
         else:
-            all_not_shared_ann = AnnData.concatenate(*not_shared_ct, batch_key="concat_batch", index_unique=None)
-            all_corrected_data = AnnData.concatenate(
+            all_not_shared_ann = AnnData.concatenate(  # type: ignore[attr-defined]
+                *not_shared_ct, batch_key="concat_batch", index_unique=None
+            )
+            all_corrected_data = AnnData.concatenate(  # type: ignore[attr-defined]
                 all_shared_ann,
                 all_not_shared_ann,
                 batch_key="concat_batch",
                 index_unique=None,
             )
             if "concat_batch" in all_shared_ann.obs.columns:
-                del all_corrected_data.obs["concat_batch"]
+                del as_frame(all_corrected_data.obs)["concat_batch"]
             corrected = AnnData(
                 np.array(self.module.as_bound().generative(all_corrected_data.X)["px"]),
-                obs=all_corrected_data.obs,
+                obs=as_frame(all_corrected_data.obs),
             )
             corrected.var_names = adata.var_names.tolist()
             corrected = corrected[adata.obs_names].copy()
             if adata.raw is not None:
                 adata_raw = AnnData(X=adata.raw.X, var=adata.raw.var)
-                adata_raw.obs_names = adata.obs_names
+                adata_raw.obs_names = adata.obs_names.tolist()
                 corrected.raw = adata_raw
-            corrected.obsm["latent"] = all_corrected_data.X
+            corrected.obsm["latent"] = as_matrix(all_corrected_data.X)
             corrected.obsm["corrected_latent"] = self.get_latent_representation(corrected)
 
             return corrected
@@ -368,15 +371,13 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
 
         jit_inference_fn = self.module.get_jit_inference_fn(inference_kwargs={"n_samples": n_samples})
 
-        latent = []
+        latent: list[Array] = []
         for array_dict in scdl:
             out = jit_inference_fn(self.module.rngs, array_dict)
-            z = out["qz"].mean if give_mean else out["z"]
-            latent.append(z)
+            latent.append(cast("Array", out["qz"].mean if give_mean else out["z"]))
         concat_axis = 0 if ((n_samples == 1) or give_mean) else 1
-        latent = jnp.concatenate(latent, axis=concat_axis)  # type: ignore
 
-        return self.module.as_numpy_array(latent)
+        return self.module.as_numpy_array(jnp.concatenate(latent, axis=concat_axis))
 
     def plot_reg_mean_plot(  # pragma: no cover # noqa: D417
         self,
@@ -389,7 +390,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
         top_100_genes: list[str] | None = None,
         verbose: bool = False,
         legend: bool = True,
-        title: str = None,
+        title: str | None = None,
         x_coeff: float = 0.30,
         y_coeff: float = 0.8,
         fontsize: float = 14,
@@ -467,7 +468,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
         ax = sns.regplot(x=axis_keys["x"], y=axis_keys["y"], data=df)
         ax.tick_params(labelsize=fontsize)
         if "range" in kwargs:
-            start, stop, step = kwargs.get("range")
+            start, stop, step = kwargs["range"]
             ax.set_xticks(np.arange(start, stop, step))
             ax.set_yticks(np.arange(start, stop, step))
         ax.set_xlabel(labels["x"], fontsize=fontsize)
@@ -511,7 +512,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
                 fontsize=kwargs.get("textsize", fontsize),
             )
 
-        if save:
+        if isinstance(save, str):
             plt.savefig(save, bbox_inches="tight")
         if show:
             plt.show()
@@ -528,10 +529,10 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
         axis_keys: dict[str, str],
         labels: dict[str, str],
         *,
-        gene_list: list[str] = None,
-        top_100_genes: list[str] = None,
+        gene_list: list[str] | None = None,
+        top_100_genes: list[str] | None = None,
         legend: bool = True,
-        title: str = None,
+        title: str | None = None,
         verbose: bool = False,
         x_coeff: float = 0.3,
         y_coeff: float = 0.8,
@@ -592,7 +593,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
         ax = sns.regplot(x=axis_keys["x"], y=axis_keys["y"], data=df)
         ax.tick_params(labelsize=fontsize)
         if "range" in kwargs:
-            start, stop, step = kwargs.get("range")
+            start, stop, step = kwargs["range"]
             ax.set_xticks(np.arange(start, stop, step))
             ax.set_yticks(np.arange(start, stop, step))
         # _p1 = plt.scatter(x, y, marker=".", label=f"{axis_keys['x']}-{axis_keys['y']}")
@@ -639,7 +640,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
                 fontsize=kwargs.get("textsize", fontsize),
             )
 
-        if save:
+        if isinstance(save, str):
             plt.savefig(save, bbox_inches="tight")
         if show:
             plt.show()
@@ -686,8 +687,8 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
         condition_key = scgen.adata_manager.get_state_registry(REGISTRY_KEYS.BATCH_KEY).original_key
         cd = adata[adata.obs[condition_key] == ctrl_key, :]
         stim = adata[adata.obs[condition_key] == stim_key, :]
-        all_latent_cd = scgen.get_latent_representation(cd.X)
-        all_latent_stim = scgen.get_latent_representation(stim.X)
+        all_latent_cd = scgen.get_latent_representation(cd.X)  # type: ignore[arg-type]
+        all_latent_stim = scgen.get_latent_representation(stim.X)  # type: ignore[arg-type]
         dot_cd = np.zeros(len(all_latent_cd))
         dot_sal = np.zeros(len(all_latent_stim))
         for ind, vec in enumerate(all_latent_cd):

--- a/pertpy/tools/_scgen/_scgenvae.py
+++ b/pertpy/tools/_scgen/_scgenvae.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import flax.linen as nn
 import jax.numpy as jnp
-import numpyro.distributions as dist
-from scvi import REGISTRY_KEYS
+import numpyro.distributions as dist  # type: ignore[import-untyped]
+from scvi import REGISTRY_KEYS  # type: ignore[import-untyped,import-not-found]
 
 from ._base_components import FlaxDecoder, FlaxEncoder
 from ._jax import JaxBaseModuleClass, LossOutput, flax_configure

--- a/pertpy/tools/core.py
+++ b/pertpy/tools/core.py
@@ -1,18 +1,15 @@
 import numpy as np
-from scipy import sparse
+
+from pertpy._types import CSBase
 
 
-def _is_raw_counts(X: np.ndarray | sparse.spmatrix) -> bool:
+def _is_raw_counts(X: np.ndarray | CSBase) -> bool:
     """Check if data appears to be raw counts."""
-    if sparse.issparse(X):
-        sample = X[:1000, :1000] if X.shape[0] > 1000 else X
-        data = sample.data
-    else:
-        sample = X[:1000, :1000] if X.shape[0] > 1000 else X
-        data = sample.ravel()
+    sample = X[:1000, :1000] if X.shape[0] > 1000 else X
+    data = sample.ravel() if isinstance(sample, np.ndarray) else sample.data
 
     non_zero_data = data[data > 0]
     if len(non_zero_data) == 0:
         return True
 
-    return np.all(data >= 0) and np.all(data == np.round(data))
+    return bool(np.all(data >= 0) and np.all(data == np.round(data)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "blitzgsea",
     "scikit-learn>=1.4",
     "fast-array-utils[accel,sparse]",
-    "arviz>=1.0.0",
+    "arviz>=1.2.0",
     "pooch",
     "scverse-misc"
 ]
@@ -89,7 +89,14 @@ all = [
     "pertpy[tcoda,de,scgen]"
 ]
 dev = [
+    "joblib-stubs",
+    "mypy",
+    "pandas-stubs",
     "pre-commit",
+    "scipy-stubs",
+    "types-requests",
+    "types-seaborn",
+    "types-tqdm",
 ]
 doc = [
     "docutils>=0.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Visualization",
+    "Typing :: Typed",
 ]
 
 dependencies = [

--- a/tests/metadata/test_cell_line.py
+++ b/tests/metadata/test_cell_line.py
@@ -30,8 +30,7 @@ def adata() -> AnnData:
     var_data = {"gene_name": [f"gene{i}" for i in range(1, NUM_GENES + 1)]}
     var = pd.DataFrame(var_data).set_index("gene_name", drop=False).rename_axis("index")
 
-    X = sparse.csr_matrix(X)
-    adata = anndata.AnnData(X=X, obs=obs, var=var)
+    adata = anndata.AnnData(X=sparse.csr_matrix(X), obs=obs, var=var)
 
     return adata
 

--- a/tests/metadata/test_compound.py
+++ b/tests/metadata/test_compound.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from anndata import AnnData
-from pubchempy import PubChemHTTPError
+from pubchempy import PubChemHTTPError  # type: ignore[import-untyped]
 from scipy import sparse
 
 import pertpy as pt
@@ -35,8 +35,7 @@ def adata() -> AnnData:
     var_data = {"gene_name": [f"gene{i}" for i in range(1, NUM_GENES + 1)]}
     var = pd.DataFrame(var_data).set_index("gene_name", drop=False).rename_axis("index")
 
-    X = sparse.csr_matrix(X)
-    adata = anndata.AnnData(X=X, obs=obs, var=var)
+    adata = anndata.AnnData(X=sparse.csr_matrix(X), obs=obs, var=var)
 
     return adata
 

--- a/tests/metadata/test_metadata.py
+++ b/tests/metadata/test_metadata.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from scanpy import settings
+from scanpy import settings  # type: ignore[import-untyped]
 
 from pertpy.metadata._metadata import MetaData
 

--- a/tests/metadata/test_moa.py
+++ b/tests/metadata/test_moa.py
@@ -32,8 +32,7 @@ def adata() -> AnnData:
     var_data = {"gene_name": [f"gene{i}" for i in range(1, NUM_GENES + 1)]}
     var = pd.DataFrame(var_data).set_index("gene_name", drop=False).rename_axis("index")
 
-    X = sparse.csr_matrix(X)
-    adata = anndata.AnnData(X=X, obs=obs, var=var)
+    adata = anndata.AnnData(X=sparse.csr_matrix(X), obs=obs, var=var)
 
     return adata
 

--- a/tests/tools/_coda/test_sccoda.py
+++ b/tests/tools/_coda/test_sccoda.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
-import scanpy as sc
-from mudata import MuData
+import scanpy as sc  # type: ignore[import-untyped]
+from mudata import MuData  # type: ignore[import-untyped]
 from xarray import DataTree
 
 import pertpy as pt

--- a/tests/tools/_coda/test_tasccoda.py
+++ b/tests/tools/_coda/test_tasccoda.py
@@ -2,11 +2,11 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import scanpy as sc
-from mudata import MuData
+import scanpy as sc  # type: ignore[import-untyped]
+from mudata import MuData  # type: ignore[import-untyped]
 
 try:
-    import ete4
+    import ete4  # type: ignore[import-untyped]
 except ImportError:
     pytest.skip("ete4 not available", allow_module_level=True)
 

--- a/tests/tools/_differential_gene_expression/conftest.py
+++ b/tests/tools/_differential_gene_expression/conftest.py
@@ -14,7 +14,7 @@ def test_counts():
     if not PYDESEQ2_AVAILABLE:
         pytest.skip("pydeseq2 not available")
 
-    from pydeseq2.utils import load_example_data
+    from pydeseq2.utils import load_example_data  # type: ignore[import-untyped]
 
     return load_example_data(
         modality="raw_counts",
@@ -28,7 +28,7 @@ def test_metadata():
     if not PYDESEQ2_AVAILABLE:
         pytest.skip("pydeseq2 not available")
 
-    from pydeseq2.utils import load_example_data
+    from pydeseq2.utils import load_example_data  # type: ignore[import-untyped]
 
     return load_example_data(
         modality="metadata",

--- a/tests/tools/_differential_gene_expression/test_base.py
+++ b/tests/tools/_differential_gene_expression/test_base.py
@@ -22,7 +22,7 @@ def MockLinearModel():
             pass
 
         def _test_single_contrast(self, contrast: Sequence[float], **kwargs) -> DataFrame:
-            pass
+            return DataFrame()
 
     return _MockLinearModel
 

--- a/tests/tools/_differential_gene_expression/test_edger.py
+++ b/tests/tools/_differential_gene_expression/test_edger.py
@@ -4,7 +4,7 @@ import pytest
 from pertpy.tools._differential_gene_expression import EdgeR
 
 try:
-    from rpy2.robjects.packages import importr
+    from rpy2.robjects.packages import importr  # type: ignore[import-untyped,import-not-found]
 
     r_dependency = importr("edgeR")
 except Exception:  # noqa: BLE001

--- a/tests/tools/_differential_gene_expression/test_statsmodels.py
+++ b/tests/tools/_differential_gene_expression/test_statsmodels.py
@@ -2,7 +2,7 @@ from importlib.util import find_spec
 
 import numpy as np
 import pytest
-import statsmodels.api as sm
+import statsmodels.api as sm  # type: ignore[import-untyped]
 
 if find_spec("formulaic_contrasts") is None or find_spec("formulaic") is None:
     pytestmark = pytest.mark.skip(reason="formulaic_contrasts and formulaic not available")

--- a/tests/tools/_distances/test_distance_tests.py
+++ b/tests/tools/_distances/test_distance_tests.py
@@ -1,5 +1,5 @@
 import pytest
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from anndata import AnnData
 from pandas import DataFrame
 

--- a/tests/tools/_distances/test_distances.py
+++ b/tests/tools/_distances/test_distances.py
@@ -7,7 +7,7 @@ from pandas import DataFrame, Series
 from pytest import fixture, mark
 
 import pertpy as pt
-from pertpy._types import as_matrix
+from pertpy._types import cast_matrix
 from pertpy.tools._distances._distances import Distance, Metric
 
 actual_distances: tuple[Metric, ...] = (
@@ -64,7 +64,7 @@ def adata(distance: Metric, rng: np.random.Generator) -> AnnData:
 
     adata = adata[:, rng.choice(adata.n_vars, 100, replace=False)].copy()
 
-    X = as_matrix(adata.X)
+    X = cast_matrix(adata.X)
     adata.layers["lognorm"] = X.copy()
     adata.layers["counts"] = np.round(to_dense(X)).astype(int)
     if "X_pca" not in adata.obsm:

--- a/tests/tools/_distances/test_distances.py
+++ b/tests/tools/_distances/test_distances.py
@@ -1,11 +1,13 @@
 import numpy as np
 import pytest
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from anndata import AnnData
+from fast_array_utils.conv import to_dense
 from pandas import DataFrame, Series
 from pytest import fixture, mark
 
 import pertpy as pt
+from pertpy._types import as_matrix
 from pertpy.tools._distances._distances import Distance, Metric
 
 actual_distances: tuple[Metric, ...] = (
@@ -62,8 +64,9 @@ def adata(distance: Metric, rng: np.random.Generator) -> AnnData:
 
     adata = adata[:, rng.choice(adata.n_vars, 100, replace=False)].copy()
 
-    adata.layers["lognorm"] = adata.X.copy()
-    adata.layers["counts"] = np.round(adata.X.toarray()).astype(int)
+    X = as_matrix(adata.X)
+    adata.layers["lognorm"] = X.copy()
+    adata.layers["counts"] = np.round(to_dense(X)).astype(int)
     if "X_pca" not in adata.obsm:
         sc.pp.pca(adata, n_comps=5)
     if distance in lognorm_counts_distances:
@@ -84,7 +87,7 @@ def distance_obj(distance: Metric) -> pt.tl.Distance:
 
 
 @fixture
-def pairwise_distance(adata: AnnData, distance_obj: pt.tl.Distance) -> DataFrame:
+def pairwise_distance(adata: AnnData, distance_obj: pt.tl.Distance) -> DataFrame | tuple[DataFrame, DataFrame]:
     return distance_obj.pairwise(adata, groupby="perturbation", show_progressbar=True)
 
 

--- a/tests/tools/_perturbation_space/test_classifier_spaces.py
+++ b/tests/tools/_perturbation_space/test_classifier_spaces.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 import scipy.sparse as sp
 from anndata import AnnData
 

--- a/tests/tools/_perturbation_space/test_perturbation_space_extras.py
+++ b/tests/tools/_perturbation_space/test_perturbation_space_extras.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from anndata import AnnData
 
 import pertpy as pt

--- a/tests/tools/_perturbation_space/test_simple_perturbation_space.py
+++ b/tests/tools/_perturbation_space/test_simple_perturbation_space.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from anndata import AnnData
 
 import pertpy as pt

--- a/tests/tools/test_augur.py
+++ b/tests/tools/test_augur.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 
 import pertpy as pt
 

--- a/tests/tools/test_cinemaot.py
+++ b/tests/tools/test_cinemaot.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import numpy as np
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from _pytest.fixtures import fixture
 
 import pertpy as pt

--- a/tests/tools/test_dialogue.py
+++ b/tests/tools/test_dialogue.py
@@ -10,10 +10,11 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import pytest
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from scipy import sparse
 
 import pertpy as pt
+from pertpy._types import as_frame
 from pertpy.tools._dialogue import (
     _anova_filter_features,
     _center_scale_winsorize,
@@ -265,7 +266,8 @@ def _preprocess_dialogue_adata(adata: ad.AnnData) -> ad.AnnData:
     """Same preprocessing as the docstrings: PCA, drop a sparse celltype, keep samples with all remaining types."""
     sc.pp.pca(adata, n_comps=15, random_state=0)
     adata = adata[adata.obs["cell.subtypes"] != "CD8+ IL17+"].copy()
-    isecs = pd.crosstab(adata.obs["cell.subtypes"], adata.obs["sample"])
+    obs = as_frame(adata.obs)
+    isecs = pd.crosstab(obs["cell.subtypes"], obs["sample"])
     keep_pts = list(isecs.loc[:, (isecs > 3).sum(axis=0) == isecs.shape[0]].columns.values)
     adata = adata[adata.obs["sample"].isin(keep_pts), :].copy()
     adata.obs["cell.subtypes"] = adata.obs["cell.subtypes"].astype("category").cat.remove_unused_categories()

--- a/tests/tools/test_dialogue.py
+++ b/tests/tools/test_dialogue.py
@@ -14,7 +14,7 @@ import scanpy as sc  # type: ignore[import-untyped]
 from scipy import sparse
 
 import pertpy as pt
-from pertpy._types import as_frame
+from pertpy._types import cast_frame
 from pertpy.tools._dialogue import (
     _anova_filter_features,
     _center_scale_winsorize,
@@ -266,7 +266,7 @@ def _preprocess_dialogue_adata(adata: ad.AnnData) -> ad.AnnData:
     """Same preprocessing as the docstrings: PCA, drop a sparse celltype, keep samples with all remaining types."""
     sc.pp.pca(adata, n_comps=15, random_state=0)
     adata = adata[adata.obs["cell.subtypes"] != "CD8+ IL17+"].copy()
-    obs = as_frame(adata.obs)
+    obs = cast_frame(adata.obs)
     isecs = pd.crosstab(obs["cell.subtypes"], obs["sample"])
     keep_pts = list(isecs.loc[:, (isecs > 3).sum(axis=0) == isecs.shape[0]].columns.values)
     adata = adata[adata.obs["sample"].isin(keep_pts), :].copy()

--- a/tests/tools/test_enrichment.py
+++ b/tests/tools/test_enrichment.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from anndata import AnnData
 
 import pertpy as pt

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -3,10 +3,10 @@ from importlib.util import find_spec
 import numpy as np
 import pandas as pd
 import pytest
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 import scipy.sparse as sp
 from anndata import AnnData
-from mudata import MuData
+from mudata import MuData  # type: ignore[import-untyped]
 
 import pertpy as pt
 
@@ -17,7 +17,7 @@ def solver(request):
 
     if solver_name == "edger":
         try:
-            from rpy2.robjects.packages import importr
+            from rpy2.robjects.packages import importr  # type: ignore[import-untyped,import-not-found]
 
             importr("edgeR")
         except Exception:  # noqa: BLE001

--- a/tests/tools/test_scgen.py
+++ b/tests/tools/test_scgen.py
@@ -1,7 +1,7 @@
 import pytest
 
 try:
-    import scvi
+    import scvi  # type: ignore[import-untyped,import-not-found]
 except Exception:  # noqa: BLE001
     pytest.skip("Required R package 'edgeR' not available", allow_module_level=True)
 
@@ -10,7 +10,7 @@ import warnings
 import anndata as ad
 import jax
 import jax.numpy as jnp
-import scanpy as sc
+import scanpy as sc  # type: ignore[import-untyped]
 from scvi import REGISTRY_KEYS
 
 import pertpy as pt
@@ -19,7 +19,7 @@ from pertpy.tools._scgen._scgenvae import JaxSCGENVAE
 
 
 def test_scgen():
-    from scvi.data import synthetic_iid
+    from scvi.data import synthetic_iid  # type: ignore[import-untyped,import-not-found]
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Observation names are not unique")


### PR DESCRIPTION
Closes #1052.

Adopts the mypy setup from the cookiecutter-scverse template (scverse/cookiecutter-scverse#530): mypy as a local pre-commit hook run against the project environment, a `Pre-commit checks` CI job wired into the `check` gate, and `ci: skip: [mypy]` since pre-commit.ci cannot provide that environment. No `[tool.mypy]` section, as on the template.

Then makes the codebase pass: 1157 errors to 0.

- 114 of the 265 import errors were packages that ship stubs, so those are installed (`pandas-stubs`, `scipy-stubs`, `joblib-stubs`, `types-{requests,seaborn,tqdm}`) rather than silenced. Only the 20 dependencies with neither `py.typed` nor stubs get a per-import ignore.
- `pertpy._types` gains `as_matrix`, `as_frame` and `as_dense` to narrow `AnnData.X` and `.obs`/`.var`, whose unions cover containers these functions do not accept. They are `cast`-based and have no runtime effect.
- Hand-rolled dense/sparse branches now use `to_dense` from fast-array-utils.
- Implicit `Optional` defaults and a few wrong return annotations are fixed.
- `CSBase` is widened to the sparse array classes; `CSRBase`, `CSCBase` and `SpBase` keep their definitions because they drive `singledispatch` registrations.

Behavior is otherwise unchanged. mypy did uncover latent bugs. `Scgen.batch_removal` called `AnnData.concatenate`, removed in anndata 0.13, so the branch for cell types present in a single batch raised `AttributeError`; that one is fixed here. Left for separate fixes: `Scgen.plot_binary_classifier` passes `.X` where an `AnnData` is expected, `perturbation_signature(batch_size=...)` reshapes to 3D and so fails on sparse `X`, and scCODA/tascCODA passed `0.0001` as `jnp.nan_to_num`'s `copy` argument instead of `nan`.

`arviz>=1.2.0` is required because older releases pull an `arviz_plots` that calls `matplotlib.style.core`, removed in matplotlib 3.11, failing six CODA tests on main.
