### PR TITLE
Align dataset download progress

### DIFF
--- a/src/pertpy/data/_dataloader.py
+++ b/src/pertpy/data/_dataloader.py
@@ -98,7 +98,7 @@ def _download(  # pragma: no cover
                 fname=output_file_name,
                 path=str(output_path),
                 downloader=pooch.HTTPDownloader(
-                    progressbar=_RichProgress(description=f"[red]Downloading {output_file_name}"),
+                    progressbar=_RichProgress(description=f"[red]Downloading {output_file_name:<40}"),
                     chunk_size=block_size,
                     timeout=timeout,
                 ),

--- a/src/pertpy/data/_dataloader.py
+++ b/src/pertpy/data/_dataloader.py
@@ -16,6 +16,9 @@ pooch.get_logger().setLevel(logging.WARNING)
 # while pooch's ``requests``-based downloader raises ``requests.exceptions.RequestException``.
 _TRANSIENT_DOWNLOAD_ERRORS = (OSError, requests.exceptions.RequestException)
 
+# The longest registered dataset filename is currently 38 characters.
+_FILENAME_FIELD_WIDTH = 45
+
 
 class _RichProgress:
     """Adapter exposing the tqdm-like interface pooch expects, backed by rich.progress."""
@@ -98,7 +101,9 @@ def _download(  # pragma: no cover
                 fname=output_file_name,
                 path=str(output_path),
                 downloader=pooch.HTTPDownloader(
-                    progressbar=_RichProgress(description=f"[red]Downloading {output_file_name:<40}"),
+                    progressbar=_RichProgress(
+                        description=f"[red]Downloading {output_file_name:<{_FILENAME_FIELD_WIDTH}}"
+                    ),
                     chunk_size=block_size,
                     timeout=timeout,
                 ),


### PR DESCRIPTION
**Description of changes**

Left-align output filenames in a 40-character field so that progress bars for sequential dataset downloads start at the same position.

- Before: Progress bars start at different positions depending on the filename length.
   <img width="764" height="50" alt="Screenshot 2026-07-29 at 09 00 00" src="https://github.com/user-attachments/assets/9772d4f0-4987-4fee-807b-1059b73baf0e" />

- After: The output filenames use a minimum width of 40 characters, aligning the progress bars, percentages, and remaining-time columns.
   <img width="766" height="49" alt="Screenshot 2026-07-29 at 08 59 42" src="https://github.com/user-attachments/assets/830ca6e9-f246-4c1a-8148-0e14ce2e718d" />

**Technical details**

The longest output filename currently defined in `_datasets.py` is 38 characters (which is "schraivogel_2020_tap_screen_chr11.h5ad").
The 40-character field is a minimum width, so longer filenames will still be displayed in full rather than truncated.

Validation:
- `uv run pre-commit run --files pertpy/data/_dataloader.py`
- `git diff --check`

**Additional context**

Follow-up to #1056 
