### PR TITLE
Correct the version of the Milo deprecations

### DIFF
--- a/src/pertpy/tools/_milo.py
+++ b/src/pertpy/tools/_milo.py
@@ -276,7 +276,7 @@ class Milo:
         cast(
             "Deprecation",
             Deprecation(
-                "1.0.7",
+                "1.1.0",
                 "subset_samples is buggy in edge cases and will be removed. "
                 "Specify the comparison via `model_contrasts` instead, or subset cells before building the kNN graph.",
             ),
@@ -932,7 +932,7 @@ class Milo:
 
     @deprecated(
         Deprecation(
-            "1.0.7", "Use `add_covariate_to_nhoods_obs` instead — the destination is `mdata['milo'].obs`, not `.var`."
+            "1.1.0", "Use `add_covariate_to_nhoods_obs` instead — the destination is `mdata['milo'].obs`, not `.var`."
         )
     )
     def add_covariate_to_nhoods_var(self, mdata: MuData, new_covariates: list[str], feature_key: str | None = "rna"):


### PR DESCRIPTION
1.0.7 was never released — the tags go from 1.0.6 straight to 1.1.0 — so the rendered deprecation notices for `subset_samples` and `add_covariate_to_nhoods_var` pointed at a version nobody can have installed.
Both shipped in 1.1.0.