### PR TITLE
Show output filename in download progress

### DIFF
--- a/pertpy/data/_dataloader.py
+++ b/pertpy/data/_dataloader.py
@@ -96,7 +96,7 @@ def _download(  # pragma: no cover
                 fname=output_file_name,
                 path=str(output_path),
                 downloader=pooch.HTTPDownloader(
-                    progressbar=_RichProgress(),
+                    progressbar=_RichProgress(description=f"[red]Downloading {output_file_name}"),
                     chunk_size=block_size,
                     timeout=timeout,
                 ),


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] Referenced issue is linked
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
  - No new automated test was added because this is a presentation-only change to the progress description.

**Description of changes**

Dataset download progress now includes the output filename instead of displaying the same generic `Downloading...` description for every dataset.

For example:

```text
Downloading replogle_2022_k562_essential.h5ad ━━━━━━━━━━ 100% 0:00:00
Downloading norman_2019.h5ad ━━━━━━━━━━ 100% 0:00:00
```

This makes sequential dataset downloads easier to distinguish

Closes #1055 

**Technical details**

`output_file_name` is passed to `_RichProgress` when constructing the `pooch.HTTPDownloader`:
```python
progressbar=_RichProgress(description=f"[red]Downloading {output_file_name}")
```

This does not change the download behavior, public API, dependencies, or dataset contents.

Validation:
- uv run pytest -k "not EdgeR": 577 passed, 3 skipped, 17 deselected
- uv run pre-commit run --files pertpy/data/_dataloader.py
- git diff --check
EdgeR tests were excluded because the local environment does not have a working R installation. The failures observed when running them were unrelated to this change.

**Additional context**

