### PR TITLE
Add mixed models to Milo differential abundance testing

### DIFF
--- a/docs/api/tools_index.md
+++ b/docs/api/tools_index.md
@@ -160,6 +160,9 @@ mdata["rna"].obs["Status"] = (
 )
 milo.da_nhoods(mdata, design="~Status")
 
+# Repeated measurements of the same donor are accounted for with a random intercept
+milo.da_nhoods(mdata, design="~ Status + (1 | patient_id)")
+
 # Group differentially abundant neighbourhoods and find their marker genes
 milo.build_nhood_graph(mdata)
 milo.group_nhoods(mdata)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,7 +313,6 @@ module = [
     "arviz.*",
     "blitzgsea.*",
     "ete4.*",
-    "formulaic.*",
     "formulaic_contrasts.*",
     "mudata.*",
     "numpyro.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,6 +313,7 @@ module = [
     "arviz.*",
     "blitzgsea.*",
     "ete4.*",
+    "formulaic.*",
     "formulaic_contrasts.*",
     "mudata.*",
     "numpyro.*",

--- a/src/pertpy/tools/_milo.py
+++ b/src/pertpy/tools/_milo.py
@@ -590,9 +590,18 @@ class Milo:
             res = res[["logCPM", "logFC", "PValue", "FDR"]]
 
         res.index = sample_adata.var_names[keep_nhoods]
-        if any(col in sample_adata.var.columns for col in res.columns):
-            sample_adata.var = sample_adata.var.drop(res.columns, axis=1)  # type: ignore[union-attr]
+        # Solvers report different columns, so clear the ones the previous run wrote instead of leaving a
+        # mixture of both behind.
+        written = [*res.columns, "SpatialFDR"]
+        stale = [
+            col
+            for col in dict.fromkeys([*sample_adata.uns.get("da_nhoods_columns", []), *written])
+            if col in sample_adata.var.columns
+        ]
+        if stale:
+            sample_adata.var = sample_adata.var.drop(columns=stale)  # type: ignore[union-attr]
         sample_adata.var = pd.concat([sample_adata.var, res], axis=1)  # type: ignore[call-overload]
+        sample_adata.uns["da_nhoods_columns"] = written
 
         self._graph_spatial_fdr(sample_adata)  # type: ignore[arg-type]
 

--- a/src/pertpy/tools/_milo.py
+++ b/src/pertpy/tools/_milo.py
@@ -316,14 +316,13 @@ class Milo:
     ):
         """Performs differential abundance testing on neighbourhoods using QLF test implementation as implemented in edgeR.
 
-        A random effect in the design switches to a negative binomial mixed model, which accounts for repeated measurements of the same donor, batch or timepoint instead of treating every sample as independent.
+        A random intercept in the design switches to a negative binomial mixed model, which accounts for repeated measurements of the same donor, batch or timepoint instead of treating every sample as independent.
 
         Args:
             mdata: MuData object
             design: Formula for the test, following glm syntax from R (e.g. '~ condition').
                     Terms should be columns in `milo_mdata[feature_key].obs`.
-                    Random effects follow the `(1 | group)` syntax of R Milo (e.g. '~ condition + (1 | donor)') and fit a mixed model.
-                    `(variable | group)` additionally lets the effect of that variable vary between groups, whose variance is estimated separately from the intercept's.
+                    Random intercepts follow the `(1 | variable)` syntax of R Milo (e.g. '~ condition + (1 | donor)') and fit a mixed model.
             model_contrasts: A string vector that defines the contrasts used to perform DA testing, following glm syntax from R (e.g. "conditionDisease - conditionControl").
                              If no contrast is specified (default), then the last categorical level in condition of interest is used as the test group.
             subset_samples: subset of samples (obs in `milo_mdata['milo']`) to use for the test.
@@ -371,12 +370,7 @@ class Milo:
 
         fixed_design, random_effects = parse_random_effects(design)
         covariates = [x.strip(" ") for x in set(re.split("\\+|\\*", fixed_design.lstrip("~ ")))]
-        covariates = list(
-            dict.fromkeys(
-                [x for x in covariates if x not in {"", "0", "1"}]
-                + [name for term in random_effects for name in term if name != "1"]
-            )
-        )
+        covariates = [x for x in covariates if x not in {"", "0", "1"}] + random_effects
 
         # Add covariates used for testing to sample_adata.var
         sample_col = sample_adata.uns["sample_col"]

--- a/src/pertpy/tools/_milo.py
+++ b/src/pertpy/tools/_milo.py
@@ -412,13 +412,14 @@ class Milo:
         # Subset samples
         if subset_samples is not None:
             keep_smp = keep_smp & sample_adata.obs_names.isin(subset_samples)
-            design_df = design_df[keep_smp]
-            for i, e in enumerate(design_df.columns):
-                if design_df.dtypes[i].name == "category":
-                    design_df[e] = design_df[e].cat.remove_unused_categories()
 
         # Filter out nhoods with zero counts (they can appear after sample filtering)
         keep_nhoods = count_mat[:, keep_smp].sum(1) > 0
+
+        design_df = design_df[keep_smp].copy()
+        for column in design_df.columns:
+            if isinstance(design_df[column].dtype, pd.CategoricalDtype):
+                design_df[column] = design_df[column].cat.remove_unused_categories()
 
         if random_effects:
             if find_spec("formulaic_contrasts") is None:
@@ -427,16 +428,15 @@ class Milo:
                 )
             from formulaic_contrasts import FormulaicContrasts
 
-            design_df_filtered = design_df[keep_smp]
             fixed = fixed_design if add_intercept and model_contrasts is None else fixed_design + " + 0"
-            design_matrix = FormulaicContrasts(design_df_filtered, fixed).design_matrix
+            design_matrix = FormulaicContrasts(design_df, fixed).design_matrix
             counts_filtered = count_mat[np.ix_(keep_nhoods, keep_smp)]
             lib_size_filtered = lib_size[keep_smp]
 
             res = fit_nb_glmm_nhoods(
                 counts_filtered,
                 np.asarray(design_matrix, dtype=float),
-                random_effect_matrices(design_df_filtered, random_effects),
+                random_effect_matrices(design_df, random_effects),
                 np.log(lib_size_filtered),
                 contrast=_contrast_vector(list(design_matrix.columns), model_contrasts)
                 if model_contrasts is not None
@@ -542,7 +542,7 @@ class Milo:
             warnings.filterwarnings("always", message=".*(alpha).*")
 
             counts_filtered = count_mat[np.ix_(keep_nhoods, keep_smp)]
-            design_df_filtered = design_df.iloc[keep_smp].copy()
+            design_df_filtered = design_df.copy()
 
             design_df_filtered = design_df_filtered.astype(
                 dict.fromkeys(design_df_filtered.select_dtypes(exclude=["number"]).columns, "category")

--- a/src/pertpy/tools/_milo.py
+++ b/src/pertpy/tools/_milo.py
@@ -316,13 +316,14 @@ class Milo:
     ):
         """Performs differential abundance testing on neighbourhoods using QLF test implementation as implemented in edgeR.
 
-        A random intercept in the design switches to a negative binomial mixed model, which accounts for repeated measurements of the same donor, batch or timepoint instead of treating every sample as independent.
+        A random effect in the design switches to a negative binomial mixed model, which accounts for repeated measurements of the same donor, batch or timepoint instead of treating every sample as independent.
 
         Args:
             mdata: MuData object
             design: Formula for the test, following glm syntax from R (e.g. '~ condition').
                     Terms should be columns in `milo_mdata[feature_key].obs`.
-                    Random intercepts follow the `(1 | variable)` syntax of R Milo (e.g. '~ condition + (1 | donor)') and fit a mixed model.
+                    Random effects follow the `(1 | group)` syntax of R Milo (e.g. '~ condition + (1 | donor)') and fit a mixed model.
+                    `(variable | group)` additionally lets the effect of that variable vary between groups, whose variance is estimated separately from the intercept's.
             model_contrasts: A string vector that defines the contrasts used to perform DA testing, following glm syntax from R (e.g. "conditionDisease - conditionControl").
                              If no contrast is specified (default), then the last categorical level in condition of interest is used as the test group.
             subset_samples: subset of samples (obs in `milo_mdata['milo']`) to use for the test.
@@ -370,7 +371,12 @@ class Milo:
 
         fixed_design, random_effects = parse_random_effects(design)
         covariates = [x.strip(" ") for x in set(re.split("\\+|\\*", fixed_design.lstrip("~ ")))]
-        covariates = [x for x in covariates if x not in {"", "0", "1"}] + random_effects
+        covariates = list(
+            dict.fromkeys(
+                [x for x in covariates if x not in {"", "0", "1"}]
+                + [name for term in random_effects for name in term if name != "1"]
+            )
+        )
 
         # Add covariates used for testing to sample_adata.var
         sample_col = sample_adata.uns["sample_col"]

--- a/src/pertpy/tools/_milo.py
+++ b/src/pertpy/tools/_milo.py
@@ -33,6 +33,23 @@ from scipy.sparse import coo_matrix, csr_matrix, issparse, spmatrix
 from sklearn.metrics.pairwise import euclidean_distances
 
 
+def _contrast_vector(columns: list[str], model_contrasts: str) -> np.ndarray:
+    """Turn an R style contrast such as ``conditionB-conditionA`` into weights over formulaic design columns.
+
+    Formulaic names a coefficient ``condition[T.B]`` where R names it ``conditionB``, so the columns are matched on their R spelling.
+    """
+    r_names = {column.replace("[T.", "").replace("[", "").replace("]", ""): column for column in columns}
+    weights = pd.Series(0.0, index=columns)
+    for sign, term in re.findall(r"([+-]?)\s*([^+-]+)", model_contrasts):
+        name = term.strip()
+        if name not in r_names:
+            raise ValueError(
+                f"Contrast term {name!r} does not match any coefficient of the design. Available: {sorted(r_names)}."
+            )
+        weights[r_names[name]] += -1.0 if sign == "-" else 1.0
+    return weights.to_numpy()
+
+
 def _weighted_bh(pvalues: np.ndarray, weights: np.ndarray) -> np.ndarray:
     """Density-weighted Benjamini-Hochberg adjustment (Cydar/Milo style).
 
@@ -292,10 +309,10 @@ class Milo:
         subset_samples: list[str] | None = None,
         add_intercept: bool = True,
         feature_key: str | None = "rna",
-        solver: Literal["edger", "pydeseq2"] = "pydeseq2",
         reml: bool = True,
         max_iter: int = 50,
         tol: float = 1e-5,
+        solver: Literal["edger", "pydeseq2"] = "pydeseq2",
     ):
         """Performs differential abundance testing on neighbourhoods using QLF test implementation as implemented in edgeR.
 
@@ -312,17 +329,13 @@ class Milo:
             add_intercept: whether to include an intercept in the model. If False, this is equivalent to adding + 0 in the design formula.
                 When model_contrasts is specified, this is set to False by default.
             feature_key: If input data is MuData, specify key to cell-level AnnData object.
-            solver: The solver to fit the model to.
+            reml: Whether a mixed model estimates its variance components by restricted maximum likelihood rather than maximum likelihood.
+            max_iter: Maximum number of iterations of a mixed model fit.
+            tol: Convergence tolerance of a mixed model fit.
+            solver: The solver to fit the model to, ignored for a mixed model.
                 The "edger" solver requires R, rpy2 and edgeR to be installed and is the closest to the R implementation.
                 The "pydeseq2" requires pydeseq2 to be installed.
                 It is still very comparable to the "edger" solver but might be a bit slower.
-                Ignored when the design contains random intercepts.
-            reml: Whether to estimate the variance components by restricted maximum likelihood rather than maximum likelihood.
-                Only used when the design contains random intercepts.
-            max_iter: Maximum number of iterations of the mixed model fit.
-                Only used when the design contains random intercepts.
-            tol: Convergence tolerance of the mixed model fit.
-                Only used when the design contains random intercepts.
 
         Returns:
             None, modifies `milo_mdata['milo']` in place, adding the results of the DA test to `.var`:
@@ -330,6 +343,7 @@ class Milo:
             - `PValue` stores the p-value for the QLF test before multiple testing correction
             - `SpatialFDR` stores the p-value adjusted for multiple testing to limit the false discovery rate,
                 calculated with weighted Benjamini-Hochberg procedure
+
             For a mixed model, `SE`, `tvalue`, one `<variable>_variance` per random intercept, `Dispersion`,
             `Logliklihood` and `Converged` are added as well.
 
@@ -407,17 +421,15 @@ class Milo:
         keep_nhoods = count_mat[:, keep_smp].sum(1) > 0
 
         if random_effects:
-            if model_contrasts is not None:
-                raise ValueError(
-                    "model_contrasts is not supported for mixed models. The last coefficient of the fixed effects is tested."
+            if find_spec("formulaic_contrasts") is None:
+                raise ImportError(
+                    "formulaic-contrasts is required for mixed models. Install with: pip install pertpy[de]"
                 )
-            if find_spec("formulaic") is None:
-                raise ImportError("formulaic is required for mixed models. Install with: pip install pertpy[de]")
-            from formulaic import model_matrix
+            from formulaic_contrasts import FormulaicContrasts
 
             design_df_filtered = design_df[keep_smp]
-            fixed = fixed_design if add_intercept else fixed_design + " + 0"
-            design_matrix = model_matrix(fixed, design_df_filtered)
+            fixed = fixed_design if add_intercept and model_contrasts is None else fixed_design + " + 0"
+            design_matrix = FormulaicContrasts(design_df_filtered, fixed).design_matrix
             counts_filtered = count_mat[np.ix_(keep_nhoods, keep_smp)]
             lib_size_filtered = lib_size[keep_smp]
 
@@ -426,6 +438,9 @@ class Milo:
                 np.asarray(design_matrix, dtype=float),
                 random_effect_matrices(design_df_filtered, random_effects),
                 np.log(lib_size_filtered),
+                contrast=_contrast_vector(list(design_matrix.columns), model_contrasts)
+                if model_contrasts is not None
+                else None,
                 reml=reml,
                 max_iter=max_iter,
                 tol=tol,
@@ -590,8 +605,6 @@ class Milo:
             res = res[["logCPM", "logFC", "PValue", "FDR"]]
 
         res.index = sample_adata.var_names[keep_nhoods]
-        # Solvers report different columns, so clear the ones the previous run wrote instead of leaving a
-        # mixture of both behind.
         written = [*res.columns, "SpatialFDR"]
         stale = [
             col

--- a/src/pertpy/tools/_milo.py
+++ b/src/pertpy/tools/_milo.py
@@ -695,6 +695,12 @@ class Milo:
                     "sample_col not found in mdata['milo'].uns -- run count_nhoods() first or pass `sample_col`."
                 )
 
+        if parse_random_effects(design)[1]:
+            raise ValueError(
+                "Random effects are not supported by de_nhoods, which fits one model per gene and neighbourhood. "
+                "Use da_nhoods for a mixed model of cell abundance, or drop the random effect term to test expression."
+            )
+
         covariates = [c.strip() for c in re.split(r"\+|\*|:", design.lstrip("~ "))]
         covariates = [c for c in covariates if c and c not in {"0", "1"}]
         missing = [c for c in covariates + [sample_col] if c not in adata.obs.columns]

--- a/src/pertpy/tools/_milo.py
+++ b/src/pertpy/tools/_milo.py
@@ -20,6 +20,7 @@ from scverse_misc import Deprecation, deprecated, deprecated_arg
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy._logger import logger
 from pertpy._types import CSBase, cast_frame, cast_matrix
+from pertpy.tools._milo_glmm import fit_nb_glmm_nhoods, parse_random_effects, random_effect_matrices
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
@@ -292,13 +293,19 @@ class Milo:
         add_intercept: bool = True,
         feature_key: str | None = "rna",
         solver: Literal["edger", "pydeseq2"] = "pydeseq2",
+        reml: bool = True,
+        max_iter: int = 50,
+        tol: float = 1e-5,
     ):
         """Performs differential abundance testing on neighbourhoods using QLF test implementation as implemented in edgeR.
+
+        A random intercept in the design switches to a negative binomial mixed model, which accounts for repeated measurements of the same donor, batch or timepoint instead of treating every sample as independent.
 
         Args:
             mdata: MuData object
             design: Formula for the test, following glm syntax from R (e.g. '~ condition').
                     Terms should be columns in `milo_mdata[feature_key].obs`.
+                    Random intercepts follow the `(1 | variable)` syntax of R Milo (e.g. '~ condition + (1 | donor)') and fit a mixed model.
             model_contrasts: A string vector that defines the contrasts used to perform DA testing, following glm syntax from R (e.g. "conditionDisease - conditionControl").
                              If no contrast is specified (default), then the last categorical level in condition of interest is used as the test group.
             subset_samples: subset of samples (obs in `milo_mdata['milo']`) to use for the test.
@@ -309,6 +316,13 @@ class Milo:
                 The "edger" solver requires R, rpy2 and edgeR to be installed and is the closest to the R implementation.
                 The "pydeseq2" requires pydeseq2 to be installed.
                 It is still very comparable to the "edger" solver but might be a bit slower.
+                Ignored when the design contains random intercepts.
+            reml: Whether to estimate the variance components by restricted maximum likelihood rather than maximum likelihood.
+                Only used when the design contains random intercepts.
+            max_iter: Maximum number of iterations of the mixed model fit.
+                Only used when the design contains random intercepts.
+            tol: Convergence tolerance of the mixed model fit.
+                Only used when the design contains random intercepts.
 
         Returns:
             None, modifies `milo_mdata['milo']` in place, adding the results of the DA test to `.var`:
@@ -316,6 +330,8 @@ class Milo:
             - `PValue` stores the p-value for the QLF test before multiple testing correction
             - `SpatialFDR` stores the p-value adjusted for multiple testing to limit the false discovery rate,
                 calculated with weighted Benjamini-Hochberg procedure
+            For a mixed model, `SE`, `tvalue`, one `<variable>_variance` per random intercept, `Dispersion`,
+            `Logliklihood` and `Converged` are added as well.
 
         Examples:
             >>> import pertpy as pt
@@ -338,7 +354,9 @@ class Milo:
             raise
         adata = mdata[feature_key]
 
-        covariates = [x.strip(" ") for x in set(re.split("\\+|\\*", design.lstrip("~ ")))]
+        fixed_design, random_effects = parse_random_effects(design)
+        covariates = [x.strip(" ") for x in set(re.split("\\+|\\*", fixed_design.lstrip("~ ")))]
+        covariates = [x for x in covariates if x not in {"", "0", "1"}] + random_effects
 
         # Add covariates used for testing to sample_adata.var
         sample_col = sample_adata.uns["sample_col"]
@@ -388,7 +406,42 @@ class Milo:
         # Filter out nhoods with zero counts (they can appear after sample filtering)
         keep_nhoods = count_mat[:, keep_smp].sum(1) > 0
 
-        if solver == "edger":
+        if random_effects:
+            if model_contrasts is not None:
+                raise ValueError(
+                    "model_contrasts is not supported for mixed models. The last coefficient of the fixed effects is tested."
+                )
+            if find_spec("formulaic") is None:
+                raise ImportError("formulaic is required for mixed models. Install with: pip install pertpy[de]")
+            from formulaic import model_matrix
+
+            design_df_filtered = design_df[keep_smp]
+            fixed = fixed_design if add_intercept else fixed_design + " + 0"
+            design_matrix = model_matrix(fixed, design_df_filtered)
+            counts_filtered = count_mat[np.ix_(keep_nhoods, keep_smp)]
+            lib_size_filtered = lib_size[keep_smp]
+
+            res = fit_nb_glmm_nhoods(
+                counts_filtered,
+                np.asarray(design_matrix, dtype=float),
+                random_effect_matrices(design_df_filtered, random_effects),
+                np.log(lib_size_filtered),
+                reml=reml,
+                max_iter=max_iter,
+                tol=tol,
+            )
+            fitted = res["logFC"].notna()
+            if separated := int((~fitted).sum()):
+                logger.warning(
+                    f"{separated} out of {len(res)} neighbourhoods have a group without any cells, so their fold change "
+                    "is not identifiable and is reported as NaN."
+                )
+            if not_converged := int((~res["Converged"] & fitted).sum()):
+                logger.warning(
+                    f"{not_converged} out of {int(fitted.sum())} fitted neighbourhoods did not converge; "
+                    "consider increasing `max_iter`."
+                )
+        elif solver == "edger":
             # Set up rpy2 to run edgeR
             edgeR, limma, stats, base = self._setup_rpy2()
 

--- a/src/pertpy/tools/_milo_glmm.py
+++ b/src/pertpy/tools/_milo_glmm.py
@@ -140,18 +140,48 @@ def fit_nb_glmm(
         max_iter: Maximum number of pseudo-likelihood iterations.
         tol: Convergence tolerance on the fixed effects and variance components.
     """
+    matrices = [Z for _, Z in random_effects]
+    return _fit_nb_glmm(
+        y,
+        X,
+        matrices,
+        [Z @ Z.T for Z in matrices],
+        offset,
+        dispersion=dispersion,
+        reml=reml,
+        max_iter=max_iter,
+        tol=tol,
+    )
+
+
+def _fit_nb_glmm(
+    y: np.ndarray,
+    X: np.ndarray,
+    matrices: Sequence[np.ndarray],
+    zz: Sequence[np.ndarray],
+    offset: np.ndarray,
+    *,
+    dispersion: float | None,
+    reml: bool,
+    max_iter: int,
+    tol: float,
+) -> GLMMFit:
+    """Fit one neighbourhood, reusing the outer products of the random effect matrices across neighbourhoods."""
     y = np.asarray(y, dtype=float)
     n, p = X.shape
-    matrices = [Z for _, Z in random_effects]
-    zz = [Z @ Z.T for Z in matrices]
     residual_df = max(n - p, 1)
 
-    def pseudo_likelihood(dispersion: float) -> tuple[np.ndarray, np.ndarray, list[np.ndarray], np.ndarray, bool]:
+    def pseudo_likelihood(
+        dispersion: float, start_from: tuple | None = None
+    ) -> tuple[np.ndarray, np.ndarray, list[np.ndarray], np.ndarray, bool]:
         size = np.inf if dispersion <= 0 else 1.0 / dispersion
-        beta, *_ = np.linalg.lstsq(X, np.log(y + 1) - offset, rcond=None)
-        start = np.log(y + 1) - offset - X @ beta
-        sigma = np.full(len(random_effects), max(float(start @ start) / residual_df, 1e-3))
-        u = [np.zeros(Z.shape[1]) for Z in matrices]
+        if start_from is None:
+            beta, *_ = np.linalg.lstsq(X, np.log(y + 1) - offset, rcond=None)
+            start = np.log(y + 1) - offset - X @ beta
+            sigma = np.full(len(matrices), max(float(start @ start) / residual_df, 1e-3))
+            u = [np.zeros(Z.shape[1]) for Z in matrices]
+        else:
+            beta, sigma, u = start_from
         converged = False
 
         for _ in range(max_iter):
@@ -205,14 +235,16 @@ def fit_nb_glmm(
         eta = offset + X @ beta + sum((Z @ u_k for Z, u_k in zip(matrices, u, strict=True)), np.zeros(n))
         return beta, sigma, u, np.exp(np.clip(eta, -30, 30)), converged
 
+    warm_start = None
     if dispersion is None:
         # The fixed effects only estimate absorbs part of the random effect variance, so refine it once the
         # neighbourhood has been fitted with its random effects.
         dispersion = _dispersion_from_means(y, _poisson_means(y, X, offset), residual_df)
-        _, _, _, fitted_mean, _ = pseudo_likelihood(dispersion)
+        beta, sigma, u, fitted_mean, _ = pseudo_likelihood(dispersion)
         dispersion = _dispersion_from_means(y, fitted_mean, residual_df)
+        warm_start = (beta, sigma, u)
 
-    beta, sigma, u, mu, converged = pseudo_likelihood(dispersion)
+    beta, sigma, u, mu, converged = pseudo_likelihood(dispersion, warm_start)
 
     size = np.inf if dispersion <= 0 else 1.0 / dispersion
     weights = np.maximum(mu if np.isinf(size) else mu / (1.0 + mu / size), 1e-8)
@@ -252,6 +284,8 @@ def fit_nb_glmm_nhoods(
     logcpm = np.log2(np.mean(counts / np.where(library_size > 0, library_size, 1), axis=1) * 1e6 + 1e-12)
 
     df = between_within_df(X, random_effects)
+    matrices = [Z for _, Z in random_effects]
+    zz = [Z @ Z.T for Z in matrices]
     records = []
     for nhood in range(counts.shape[0]):
         y = counts[nhood].astype(float)
@@ -270,7 +304,7 @@ def fit_nb_glmm_nhoods(
             )
             continue
 
-        fit = fit_nb_glmm(y, X, random_effects, offset, reml=reml, max_iter=max_iter, tol=tol)
+        fit = _fit_nb_glmm(y, X, matrices, zz, offset, dispersion=None, reml=reml, max_iter=max_iter, tol=tol)
         t_value = fit.beta[-1] / fit.se[-1] if fit.se[-1] > 0 else np.nan
         records.append(
             {

--- a/src/pertpy/tools/_milo_glmm.py
+++ b/src/pertpy/tools/_milo_glmm.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, NamedTuple
 import numpy as np
 import pandas as pd
 from scipy import stats
+from scipy.linalg import cho_factor, cho_solve
 from scipy.optimize import brentq
 
 if TYPE_CHECKING:
@@ -97,6 +98,23 @@ def has_separation(y: np.ndarray, X: np.ndarray) -> bool:
     )
 
 
+def between_within_df(X: np.ndarray, random_effects: Sequence[tuple[str, np.ndarray]]) -> int:
+    """Degrees of freedom for the t-test on the last fixed effect, following the between-within rule.
+
+    A coefficient that is constant within every level of a random intercept is only informed by as many independent units as there are levels, so testing it against the number of samples treats repeated measurements as independent and is anti-conservative.
+    """
+    n, p = X.shape
+    tested = X[:, -1]
+    between = [
+        Z.shape[1]
+        for _, Z in random_effects
+        if all(np.ptp(tested[mask]) == 0 for mask in (Z[:, level] != 0 for level in range(Z.shape[1])) if mask.any())
+    ]
+    if between:
+        return max(min(between) - p, 1)
+    return max(n - sum(Z.shape[1] for _, Z in random_effects) - p + 1, 1)
+
+
 def fit_nb_glmm(
     y: np.ndarray,
     X: np.ndarray,
@@ -124,7 +142,8 @@ def fit_nb_glmm(
     """
     y = np.asarray(y, dtype=float)
     n, p = X.shape
-    zz = [Z @ Z.T for _, Z in random_effects]
+    matrices = [Z for _, Z in random_effects]
+    zz = [Z @ Z.T for Z in matrices]
     residual_df = max(n - p, 1)
 
     def pseudo_likelihood(dispersion: float) -> tuple[np.ndarray, np.ndarray, list[np.ndarray], np.ndarray, bool]:
@@ -132,33 +151,49 @@ def fit_nb_glmm(
         beta, *_ = np.linalg.lstsq(X, np.log(y + 1) - offset, rcond=None)
         start = np.log(y + 1) - offset - X @ beta
         sigma = np.full(len(random_effects), max(float(start @ start) / residual_df, 1e-3))
-        u = [np.zeros(Z.shape[1]) for _, Z in random_effects]
+        u = [np.zeros(Z.shape[1]) for Z in matrices]
         converged = False
 
         for _ in range(max_iter):
-            eta = offset + X @ beta + sum((Z @ u_k for (_, Z), u_k in zip(random_effects, u, strict=True)), np.zeros(n))
+            eta = offset + X @ beta + sum((Z @ u_k for Z, u_k in zip(matrices, u, strict=True)), np.zeros(n))
             mu = np.exp(np.clip(eta, -30, 30))
             weights = np.maximum(mu if np.isinf(size) else mu / (1.0 + mu / size), 1e-8)
             working = eta - offset + (y - mu) / mu
 
             V = sum((s * m for s, m in zip(sigma, zz, strict=True)), np.diag(1.0 / weights))
-            V_inv = np.linalg.pinv(V)
-            xtvx_inv = np.linalg.pinv(X.T @ V_inv @ X)
-            new_beta = xtvx_inv @ X.T @ V_inv @ working
-            projection = V_inv - V_inv @ X @ xtvx_inv @ X.T @ V_inv if reml else V_inv
+            chol = cho_factor(V, lower=True)
+
+            solved = cho_solve(chol, np.column_stack([X, *matrices]))
+            v_inv_x = solved[:, :p]
+
+            xtvx_inv = np.linalg.pinv(X.T @ v_inv_x)
+            new_beta = xtvx_inv @ (v_inv_x.T @ working)
 
             resid = working - X @ new_beta
-            new_u = [s * (Z.T @ (V_inv @ resid)) for s, (_, Z) in zip(sigma, random_effects, strict=True)]
+            v_inv_resid = cho_solve(chol, resid)
+            new_u = [s * (Z.T @ v_inv_resid) for s, Z in zip(sigma, matrices, strict=True)]
 
-            projected = projection @ resid
-            moments = [projection @ m for m in zz]
+            stacked = np.column_stack([v_inv_resid, solved[:, p:]])
+            if reml:
+                stacked = stacked - v_inv_x @ (xtvx_inv @ (X.T @ stacked))
+            projected = stacked[:, 0]
+            p_z = np.split(stacked[:, 1:], np.cumsum([Z.shape[1] for Z in matrices])[:-1], axis=1)
+
             score = np.array(
                 [
-                    -0.5 * np.trace(m) + 0.5 * float(projected @ zz_k @ projected)
-                    for m, zz_k in zip(moments, zz, strict=True)
+                    -0.5 * float(np.sum(b * Z)) + 0.5 * float((Z.T @ projected) @ (Z.T @ projected))
+                    for b, Z in zip(p_z, matrices, strict=True)
                 ]
             )
-            information = np.array([[0.5 * float(np.sum(a * b.T)) for b in moments] for a in moments])
+            information = np.array(
+                [
+                    [
+                        0.5 * float(np.sum((Z_k.T @ b_l) * (Z_l.T @ b_k).T))
+                        for b_l, Z_l in zip(p_z, matrices, strict=True)
+                    ]
+                    for b_k, Z_k in zip(p_z, matrices, strict=True)
+                ]
+            )
             new_sigma = np.maximum(sigma + np.linalg.pinv(information) @ score, 1e-8)
 
             delta = max(np.max(np.abs(new_beta - beta)), np.max(np.abs(new_sigma - sigma)))
@@ -167,7 +202,7 @@ def fit_nb_glmm(
                 converged = True
                 break
 
-        eta = offset + X @ beta + sum((Z @ u_k for (_, Z), u_k in zip(random_effects, u, strict=True)), np.zeros(n))
+        eta = offset + X @ beta + sum((Z @ u_k for Z, u_k in zip(matrices, u, strict=True)), np.zeros(n))
         return beta, sigma, u, np.exp(np.clip(eta, -30, 30)), converged
 
     if dispersion is None:
@@ -183,14 +218,15 @@ def fit_nb_glmm(
     weights = np.maximum(mu if np.isinf(size) else mu / (1.0 + mu / size), 1e-8)
     working = np.log(mu) - offset + (y - mu) / mu
     V = sum((s * m for s, m in zip(sigma, zz, strict=True)), np.diag(1.0 / weights))
-    V_inv = np.linalg.pinv(V)
-    se = np.sqrt(np.maximum(np.diag(np.linalg.pinv(X.T @ V_inv @ X)), 0))
+    chol = cho_factor(V, lower=True)
+    xtvx = X.T @ cho_solve(chol, X)
+    se = np.sqrt(np.maximum(np.diag(np.linalg.pinv(xtvx)), 0))
 
     resid = working - X @ beta
-    sign, logdet = np.linalg.slogdet(V)
-    loglik = -0.5 * (logdet + float(resid @ V_inv @ resid) + n * np.log(2 * np.pi)) if sign > 0 else np.nan
-    if reml and sign > 0:
-        loglik -= 0.5 * np.linalg.slogdet(X.T @ V_inv @ X)[1]
+    logdet = 2.0 * float(np.sum(np.log(np.abs(np.diag(chol[0])))))
+    loglik = -0.5 * (logdet + float(resid @ cho_solve(chol, resid)) + n * np.log(2 * np.pi))
+    if reml:
+        loglik -= 0.5 * np.linalg.slogdet(xtvx)[1]
 
     return GLMMFit(
         beta=beta, se=se, sigma=sigma, dispersion=float(dispersion), loglik=float(loglik), converged=converged
@@ -210,11 +246,12 @@ def fit_nb_glmm_nhoods(
     """Fit :func:`fit_nb_glmm` to every neighbourhood and assemble the results like R Milo does.
 
     The reported log fold change is the last column of the fixed effects model matrix, matching the coefficient that the edgeR solver tests.
+    Its p-value comes from a t-test whose degrees of freedom follow :func:`between_within_df`.
     """
     library_size = counts.sum(axis=0)
     logcpm = np.log2(np.mean(counts / np.where(library_size > 0, library_size, 1), axis=1) * 1e6 + 1e-12)
 
-    df = max(counts.shape[1] - X.shape[1], 1)
+    df = between_within_df(X, random_effects)
     records = []
     for nhood in range(counts.shape[0]):
         y = counts[nhood].astype(float)

--- a/src/pertpy/tools/_milo_glmm.py
+++ b/src/pertpy/tools/_milo_glmm.py
@@ -69,7 +69,7 @@ def _poisson_means(y: np.ndarray, X: np.ndarray, offset: np.ndarray) -> np.ndarr
     return mu
 
 
-def _dispersion_from_means(y: np.ndarray, mu: np.ndarray, df: int) -> float:
+def _dispersion_from_means(y: np.ndarray, mu: np.ndarray, df: float) -> float:
     """Solve for the dispersion at which the negative binomial Pearson statistic equals its degrees of freedom."""
     squared_error = (y - mu) ** 2
 
@@ -173,7 +173,7 @@ def _fit_nb_glmm(
 
     def pseudo_likelihood(
         dispersion: float, start_from: tuple | None = None
-    ) -> tuple[np.ndarray, np.ndarray, list[np.ndarray], np.ndarray, bool]:
+    ) -> tuple[np.ndarray, np.ndarray, list[np.ndarray], np.ndarray, bool, float]:
         size = np.inf if dispersion <= 0 else 1.0 / dispersion
         if start_from is None:
             beta, *_ = np.linalg.lstsq(X, np.log(y + 1) - offset, rcond=None)
@@ -233,18 +233,20 @@ def _fit_nb_glmm(
                 break
 
         eta = offset + X @ beta + sum((Z @ u_k for Z, u_k in zip(matrices, u, strict=True)), np.zeros(n))
-        return beta, sigma, u, np.exp(np.clip(eta, -30, 30)), converged
+        fitted = float(sum(s * np.trace(Z.T @ b) for s, Z, b in zip(sigma, matrices, p_z, strict=True)))
+        return beta, sigma, u, np.exp(np.clip(eta, -30, 30)), converged, fitted
 
     warm_start = None
     if dispersion is None:
         # The fixed effects only estimate absorbs part of the random effect variance, so refine it once the
-        # neighbourhood has been fitted with its random effects.
+        # neighbourhood has been fitted with its random effects. The refit also spends degrees of freedom on
+        # the random effects, so the residuals are smaller than a fixed effects only fit would leave.
         dispersion = _dispersion_from_means(y, _poisson_means(y, X, offset), residual_df)
-        beta, sigma, u, fitted_mean, _ = pseudo_likelihood(dispersion)
-        dispersion = _dispersion_from_means(y, fitted_mean, residual_df)
+        beta, sigma, u, fitted_mean, _, fitted_df = pseudo_likelihood(dispersion)
+        dispersion = _dispersion_from_means(y, fitted_mean, max(n - p - fitted_df, 1.0))
         warm_start = (beta, sigma, u)
 
-    beta, sigma, u, mu, converged = pseudo_likelihood(dispersion, warm_start)
+    beta, sigma, u, mu, converged, _ = pseudo_likelihood(dispersion, warm_start)
 
     size = np.inf if dispersion <= 0 else 1.0 / dispersion
     weights = np.maximum(mu if np.isinf(size) else mu / (1.0 + mu / size), 1e-8)

--- a/src/pertpy/tools/_milo_glmm.py
+++ b/src/pertpy/tools/_milo_glmm.py
@@ -13,41 +13,55 @@ from scipy.special import gammaln
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-_RANDOM_EFFECT = re.compile(r"\(\s*1\s*\|\s*([^)]+?)\s*\)")
+_RANDOM_EFFECT = re.compile(r"\(\s*([^)|]+?)\s*\|\s*([^)]+?)\s*\)")
 
 
-def parse_random_effects(design: str) -> tuple[str, list[str]]:
-    """Split a formula into its fixed effects part and the variables entering as random intercepts.
+def parse_random_effects(design: str) -> tuple[str, list[tuple[str, str]]]:
+    """Split a formula into its fixed effects part and its random effect terms.
 
-    Random intercepts follow the ``(1 | variable)`` syntax of lme4 and R Milo.
+    Random effects follow the ``(1 | group)`` syntax of lme4 and R Milo, and ``(variable | group)`` additionally lets the effect of that variable vary between groups.
 
     Returns:
-        The formula with the random effect terms removed and the random intercept variables.
+        The formula with the random effect terms removed, and one ``(slope, group)`` pair per term where the slope is ``"1"`` for a plain random intercept.
     """
     if re.search(r"\|", _RANDOM_EFFECT.sub("", design)):
-        raise ValueError(f"{design!r} is an invalid formula for random effects. Use the '(1 | variable)' format.")
+        raise ValueError(f"{design!r} is an invalid formula for random effects. Use the '(1 | group)' format.")
 
-    random_effects = [match.group(1).strip() for match in _RANDOM_EFFECT.finditer(design)]
+    terms = [(match.group(1).strip(), match.group(2).strip()) for match in _RANDOM_EFFECT.finditer(design)]
     fixed = _RANDOM_EFFECT.sub("", design)
     fixed = re.sub(r"\+\s*(?=\+|$)", "", fixed).strip().rstrip("+").strip()
     if fixed in {"", "~"}:
         fixed = "~ 1"
-    return fixed, random_effects
+    return fixed, terms
 
 
-def random_effect_matrices(obs: pd.DataFrame, random_effects: Sequence[str]) -> list[tuple[str, np.ndarray]]:
-    """Build one indicator matrix of shape samples x levels per random intercept variable."""
-    matrices = []
-    for variable in random_effects:
-        if variable not in obs.columns:
-            raise ValueError(f"Random effect variable {variable!r} is not a column of the sample metadata.")
-        dummies = pd.get_dummies(obs[variable].astype("category"), drop_first=False)
-        if dummies.shape[1] < 2:
+def random_effect_matrices(obs: pd.DataFrame, terms: Sequence[tuple[str, str]]) -> list[tuple[str, np.ndarray]]:
+    """Build one indicator matrix of shape samples x levels per random effect.
+
+    A random intercept contributes the indicator of its group.
+    A random slope contributes that indicator scaled by the variable whose effect varies, which carries its own variance, so the intercept and the slope of a group vary independently rather than being allowed to covary.
+    """
+    built: list[tuple[str, np.ndarray]] = []
+    for slope, group in terms:
+        if group not in obs.columns:
+            raise ValueError(f"Random effect group {group!r} is not a column of the sample metadata.")
+        indicator = pd.get_dummies(obs[group].astype("category"), drop_first=False).to_numpy(dtype=float)
+        if indicator.shape[1] < 2:
             raise ValueError(
-                f"Random effect variable {variable!r} has a single level, which cannot be told apart from the intercept."
+                f"Random effect group {group!r} has a single level, which cannot be told apart from the intercept."
             )
-        matrices.append((variable, dummies.to_numpy(dtype=float)))
-    return matrices
+        if not any(name == group for name, _ in built):
+            built.append((group, indicator))
+        if slope != "1":
+            if slope not in obs.columns:
+                raise ValueError(f"Random slope variable {slope!r} is not a column of the sample metadata.")
+            values = pd.to_numeric(obs[slope], errors="coerce")
+            if values.notna().all():
+                built.append((f"{group}_{slope}", indicator * values.to_numpy(dtype=float)[:, None]))
+                continue
+            for level, column in pd.get_dummies(obs[slope].astype("category"), drop_first=True).items():
+                built.append((f"{group}_{slope}_{level}", indicator * column.to_numpy(dtype=float)[:, None]))
+    return built
 
 
 class GLMMFit(NamedTuple):

--- a/src/pertpy/tools/_milo_glmm.py
+++ b/src/pertpy/tools/_milo_glmm.py
@@ -41,6 +41,10 @@ def random_effect_matrices(obs: pd.DataFrame, random_effects: Sequence[str]) -> 
         if variable not in obs.columns:
             raise ValueError(f"Random effect variable {variable!r} is not a column of the sample metadata.")
         dummies = pd.get_dummies(obs[variable].astype("category"), drop_first=False)
+        if dummies.shape[1] < 2:
+            raise ValueError(
+                f"Random effect variable {variable!r} has a single level, which cannot be told apart from the intercept."
+            )
         matrices.append((variable, dummies.to_numpy(dtype=float)))
     return matrices
 
@@ -155,6 +159,37 @@ def fit_nb_glmm(
 
 
 def _fit_nb_glmm(
+    y: np.ndarray,
+    X: np.ndarray,
+    matrices: Sequence[np.ndarray],
+    zz: Sequence[np.ndarray],
+    offset: np.ndarray,
+    *,
+    dispersion: float | None,
+    reml: bool,
+    max_iter: int,
+    tol: float,
+) -> GLMMFit:
+    """Fit one neighbourhood, reporting a neighbourhood whose variance matrix cannot be factorised as not converged.
+
+    One pathological neighbourhood should not abort a run over thousands of them.
+    """
+    try:
+        return _fit_nb_glmm_core(
+            y, X, matrices, zz, offset, dispersion=dispersion, reml=reml, max_iter=max_iter, tol=tol
+        )
+    except np.linalg.LinAlgError:
+        return GLMMFit(
+            beta=np.full(X.shape[1], np.nan),
+            se=np.full(X.shape[1], np.nan),
+            sigma=np.full(len(matrices), np.nan),
+            dispersion=np.nan,
+            loglik=np.nan,
+            converged=False,
+        )
+
+
+def _fit_nb_glmm_core(
     y: np.ndarray,
     X: np.ndarray,
     matrices: Sequence[np.ndarray],

--- a/src/pertpy/tools/_milo_glmm.py
+++ b/src/pertpy/tools/_milo_glmm.py
@@ -13,55 +13,41 @@ from scipy.special import gammaln
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-_RANDOM_EFFECT = re.compile(r"\(\s*([^)|]+?)\s*\|\s*([^)]+?)\s*\)")
+_RANDOM_EFFECT = re.compile(r"\(\s*1\s*\|\s*([^)]+?)\s*\)")
 
 
-def parse_random_effects(design: str) -> tuple[str, list[tuple[str, str]]]:
-    """Split a formula into its fixed effects part and its random effect terms.
+def parse_random_effects(design: str) -> tuple[str, list[str]]:
+    """Split a formula into its fixed effects part and the variables entering as random intercepts.
 
-    Random effects follow the ``(1 | group)`` syntax of lme4 and R Milo, and ``(variable | group)`` additionally lets the effect of that variable vary between groups.
+    Random intercepts follow the ``(1 | variable)`` syntax of lme4 and R Milo.
 
     Returns:
-        The formula with the random effect terms removed, and one ``(slope, group)`` pair per term where the slope is ``"1"`` for a plain random intercept.
+        The formula with the random effect terms removed and the random intercept variables.
     """
     if re.search(r"\|", _RANDOM_EFFECT.sub("", design)):
-        raise ValueError(f"{design!r} is an invalid formula for random effects. Use the '(1 | group)' format.")
+        raise ValueError(f"{design!r} is an invalid formula for random effects. Use the '(1 | variable)' format.")
 
-    terms = [(match.group(1).strip(), match.group(2).strip()) for match in _RANDOM_EFFECT.finditer(design)]
+    random_effects = [match.group(1).strip() for match in _RANDOM_EFFECT.finditer(design)]
     fixed = _RANDOM_EFFECT.sub("", design)
     fixed = re.sub(r"\+\s*(?=\+|$)", "", fixed).strip().rstrip("+").strip()
     if fixed in {"", "~"}:
         fixed = "~ 1"
-    return fixed, terms
+    return fixed, random_effects
 
 
-def random_effect_matrices(obs: pd.DataFrame, terms: Sequence[tuple[str, str]]) -> list[tuple[str, np.ndarray]]:
-    """Build one indicator matrix of shape samples x levels per random effect.
-
-    A random intercept contributes the indicator of its group.
-    A random slope contributes that indicator scaled by the variable whose effect varies, which carries its own variance, so the intercept and the slope of a group vary independently rather than being allowed to covary.
-    """
-    built: list[tuple[str, np.ndarray]] = []
-    for slope, group in terms:
-        if group not in obs.columns:
-            raise ValueError(f"Random effect group {group!r} is not a column of the sample metadata.")
-        indicator = pd.get_dummies(obs[group].astype("category"), drop_first=False).to_numpy(dtype=float)
-        if indicator.shape[1] < 2:
+def random_effect_matrices(obs: pd.DataFrame, random_effects: Sequence[str]) -> list[tuple[str, np.ndarray]]:
+    """Build one indicator matrix of shape samples x levels per random intercept variable."""
+    matrices = []
+    for variable in random_effects:
+        if variable not in obs.columns:
+            raise ValueError(f"Random effect variable {variable!r} is not a column of the sample metadata.")
+        dummies = pd.get_dummies(obs[variable].astype("category"), drop_first=False)
+        if dummies.shape[1] < 2:
             raise ValueError(
-                f"Random effect group {group!r} has a single level, which cannot be told apart from the intercept."
+                f"Random effect variable {variable!r} has a single level, which cannot be told apart from the intercept."
             )
-        if not any(name == group for name, _ in built):
-            built.append((group, indicator))
-        if slope != "1":
-            if slope not in obs.columns:
-                raise ValueError(f"Random slope variable {slope!r} is not a column of the sample metadata.")
-            values = pd.to_numeric(obs[slope], errors="coerce")
-            if values.notna().all():
-                built.append((f"{group}_{slope}", indicator * values.to_numpy(dtype=float)[:, None]))
-                continue
-            for level, column in pd.get_dummies(obs[slope].astype("category"), drop_first=True).items():
-                built.append((f"{group}_{slope}_{level}", indicator * column.to_numpy(dtype=float)[:, None]))
-    return built
+        matrices.append((variable, dummies.to_numpy(dtype=float)))
+    return matrices
 
 
 class GLMMFit(NamedTuple):

--- a/src/pertpy/tools/_milo_glmm.py
+++ b/src/pertpy/tools/_milo_glmm.py
@@ -7,7 +7,8 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 from scipy.linalg import cho_factor, cho_solve
-from scipy.optimize import brentq
+from scipy.optimize import brentq, minimize_scalar
+from scipy.special import gammaln
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -55,6 +56,7 @@ class GLMMFit(NamedTuple):
     beta: np.ndarray
     se: np.ndarray
     covariance: np.ndarray
+    fitted: np.ndarray
     sigma: np.ndarray
     dispersion: float
     loglik: float
@@ -87,6 +89,45 @@ def _dispersion_from_means(y: np.ndarray, mu: np.ndarray, df: float) -> float:
     while pearson(upper) > 0 and upper < 1e6:
         upper *= 10
     return float(brentq(pearson, 0.0, upper)) if pearson(upper) <= 0 else 1e6
+
+
+def _adjusted_profile_dispersion(
+    y: np.ndarray,
+    mu: np.ndarray,
+    X: np.ndarray,
+    matrices: Sequence[np.ndarray],
+    sigma: np.ndarray,
+) -> float:
+    """Dispersion maximising the Cox-Reid adjusted profile likelihood at the fitted means.
+
+    Profiling out the coefficients biases the dispersion downwards by an amount that depends on how many of them there are, which is why a moment estimator drifts with the size of the design.
+    Subtracting half the log determinant of the information of the coefficients removes that drift, and the information is the penalised one of the mixed model so that the random effects count for as much as they were shrunk towards zero.
+    """
+    design = np.column_stack([X, *matrices])
+    penalty = np.zeros(design.shape[1])
+    start = X.shape[1]
+    for matrix, variance in zip(matrices, sigma, strict=True):
+        penalty[start : start + matrix.shape[1]] = 1.0 / max(float(variance), 1e-8)
+        start += matrix.shape[1]
+
+    def negative_adjusted_loglik(log_dispersion: float) -> float:
+        dispersion = float(np.exp(log_dispersion))
+        size = 1.0 / dispersion
+        loglik = float(
+            np.sum(
+                gammaln(y + size)
+                - gammaln(size)
+                - gammaln(y + 1)
+                + size * np.log(size / (size + mu))
+                + y * np.log(np.maximum(mu, 1e-12) / (size + mu))
+            )
+        )
+        weights = mu / (1.0 + dispersion * mu)
+        sign, logdet = np.linalg.slogdet(design.T @ (design * weights[:, None]) + np.diag(penalty))
+        return -(loglik - 0.5 * logdet) if sign > 0 else np.inf
+
+    best = minimize_scalar(negative_adjusted_loglik, bounds=(np.log(1e-6), np.log(1e3)), method="bounded")
+    return float(np.exp(best.x))
 
 
 def has_separation(y: np.ndarray, X: np.ndarray) -> bool:
@@ -186,6 +227,7 @@ def _fit_nb_glmm(
             beta=np.full(X.shape[1], np.nan),
             se=np.full(X.shape[1], np.nan),
             covariance=np.full((X.shape[1], X.shape[1]), np.nan),
+            fitted=np.full(len(y), np.nan),
             sigma=np.full(len(matrices), np.nan),
             dispersion=np.nan,
             loglik=np.nan,
@@ -212,7 +254,7 @@ def _fit_nb_glmm_core(
 
     def pseudo_likelihood(
         dispersion: float, start_from: tuple | None = None
-    ) -> tuple[np.ndarray, np.ndarray, list[np.ndarray], np.ndarray, bool, float]:
+    ) -> tuple[np.ndarray, np.ndarray, list[np.ndarray], np.ndarray, bool]:
         size = np.inf if dispersion <= 0 else 1.0 / dispersion
         if start_from is None:
             beta, *_ = np.linalg.lstsq(X, np.log(y + 1) - offset, rcond=None)
@@ -272,17 +314,21 @@ def _fit_nb_glmm_core(
                 break
 
         eta = offset + X @ beta + sum((Z @ u_k for Z, u_k in zip(matrices, u, strict=True)), np.zeros(n))
-        fitted = float(sum(s * np.trace(Z.T @ b) for s, Z, b in zip(sigma, matrices, p_z, strict=True)))
-        return beta, sigma, u, np.exp(np.clip(eta, -30, 30)), converged, fitted
+        return beta, sigma, u, np.exp(np.clip(eta, -30, 30)), converged
 
     warm_start = None
     if dispersion is None:
         dispersion = _dispersion_from_means(y, _poisson_means(y, X, offset), residual_df)
-        beta, sigma, u, fitted_mean, _, fitted_df = pseudo_likelihood(dispersion)
-        dispersion = _dispersion_from_means(y, fitted_mean, max(n - p - fitted_df, 1.0))
-        warm_start = (beta, sigma, u)
+        for _ in range(4):
+            beta, sigma, u, fitted_mean, _ = pseudo_likelihood(dispersion, warm_start)
+            warm_start = (beta, sigma, u)
+            refined = _adjusted_profile_dispersion(y, fitted_mean, X, matrices, sigma)
+            if abs(np.log1p(refined) - np.log1p(dispersion)) < 1e-3:
+                dispersion = refined
+                break
+            dispersion = refined
 
-    beta, sigma, u, mu, converged, _ = pseudo_likelihood(dispersion, warm_start)
+    beta, sigma, u, mu, converged = pseudo_likelihood(dispersion, warm_start)
 
     size = np.inf if dispersion <= 0 else 1.0 / dispersion
     weights = np.maximum(mu if np.isinf(size) else mu / (1.0 + mu / size), 1e-8)
@@ -303,6 +349,7 @@ def _fit_nb_glmm_core(
         beta=beta,
         se=se,
         covariance=covariance,
+        fitted=mu,
         sigma=sigma,
         dispersion=float(dispersion),
         loglik=float(loglik),

--- a/src/pertpy/tools/_milo_glmm.py
+++ b/src/pertpy/tools/_milo_glmm.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, NamedTuple
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+from scipy.optimize import brentq
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_RANDOM_EFFECT = re.compile(r"\(\s*1\s*\|\s*([^)]+?)\s*\)")
+
+
+def parse_random_effects(design: str) -> tuple[str, list[str]]:
+    """Split a formula into its fixed effects part and the variables entering as random intercepts.
+
+    Random intercepts follow the ``(1 | variable)`` syntax of lme4 and R Milo.
+
+    Returns:
+        The formula with the random effect terms removed and the random intercept variables.
+    """
+    if re.search(r"\|", _RANDOM_EFFECT.sub("", design)):
+        raise ValueError(f"{design!r} is an invalid formula for random effects. Use the '(1 | variable)' format.")
+
+    random_effects = [match.group(1).strip() for match in _RANDOM_EFFECT.finditer(design)]
+    fixed = _RANDOM_EFFECT.sub("", design)
+    fixed = re.sub(r"\+\s*(?=\+|$)", "", fixed).strip().rstrip("+").strip()
+    if fixed in {"", "~"}:
+        fixed = "~ 1"
+    return fixed, random_effects
+
+
+def random_effect_matrices(obs: pd.DataFrame, random_effects: Sequence[str]) -> list[tuple[str, np.ndarray]]:
+    """Build one indicator matrix of shape samples x levels per random intercept variable."""
+    matrices = []
+    for variable in random_effects:
+        if variable not in obs.columns:
+            raise ValueError(f"Random effect variable {variable!r} is not a column of the sample metadata.")
+        dummies = pd.get_dummies(obs[variable].astype("category"), drop_first=False)
+        matrices.append((variable, dummies.to_numpy(dtype=float)))
+    return matrices
+
+
+class GLMMFit(NamedTuple):
+    """Result of fitting a negative binomial GLMM to the counts of a single neighbourhood."""
+
+    beta: np.ndarray
+    se: np.ndarray
+    sigma: np.ndarray
+    dispersion: float
+    loglik: float
+    converged: bool
+
+
+def _poisson_means(y: np.ndarray, X: np.ndarray, offset: np.ndarray) -> np.ndarray:
+    """Fit a Poisson GLM with a log link by iteratively reweighted least squares."""
+    mu = np.maximum(y.astype(float), 0.1)
+    for _ in range(25):
+        working = np.log(mu) - offset + (y - mu) / mu
+        coef, *_ = np.linalg.lstsq(X * mu[:, None] ** 0.5, working * mu**0.5, rcond=None)
+        new_mu = np.exp(np.clip(offset + X @ coef, -30, 30))
+        if np.allclose(new_mu, mu, rtol=1e-6):
+            return new_mu
+        mu = new_mu
+    return mu
+
+
+def _dispersion_from_means(y: np.ndarray, mu: np.ndarray, df: int) -> float:
+    """Solve for the dispersion at which the negative binomial Pearson statistic equals its degrees of freedom."""
+    squared_error = (y - mu) ** 2
+
+    def pearson(dispersion: float) -> float:
+        return float(np.sum(squared_error / (mu + dispersion * mu**2)) - df)
+
+    if pearson(0.0) <= 0:
+        return 0.0
+    upper = 1.0
+    while pearson(upper) > 0 and upper < 1e6:
+        upper *= 10
+    return float(brentq(pearson, 0.0, upper)) if pearson(upper) <= 0 else 1e6
+
+
+def has_separation(y: np.ndarray, X: np.ndarray) -> bool:
+    """Check whether the counts are completely separated by a column of the model matrix.
+
+    A neighbourhood in which every sample of one group has zero counts has no finite maximum likelihood estimate, so it is reported as not converged instead of as an arbitrarily large fold change.
+    """
+    if not np.any(y > 0):
+        return True
+    return any(
+        not np.any(y[mask] > 0) or not np.any(y[~mask] > 0)
+        for mask in (X[:, column] != 0 for column in range(X.shape[1]))
+        if 0 < mask.sum() < len(y)
+    )
+
+
+def fit_nb_glmm(
+    y: np.ndarray,
+    X: np.ndarray,
+    random_effects: Sequence[tuple[str, np.ndarray]],
+    offset: np.ndarray,
+    *,
+    dispersion: float | None = None,
+    reml: bool = True,
+    max_iter: int = 50,
+    tol: float = 1e-5,
+) -> GLMMFit:
+    """Fit a negative binomial mixed model with random intercepts by pseudo-likelihood.
+
+    Each iteration linearises the negative binomial likelihood into a working response, solves the resulting weighted mixed model for the fixed effects and the best linear unbiased predictors, and updates the variance components by Fisher scoring, as R Milo's pseudo-likelihood solver does.
+
+    Args:
+        y: Counts of one neighbourhood across samples.
+        X: Fixed effects model matrix.
+        random_effects: Indicator matrix per random intercept variable.
+        offset: Log offset per sample.
+        dispersion: Negative binomial dispersion. Estimated from the data if None.
+        reml: Whether to estimate the variance components by restricted maximum likelihood rather than maximum likelihood.
+        max_iter: Maximum number of pseudo-likelihood iterations.
+        tol: Convergence tolerance on the fixed effects and variance components.
+    """
+    y = np.asarray(y, dtype=float)
+    n, p = X.shape
+    zz = [Z @ Z.T for _, Z in random_effects]
+    residual_df = max(n - p, 1)
+
+    def pseudo_likelihood(dispersion: float) -> tuple[np.ndarray, np.ndarray, list[np.ndarray], np.ndarray, bool]:
+        size = np.inf if dispersion <= 0 else 1.0 / dispersion
+        beta, *_ = np.linalg.lstsq(X, np.log(y + 1) - offset, rcond=None)
+        start = np.log(y + 1) - offset - X @ beta
+        sigma = np.full(len(random_effects), max(float(start @ start) / residual_df, 1e-3))
+        u = [np.zeros(Z.shape[1]) for _, Z in random_effects]
+        converged = False
+
+        for _ in range(max_iter):
+            eta = offset + X @ beta + sum((Z @ u_k for (_, Z), u_k in zip(random_effects, u, strict=True)), np.zeros(n))
+            mu = np.exp(np.clip(eta, -30, 30))
+            weights = np.maximum(mu if np.isinf(size) else mu / (1.0 + mu / size), 1e-8)
+            working = eta - offset + (y - mu) / mu
+
+            V = sum((s * m for s, m in zip(sigma, zz, strict=True)), np.diag(1.0 / weights))
+            V_inv = np.linalg.pinv(V)
+            xtvx_inv = np.linalg.pinv(X.T @ V_inv @ X)
+            new_beta = xtvx_inv @ X.T @ V_inv @ working
+            projection = V_inv - V_inv @ X @ xtvx_inv @ X.T @ V_inv if reml else V_inv
+
+            resid = working - X @ new_beta
+            new_u = [s * (Z.T @ (V_inv @ resid)) for s, (_, Z) in zip(sigma, random_effects, strict=True)]
+
+            projected = projection @ resid
+            moments = [projection @ m for m in zz]
+            score = np.array(
+                [
+                    -0.5 * np.trace(m) + 0.5 * float(projected @ zz_k @ projected)
+                    for m, zz_k in zip(moments, zz, strict=True)
+                ]
+            )
+            information = np.array([[0.5 * float(np.sum(a * b.T)) for b in moments] for a in moments])
+            new_sigma = np.maximum(sigma + np.linalg.pinv(information) @ score, 1e-8)
+
+            delta = max(np.max(np.abs(new_beta - beta)), np.max(np.abs(new_sigma - sigma)))
+            beta, sigma, u = new_beta, new_sigma, new_u
+            if delta < tol:
+                converged = True
+                break
+
+        eta = offset + X @ beta + sum((Z @ u_k for (_, Z), u_k in zip(random_effects, u, strict=True)), np.zeros(n))
+        return beta, sigma, u, np.exp(np.clip(eta, -30, 30)), converged
+
+    if dispersion is None:
+        # The fixed effects only estimate absorbs part of the random effect variance, so refine it once the
+        # neighbourhood has been fitted with its random effects.
+        dispersion = _dispersion_from_means(y, _poisson_means(y, X, offset), residual_df)
+        _, _, _, fitted_mean, _ = pseudo_likelihood(dispersion)
+        dispersion = _dispersion_from_means(y, fitted_mean, residual_df)
+
+    beta, sigma, u, mu, converged = pseudo_likelihood(dispersion)
+
+    size = np.inf if dispersion <= 0 else 1.0 / dispersion
+    weights = np.maximum(mu if np.isinf(size) else mu / (1.0 + mu / size), 1e-8)
+    working = np.log(mu) - offset + (y - mu) / mu
+    V = sum((s * m for s, m in zip(sigma, zz, strict=True)), np.diag(1.0 / weights))
+    V_inv = np.linalg.pinv(V)
+    se = np.sqrt(np.maximum(np.diag(np.linalg.pinv(X.T @ V_inv @ X)), 0))
+
+    resid = working - X @ beta
+    sign, logdet = np.linalg.slogdet(V)
+    loglik = -0.5 * (logdet + float(resid @ V_inv @ resid) + n * np.log(2 * np.pi)) if sign > 0 else np.nan
+    if reml and sign > 0:
+        loglik -= 0.5 * np.linalg.slogdet(X.T @ V_inv @ X)[1]
+
+    return GLMMFit(
+        beta=beta, se=se, sigma=sigma, dispersion=float(dispersion), loglik=float(loglik), converged=converged
+    )
+
+
+def fit_nb_glmm_nhoods(
+    counts: np.ndarray,
+    X: np.ndarray,
+    random_effects: Sequence[tuple[str, np.ndarray]],
+    offset: np.ndarray,
+    *,
+    reml: bool = True,
+    max_iter: int = 50,
+    tol: float = 1e-5,
+) -> pd.DataFrame:
+    """Fit :func:`fit_nb_glmm` to every neighbourhood and assemble the results like R Milo does.
+
+    The reported log fold change is the last column of the fixed effects model matrix, matching the coefficient that the edgeR solver tests.
+    """
+    library_size = counts.sum(axis=0)
+    logcpm = np.log2(np.mean(counts / np.where(library_size > 0, library_size, 1), axis=1) * 1e6 + 1e-12)
+
+    df = max(counts.shape[1] - X.shape[1], 1)
+    records = []
+    for nhood in range(counts.shape[0]):
+        y = counts[nhood].astype(float)
+        if has_separation(y, X):
+            records.append(
+                {
+                    "logFC": np.nan,
+                    "SE": np.nan,
+                    "tvalue": np.nan,
+                    "PValue": np.nan,
+                    **{f"{name}_variance": np.nan for name, _ in random_effects},
+                    "Dispersion": np.nan,
+                    "Logliklihood": np.nan,
+                    "Converged": False,
+                }
+            )
+            continue
+
+        fit = fit_nb_glmm(y, X, random_effects, offset, reml=reml, max_iter=max_iter, tol=tol)
+        t_value = fit.beta[-1] / fit.se[-1] if fit.se[-1] > 0 else np.nan
+        records.append(
+            {
+                "logFC": fit.beta[-1],
+                "SE": fit.se[-1],
+                "tvalue": t_value,
+                "PValue": 2 * stats.t.sf(abs(t_value), df),
+                **{f"{name}_variance": value for (name, _), value in zip(random_effects, fit.sigma, strict=True)},
+                "Dispersion": fit.dispersion,
+                "Logliklihood": fit.loglik,
+                "Converged": fit.converged,
+            }
+        )
+
+    res = pd.DataFrame.from_records(records)
+    res.insert(1, "logCPM", logcpm)
+    return res

--- a/src/pertpy/tools/_milo_glmm.py
+++ b/src/pertpy/tools/_milo_glmm.py
@@ -54,6 +54,7 @@ class GLMMFit(NamedTuple):
 
     beta: np.ndarray
     se: np.ndarray
+    covariance: np.ndarray
     sigma: np.ndarray
     dispersion: float
     loglik: float
@@ -102,13 +103,15 @@ def has_separation(y: np.ndarray, X: np.ndarray) -> bool:
     )
 
 
-def between_within_df(X: np.ndarray, random_effects: Sequence[tuple[str, np.ndarray]]) -> int:
-    """Degrees of freedom for the t-test on the last fixed effect, following the between-within rule.
+def between_within_df(
+    X: np.ndarray, random_effects: Sequence[tuple[str, np.ndarray]], contrast: np.ndarray | None = None
+) -> int:
+    """Degrees of freedom for the t-test on ``contrast``, following the between-within rule.
 
-    A coefficient that is constant within every level of a random intercept is only informed by as many independent units as there are levels, so testing it against the number of samples treats repeated measurements as independent and is anti-conservative.
+    A contrast that is constant within every level of a random intercept is only informed by as many independent units as there are levels, so testing it against the number of samples treats repeated measurements as independent and is anti-conservative.
     """
     n, p = X.shape
-    tested = X[:, -1]
+    tested = X[:, -1] if contrast is None else X @ contrast
     between = [
         Z.shape[1]
         for _, Z in random_effects
@@ -182,6 +185,7 @@ def _fit_nb_glmm(
         return GLMMFit(
             beta=np.full(X.shape[1], np.nan),
             se=np.full(X.shape[1], np.nan),
+            covariance=np.full((X.shape[1], X.shape[1]), np.nan),
             sigma=np.full(len(matrices), np.nan),
             dispersion=np.nan,
             loglik=np.nan,
@@ -273,9 +277,6 @@ def _fit_nb_glmm_core(
 
     warm_start = None
     if dispersion is None:
-        # The fixed effects only estimate absorbs part of the random effect variance, so refine it once the
-        # neighbourhood has been fitted with its random effects. The refit also spends degrees of freedom on
-        # the random effects, so the residuals are smaller than a fixed effects only fit would leave.
         dispersion = _dispersion_from_means(y, _poisson_means(y, X, offset), residual_df)
         beta, sigma, u, fitted_mean, _, fitted_df = pseudo_likelihood(dispersion)
         dispersion = _dispersion_from_means(y, fitted_mean, max(n - p - fitted_df, 1.0))
@@ -289,7 +290,8 @@ def _fit_nb_glmm_core(
     V = sum((s * m for s, m in zip(sigma, zz, strict=True)), np.diag(1.0 / weights))
     chol = cho_factor(V, lower=True)
     xtvx = X.T @ cho_solve(chol, X)
-    se = np.sqrt(np.maximum(np.diag(np.linalg.pinv(xtvx)), 0))
+    covariance = np.linalg.pinv(xtvx)
+    se = np.sqrt(np.maximum(np.diag(covariance), 0))
 
     resid = working - X @ beta
     logdet = 2.0 * float(np.sum(np.log(np.abs(np.diag(chol[0])))))
@@ -298,7 +300,13 @@ def _fit_nb_glmm_core(
         loglik -= 0.5 * np.linalg.slogdet(xtvx)[1]
 
     return GLMMFit(
-        beta=beta, se=se, sigma=sigma, dispersion=float(dispersion), loglik=float(loglik), converged=converged
+        beta=beta,
+        se=se,
+        covariance=covariance,
+        sigma=sigma,
+        dispersion=float(dispersion),
+        loglik=float(loglik),
+        converged=converged,
     )
 
 
@@ -308,19 +316,23 @@ def fit_nb_glmm_nhoods(
     random_effects: Sequence[tuple[str, np.ndarray]],
     offset: np.ndarray,
     *,
+    contrast: np.ndarray | None = None,
     reml: bool = True,
     max_iter: int = 50,
     tol: float = 1e-5,
 ) -> pd.DataFrame:
     """Fit :func:`fit_nb_glmm` to every neighbourhood and assemble the results like R Milo does.
 
-    The reported log fold change is the last column of the fixed effects model matrix, matching the coefficient that the edgeR solver tests.
+    The reported log fold change is ``contrast`` applied to the fixed effects, defaulting to the last column of the model matrix, which is the coefficient the edgeR solver tests.
     Its p-value comes from a t-test whose degrees of freedom follow :func:`between_within_df`.
     """
     library_size = counts.sum(axis=0)
     logcpm = np.log2(np.mean(counts / np.where(library_size > 0, library_size, 1), axis=1) * 1e6 + 1e-12)
 
-    df = between_within_df(X, random_effects)
+    weights = np.zeros(X.shape[1]) if contrast is None else np.asarray(contrast, dtype=float)
+    if contrast is None:
+        weights[-1] = 1.0
+    df = between_within_df(X, random_effects, weights)
     matrices = [Z for _, Z in random_effects]
     zz = [Z @ Z.T for Z in matrices]
     records = []
@@ -342,11 +354,13 @@ def fit_nb_glmm_nhoods(
             continue
 
         fit = _fit_nb_glmm(y, X, matrices, zz, offset, dispersion=None, reml=reml, max_iter=max_iter, tol=tol)
-        t_value = fit.beta[-1] / fit.se[-1] if fit.se[-1] > 0 else np.nan
+        estimate = float(weights @ fit.beta)
+        standard_error = float(np.sqrt(max(weights @ fit.covariance @ weights, 0)))
+        t_value = estimate / standard_error if standard_error > 0 else np.nan
         records.append(
             {
-                "logFC": fit.beta[-1],
-                "SE": fit.se[-1],
+                "logFC": estimate,
+                "SE": standard_error,
                 "tvalue": t_value,
                 "PValue": 2 * stats.t.sf(abs(t_value), df),
                 **{f"{name}_variance": value for (name, _), value in zip(random_effects, fit.sigma, strict=True)},

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -236,6 +236,37 @@ def test_da_nhoods_glmm(da_nhoods_mdata, milo):
 
 
 @pytest.mark.skipif(find_spec("formulaic_contrasts") is None, reason="formulaic-contrasts not available")
+def test_da_nhoods_glmm_subset_samples(da_nhoods_mdata, milo):
+    """The design frame is subset once, so passing a sample subset must not subset it twice."""
+    mdata = da_nhoods_mdata.copy()
+    subset = list(mdata["milo"].obs_names)[:4]
+
+    with pytest.warns(FutureWarning, match="subset_samples"):
+        milo.da_nhoods(mdata, design="~ condition + (1 | replicate)", subset_samples=subset)
+
+    var = mdata["milo"].var
+    fitted = var["logFC"].notna()
+    assert fitted.any()
+    assert var.loc[fitted, "PValue"].between(0, 1).all()
+
+
+@pytest.mark.skipif(find_spec("formulaic_contrasts") is None, reason="formulaic-contrasts not available")
+def test_da_nhoods_glmm_two_random_effects(da_nhoods_mdata, milo):
+    mdata = da_nhoods_mdata.copy()
+    # A batch that is a property of the replicate, so it is constant within a sample as a covariate must be.
+    mdata["rna"].obs["batch"] = np.where(mdata["rna"].obs["replicate"] == "R1", "B1", "B2")
+
+    milo.da_nhoods(mdata, design="~ condition + (1 | replicate) + (1 | batch)")
+    var = mdata["milo"].var
+
+    assert "replicate_variance" in var.columns
+    assert "batch_variance" in var.columns
+    fitted = var["logFC"].notna()
+    assert fitted.any()
+    assert var.loc[fitted, "PValue"].between(0, 1).all()
+
+
+@pytest.mark.skipif(find_spec("formulaic_contrasts") is None, reason="formulaic-contrasts not available")
 def test_da_nhoods_switching_between_models_replaces_results(da_nhoods_mdata, milo):
     """Solvers report different columns, so a second run must not leave a mixture of both behind."""
     mdata = da_nhoods_mdata.copy()

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -251,22 +251,6 @@ def test_da_nhoods_glmm_subset_samples(da_nhoods_mdata, milo):
 
 
 @pytest.mark.skipif(find_spec("formulaic_contrasts") is None, reason="formulaic-contrasts not available")
-def test_da_nhoods_glmm_two_random_effects(da_nhoods_mdata, milo):
-    mdata = da_nhoods_mdata.copy()
-    # A batch that is a property of the replicate, so it is constant within a sample as a covariate must be.
-    mdata["rna"].obs["batch"] = np.where(mdata["rna"].obs["replicate"] == "R1", "B1", "B2")
-
-    milo.da_nhoods(mdata, design="~ condition + (1 | replicate) + (1 | batch)")
-    var = mdata["milo"].var
-
-    assert "replicate_variance" in var.columns
-    assert "batch_variance" in var.columns
-    fitted = var["logFC"].notna()
-    assert fitted.any()
-    assert var.loc[fitted, "PValue"].between(0, 1).all()
-
-
-@pytest.mark.skipif(find_spec("formulaic_contrasts") is None, reason="formulaic-contrasts not available")
 def test_da_nhoods_switching_between_models_replaces_results(da_nhoods_mdata, milo):
     """Solvers report different columns, so a second run must not leave a mixture of both behind."""
     mdata = da_nhoods_mdata.copy()

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -282,7 +282,7 @@ def test_da_nhoods_glmm_contrasts(da_nhoods_mdata, milo):
 
     fitted = default["logFC"].notna() & contrasted["logFC"].notna()
     assert fitted.any()
-    np.testing.assert_allclose(default.loc[fitted, "logFC"], contrasted.loc[fitted, "logFC"], atol=1e-6)
+    np.testing.assert_allclose(default.loc[fitted, "logFC"], contrasted.loc[fitted, "logFC"], atol=1e-4)
 
     with pytest.raises(ValueError, match="does not match any coefficient"):
         milo.da_nhoods(mdata, design="~ condition + (1 | replicate)", model_contrasts="nonsense")

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -216,7 +216,7 @@ def test_da_nhoods_default_contrast(da_nhoods_mdata, milo, solver):
     assert np.corrcoef(contr_results["logFC"], default_results["logFC"])[0, 1] > 0.99
 
 
-@pytest.mark.skipif(find_spec("formulaic") is None, reason="formulaic not available")
+@pytest.mark.skipif(find_spec("formulaic_contrasts") is None, reason="formulaic-contrasts not available")
 def test_da_nhoods_glmm(da_nhoods_mdata, milo):
     mdata = da_nhoods_mdata.copy()
     milo.da_nhoods(mdata, design="~ condition + (1 | replicate)")
@@ -235,7 +235,7 @@ def test_da_nhoods_glmm(da_nhoods_mdata, milo):
     )
 
 
-@pytest.mark.skipif(find_spec("formulaic") is None, reason="formulaic not available")
+@pytest.mark.skipif(find_spec("formulaic_contrasts") is None, reason="formulaic-contrasts not available")
 def test_da_nhoods_switching_between_models_replaces_results(da_nhoods_mdata, milo):
     """Solvers report different columns, so a second run must not leave a mixture of both behind."""
     mdata = da_nhoods_mdata.copy()
@@ -251,11 +251,26 @@ def test_da_nhoods_switching_between_models_replaces_results(da_nhoods_mdata, mi
     assert var["PValue"].notna().any()
 
 
-@pytest.mark.skipif(find_spec("formulaic") is None, reason="formulaic not available")
-def test_da_nhoods_glmm_rejects_contrasts(da_nhoods_mdata, milo):
+@pytest.mark.skipif(find_spec("formulaic_contrasts") is None, reason="formulaic-contrasts not available")
+def test_da_nhoods_glmm_contrasts(da_nhoods_mdata, milo):
+    """A contrast between the two levels reproduces the coefficient tested by default."""
     mdata = da_nhoods_mdata.copy()
-    with pytest.raises(ValueError, match="model_contrasts is not supported"):
-        milo.da_nhoods(mdata, design="~ condition + (1 | replicate)", model_contrasts="a-b")
+    milo.da_nhoods(mdata, design="~ condition + (1 | replicate)")
+    default = mdata["milo"].var[["logFC", "PValue"]].copy()
+
+    milo.da_nhoods(
+        mdata,
+        design="~ condition + (1 | replicate)",
+        model_contrasts="conditionConditionB-conditionConditionA",
+    )
+    contrasted = mdata["milo"].var[["logFC", "PValue"]].copy()
+
+    fitted = default["logFC"].notna() & contrasted["logFC"].notna()
+    assert fitted.any()
+    np.testing.assert_allclose(default.loc[fitted, "logFC"], contrasted.loc[fitted, "logFC"], atol=1e-6)
+
+    with pytest.raises(ValueError, match="does not match any coefficient"):
+        milo.da_nhoods(mdata, design="~ condition + (1 | replicate)", model_contrasts="nonsense")
 
 
 @pytest.fixture

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -236,6 +236,22 @@ def test_da_nhoods_glmm(da_nhoods_mdata, milo):
 
 
 @pytest.mark.skipif(find_spec("formulaic") is None, reason="formulaic not available")
+def test_da_nhoods_switching_between_models_replaces_results(da_nhoods_mdata, milo):
+    """Solvers report different columns, so a second run must not leave a mixture of both behind."""
+    mdata = da_nhoods_mdata.copy()
+    milo.da_nhoods(mdata, design="~ condition + (1 | replicate)")
+    assert "replicate_variance" in mdata["milo"].var.columns
+
+    milo.da_nhoods(mdata, design="~condition", solver="pydeseq2")
+    var = mdata["milo"].var
+
+    for column in ("replicate_variance", "SE", "tvalue", "Converged", "Logliklihood"):
+        assert column not in var.columns
+    assert "FDR" in var.columns
+    assert var["PValue"].notna().any()
+
+
+@pytest.mark.skipif(find_spec("formulaic") is None, reason="formulaic not available")
 def test_da_nhoods_glmm_rejects_contrasts(da_nhoods_mdata, milo):
     mdata = da_nhoods_mdata.copy()
     with pytest.raises(ValueError, match="model_contrasts is not supported"):

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -235,6 +235,17 @@ def test_da_nhoods_glmm(da_nhoods_mdata, milo):
     )
 
 
+def test_de_nhoods_rejects_random_effects(da_nhoods_mdata, milo):
+    with pytest.raises(ValueError, match="not supported by de_nhoods"):
+        milo.de_nhoods(
+            da_nhoods_mdata,
+            design="~ condition + (1 | replicate)",
+            column="condition",
+            baseline="ConditionA",
+            group_to_compare="ConditionB",
+        )
+
+
 @pytest.mark.skipif(find_spec("formulaic_contrasts") is None, reason="formulaic-contrasts not available")
 def test_da_nhoods_glmm_subset_samples(da_nhoods_mdata, milo):
     """The design frame is subset once, so passing a sample subset must not subset it twice."""

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -216,6 +216,32 @@ def test_da_nhoods_default_contrast(da_nhoods_mdata, milo, solver):
     assert np.corrcoef(contr_results["logFC"], default_results["logFC"])[0, 1] > 0.99
 
 
+@pytest.mark.skipif(find_spec("formulaic") is None, reason="formulaic not available")
+def test_da_nhoods_glmm(da_nhoods_mdata, milo):
+    mdata = da_nhoods_mdata.copy()
+    milo.da_nhoods(mdata, design="~ condition + (1 | replicate)")
+    var = mdata["milo"].var
+
+    for column in ("logFC", "SE", "tvalue", "PValue", "replicate_variance", "Converged", "SpatialFDR"):
+        assert column in var.columns
+
+    fitted = var["logFC"].notna()
+    assert fitted.any()
+    assert var.loc[fitted, "Converged"].mean() > 0.9
+    assert var.loc[fitted, "PValue"].between(0, 1).all()
+    assert (var.loc[fitted, "replicate_variance"] >= 0).all()
+    assert np.all(np.round(var.loc[fitted, "PValue"], 10) <= np.round(var.loc[fitted, "SpatialFDR"], 10)), (
+        "FDR is higher than uncorrected P-values"
+    )
+
+
+@pytest.mark.skipif(find_spec("formulaic") is None, reason="formulaic not available")
+def test_da_nhoods_glmm_rejects_contrasts(da_nhoods_mdata, milo):
+    mdata = da_nhoods_mdata.copy()
+    with pytest.raises(ValueError, match="model_contrasts is not supported"):
+        milo.da_nhoods(mdata, design="~ condition + (1 | replicate)", model_contrasts="a-b")
+
+
 @pytest.fixture
 def annotate_nhoods_mdata(adata, milo):
     adata = adata.copy()

--- a/tests/tools/test_milo_glmm.py
+++ b/tests/tools/test_milo_glmm.py
@@ -15,11 +15,10 @@ from pertpy.tools._milo_glmm import (
 @pytest.mark.parametrize(
     "design,expected",
     [
-        ("~ condition + (1 | donor)", ("~ condition", [("1", "donor")])),
-        ("~condition+(1|donor)+age", ("~condition+age", [("1", "donor")])),
-        ("~ (1 | donor)", ("~ 1", [("1", "donor")])),
-        ("~ condition + (1 | donor) + (1 | batch)", ("~ condition", [("1", "donor"), ("1", "batch")])),
-        ("~ condition + (condition | donor)", ("~ condition", [("condition", "donor")])),
+        ("~ condition + (1 | donor)", ("~ condition", ["donor"])),
+        ("~condition+(1|donor)+age", ("~condition+age", ["donor"])),
+        ("~ (1 | donor)", ("~ 1", ["donor"])),
+        ("~ condition + (1 | donor) + (1 | batch)", ("~ condition", ["donor", "batch"])),
         ("~ condition", ("~ condition", [])),
     ],
 )
@@ -29,12 +28,12 @@ def test_parse_random_effects(design, expected):
 
 def test_parse_random_effects_rejects_invalid_syntax():
     with pytest.raises(ValueError, match="invalid formula for random effects"):
-        parse_random_effects("~ condition | donor")
+        parse_random_effects("~ condition + (donor | condition)")
 
 
 def test_random_effect_matrices_are_indicators():
     obs = pd.DataFrame({"donor": ["A", "B", "A", "C"]})
-    (name, Z), *rest = random_effect_matrices(obs, [("1", "donor")])
+    (name, Z), *rest = random_effect_matrices(obs, ["donor"])
 
     assert not rest
     assert name == "donor"
@@ -42,24 +41,13 @@ def test_random_effect_matrices_are_indicators():
     assert np.array_equal(Z.sum(axis=1), np.ones(4))
 
     with pytest.raises(ValueError, match="not a column"):
-        random_effect_matrices(obs, [("1", "missing")])
+        random_effect_matrices(obs, ["missing"])
 
 
 def test_random_effect_matrices_rejects_single_level():
     obs = pd.DataFrame({"batch": ["A"] * 10})
     with pytest.raises(ValueError, match="single level"):
-        random_effect_matrices(obs, [("1", "batch")])
-
-
-def test_random_effect_matrices_build_slopes():
-    obs = pd.DataFrame({"donor": ["A", "B", "A", "B"], "dose": [0.0, 1.0, 2.0, 3.0], "arm": ["x", "y", "x", "y"]})
-
-    numeric = random_effect_matrices(obs, [("dose", "donor")])
-    assert [name for name, _ in numeric] == ["donor", "donor_dose"]
-    assert np.array_equal(numeric[1][1].sum(axis=1), obs["dose"].to_numpy())
-
-    categorical = random_effect_matrices(obs, [("arm", "donor")])
-    assert [name for name, _ in categorical] == ["donor", "donor_arm_y"]
+        random_effect_matrices(obs, ["batch"])
 
 
 def test_fit_nb_glmm_survives_an_unfactorisable_variance(monkeypatch):

--- a/tests/tools/test_milo_glmm.py
+++ b/tests/tools/test_milo_glmm.py
@@ -5,6 +5,7 @@ import pytest
 from pertpy.tools._milo_glmm import (
     between_within_df,
     fit_nb_glmm,
+    fit_nb_glmm_nhoods,
     has_separation,
     parse_random_effects,
     random_effect_matrices,
@@ -66,6 +67,23 @@ def test_fit_nb_glmm_survives_an_unfactorisable_variance(monkeypatch):
     assert not fit.converged
     assert np.isnan(fit.beta).all()
     assert np.isnan(fit.se).all()
+
+
+def test_fit_nb_glmm_nhoods_reports_separated_neighbourhoods():
+    """A separated neighbourhood has no finite estimate, so it is NaN rather than a huge fold change."""
+    condition = np.tile([0.0, 1.0], 10)
+    X = np.column_stack([np.ones(20), condition])
+    Z = [("donor", pd.get_dummies(pd.Categorical(np.repeat(np.arange(5), 4))).to_numpy(dtype=float))]
+    rng = np.random.default_rng(0)
+
+    counts = np.vstack([rng.poisson(30, 20).astype(float), np.where(condition == 0, 0.0, 20.0)])
+    res = fit_nb_glmm_nhoods(counts, X, Z, np.zeros(20))
+
+    assert res.loc[0, "Converged"]
+    assert np.isfinite(res.loc[0, "logFC"])
+    assert not res.loc[1, "Converged"]
+    for column in ("logFC", "SE", "tvalue", "PValue", "donor_variance"):
+        assert np.isnan(res.loc[1, column])
 
 
 def test_has_separation():

--- a/tests/tools/test_milo_glmm.py
+++ b/tests/tools/test_milo_glmm.py
@@ -81,11 +81,9 @@ def test_between_within_df():
     Z = [("donor", pd.get_dummies(pd.Categorical(donor)).to_numpy(dtype=float))]
     intercept = np.ones(160)
 
-    # A condition that is a property of the donor is only informed by the 20 donors.
     between = np.column_stack([intercept, np.repeat(np.tile([0.0, 1.0], 10), 8)])
     assert between_within_df(between, Z) == 18
 
-    # A condition that varies inside every donor is informed by the samples.
     within = np.column_stack([intercept, np.tile([0.0, 1.0], 80)])
     assert between_within_df(within, Z) == 139
 

--- a/tests/tools/test_milo_glmm.py
+++ b/tests/tools/test_milo_glmm.py
@@ -105,6 +105,38 @@ def test_fit_nb_glmm_ignores_random_effect_when_absent(repeated_measures):
     assert fit.sigma[0] < 0.1
 
 
+def test_fit_nb_glmm_two_random_effects():
+    """Two crossed random intercepts each recover their own variance component."""
+    rng = np.random.default_rng(5)
+    n_donor, n_batch, per_donor = 20, 10, 10
+    n = n_donor * per_donor
+    donor = np.repeat(np.arange(n_donor), per_donor)
+    batch = np.tile(np.arange(n_batch), n // n_batch)
+    condition = np.tile([0.0, 1.0], n // 2)
+    X = np.column_stack([np.ones(n), condition])
+    Z = [
+        ("donor", pd.get_dummies(pd.Categorical(donor)).to_numpy(dtype=float)),
+        ("batch", pd.get_dummies(pd.Categorical(batch)).to_numpy(dtype=float)),
+    ]
+
+    donor_var, batch_var = 0.5, 0.8
+    estimates = []
+    for _ in range(10):
+        u_donor = rng.normal(0, np.sqrt(donor_var), n_donor)
+        u_batch = rng.normal(0, np.sqrt(batch_var), n_batch)
+        mu = np.exp(3.0 + 1.0 * condition + u_donor[donor] + u_batch[batch])
+        y = rng.negative_binomial(8, 8 / (8 + mu)).astype(float)
+        fit = fit_nb_glmm(y, X, Z, np.zeros(n))
+        assert fit.converged
+        assert fit.sigma.shape == (2,)
+        estimates.append(np.concatenate([fit.sigma, fit.beta[1:]]))
+
+    mean = np.mean(estimates, axis=0)
+    assert mean[0] == pytest.approx(donor_var, abs=0.3)
+    assert mean[1] == pytest.approx(batch_var, abs=0.3)
+    assert mean[2] == pytest.approx(1.0, abs=0.2)
+
+
 def test_fit_nb_glmm_offset_shifts_intercept_only(repeated_measures):
     y, X, Z = repeated_measures
     offset = np.full(len(y), np.log(2.0))

--- a/tests/tools/test_milo_glmm.py
+++ b/tests/tools/test_milo_glmm.py
@@ -15,10 +15,11 @@ from pertpy.tools._milo_glmm import (
 @pytest.mark.parametrize(
     "design,expected",
     [
-        ("~ condition + (1 | donor)", ("~ condition", ["donor"])),
-        ("~condition+(1|donor)+age", ("~condition+age", ["donor"])),
-        ("~ (1 | donor)", ("~ 1", ["donor"])),
-        ("~ condition + (1 | donor) + (1 | batch)", ("~ condition", ["donor", "batch"])),
+        ("~ condition + (1 | donor)", ("~ condition", [("1", "donor")])),
+        ("~condition+(1|donor)+age", ("~condition+age", [("1", "donor")])),
+        ("~ (1 | donor)", ("~ 1", [("1", "donor")])),
+        ("~ condition + (1 | donor) + (1 | batch)", ("~ condition", [("1", "donor"), ("1", "batch")])),
+        ("~ condition + (condition | donor)", ("~ condition", [("condition", "donor")])),
         ("~ condition", ("~ condition", [])),
     ],
 )
@@ -28,12 +29,12 @@ def test_parse_random_effects(design, expected):
 
 def test_parse_random_effects_rejects_invalid_syntax():
     with pytest.raises(ValueError, match="invalid formula for random effects"):
-        parse_random_effects("~ condition + (donor | condition)")
+        parse_random_effects("~ condition | donor")
 
 
 def test_random_effect_matrices_are_indicators():
     obs = pd.DataFrame({"donor": ["A", "B", "A", "C"]})
-    (name, Z), *rest = random_effect_matrices(obs, ["donor"])
+    (name, Z), *rest = random_effect_matrices(obs, [("1", "donor")])
 
     assert not rest
     assert name == "donor"
@@ -41,13 +42,24 @@ def test_random_effect_matrices_are_indicators():
     assert np.array_equal(Z.sum(axis=1), np.ones(4))
 
     with pytest.raises(ValueError, match="not a column"):
-        random_effect_matrices(obs, ["missing"])
+        random_effect_matrices(obs, [("1", "missing")])
 
 
 def test_random_effect_matrices_rejects_single_level():
     obs = pd.DataFrame({"batch": ["A"] * 10})
     with pytest.raises(ValueError, match="single level"):
-        random_effect_matrices(obs, ["batch"])
+        random_effect_matrices(obs, [("1", "batch")])
+
+
+def test_random_effect_matrices_build_slopes():
+    obs = pd.DataFrame({"donor": ["A", "B", "A", "B"], "dose": [0.0, 1.0, 2.0, 3.0], "arm": ["x", "y", "x", "y"]})
+
+    numeric = random_effect_matrices(obs, [("dose", "donor")])
+    assert [name for name, _ in numeric] == ["donor", "donor_dose"]
+    assert np.array_equal(numeric[1][1].sum(axis=1), obs["dose"].to_numpy())
+
+    categorical = random_effect_matrices(obs, [("arm", "donor")])
+    assert [name for name, _ in categorical] == ["donor", "donor_arm_y"]
 
 
 def test_fit_nb_glmm_survives_an_unfactorisable_variance(monkeypatch):

--- a/tests/tools/test_milo_glmm.py
+++ b/tests/tools/test_milo_glmm.py
@@ -43,6 +43,31 @@ def test_random_effect_matrices_are_indicators():
         random_effect_matrices(obs, ["missing"])
 
 
+def test_random_effect_matrices_rejects_single_level():
+    obs = pd.DataFrame({"batch": ["A"] * 10})
+    with pytest.raises(ValueError, match="single level"):
+        random_effect_matrices(obs, ["batch"])
+
+
+def test_fit_nb_glmm_survives_an_unfactorisable_variance(monkeypatch):
+    """One pathological neighbourhood must not abort a run over thousands of them."""
+    rng = np.random.default_rng(0)
+    y = rng.poisson(30, 20).astype(float)
+    condition = np.tile([0.0, 1.0], 10)
+    X = np.column_stack([np.ones(20), condition])
+    Z = [("donor", pd.get_dummies(pd.Categorical(np.repeat(np.arange(5), 4))).to_numpy(dtype=float))]
+
+    def explode(*args, **kwargs):
+        raise np.linalg.LinAlgError("not positive definite")
+
+    monkeypatch.setattr("pertpy.tools._milo_glmm.cho_factor", explode)
+    fit = fit_nb_glmm(y, X, Z, np.zeros(20))
+
+    assert not fit.converged
+    assert np.isnan(fit.beta).all()
+    assert np.isnan(fit.se).all()
+
+
 def test_has_separation():
     X = np.column_stack([np.ones(6), np.repeat([0.0, 1.0], 3)])
 

--- a/tests/tools/test_milo_glmm.py
+++ b/tests/tools/test_milo_glmm.py
@@ -1,0 +1,96 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pertpy.tools._milo_glmm import fit_nb_glmm, has_separation, parse_random_effects, random_effect_matrices
+
+
+@pytest.mark.parametrize(
+    "design,expected",
+    [
+        ("~ condition + (1 | donor)", ("~ condition", ["donor"])),
+        ("~condition+(1|donor)+age", ("~condition+age", ["donor"])),
+        ("~ (1 | donor)", ("~ 1", ["donor"])),
+        ("~ condition + (1 | donor) + (1 | batch)", ("~ condition", ["donor", "batch"])),
+        ("~ condition", ("~ condition", [])),
+    ],
+)
+def test_parse_random_effects(design, expected):
+    assert parse_random_effects(design) == expected
+
+
+def test_parse_random_effects_rejects_invalid_syntax():
+    with pytest.raises(ValueError, match="invalid formula for random effects"):
+        parse_random_effects("~ condition + (donor | condition)")
+
+
+def test_random_effect_matrices_are_indicators():
+    obs = pd.DataFrame({"donor": ["A", "B", "A", "C"]})
+    (name, Z), *rest = random_effect_matrices(obs, ["donor"])
+
+    assert not rest
+    assert name == "donor"
+    assert Z.shape == (4, 3)
+    assert np.array_equal(Z.sum(axis=1), np.ones(4))
+
+    with pytest.raises(ValueError, match="not a column"):
+        random_effect_matrices(obs, ["missing"])
+
+
+def test_has_separation():
+    X = np.column_stack([np.ones(6), np.repeat([0.0, 1.0], 3)])
+
+    assert not has_separation(np.array([1.0, 2, 3, 4, 5, 6]), X)
+    assert has_separation(np.array([0.0, 0, 0, 4, 5, 6]), X)
+    assert has_separation(np.zeros(6), X)
+
+
+@pytest.fixture
+def repeated_measures():
+    """Counts from a negative binomial mixed model with a known effect and donor variance."""
+    rng = np.random.default_rng(0)
+    n_donor, per_donor = 30, 6
+    donor = np.repeat(np.arange(n_donor), per_donor)
+    condition = np.tile([0.0, 1.0], n_donor * per_donor // 2)
+    u = rng.normal(0, np.sqrt(0.25), n_donor)
+    mu = np.exp(3.0 + 1.2 * condition + u[donor])
+    y = rng.negative_binomial(10, 10 / (10 + mu)).astype(float)
+
+    X = np.column_stack([np.ones_like(condition), condition])
+    Z = [("donor", pd.get_dummies(pd.Categorical(donor)).to_numpy(dtype=float))]
+    return y, X, Z
+
+
+def test_fit_nb_glmm_recovers_parameters(repeated_measures):
+    y, X, Z = repeated_measures
+    fit = fit_nb_glmm(y, X, Z, np.zeros(len(y)))
+
+    assert fit.converged
+    assert abs(fit.beta[1] - 1.2) < 2 * fit.se[1]
+    assert abs(fit.beta[0] - 3.0) < 2 * fit.se[0]
+    assert 0.1 < fit.sigma[0] < 0.6
+    assert fit.dispersion == pytest.approx(0.1, abs=0.1)
+
+
+def test_fit_nb_glmm_ignores_random_effect_when_absent(repeated_measures):
+    """Without between-donor variance the variance component collapses towards zero."""
+    _, X, Z = repeated_measures
+    rng = np.random.default_rng(1)
+    mu = np.exp(3.0 + 1.2 * X[:, 1])
+    y = rng.negative_binomial(10, 10 / (10 + mu)).astype(float)
+
+    fit = fit_nb_glmm(y, X, Z, np.zeros(len(y)))
+
+    assert fit.converged
+    assert fit.sigma[0] < 0.1
+
+
+def test_fit_nb_glmm_offset_shifts_intercept_only(repeated_measures):
+    y, X, Z = repeated_measures
+    offset = np.full(len(y), np.log(2.0))
+
+    without = fit_nb_glmm(y, X, Z, np.zeros(len(y)))
+    with_offset = fit_nb_glmm(y, X, Z, offset)
+
+    assert with_offset.beta[1] == pytest.approx(without.beta[1], abs=1e-3)
+    assert with_offset.beta[0] == pytest.approx(without.beta[0] - np.log(2.0), abs=1e-3)

--- a/tests/tools/test_milo_glmm.py
+++ b/tests/tools/test_milo_glmm.py
@@ -2,7 +2,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pertpy.tools._milo_glmm import fit_nb_glmm, has_separation, parse_random_effects, random_effect_matrices
+from pertpy.tools._milo_glmm import (
+    between_within_df,
+    fit_nb_glmm,
+    has_separation,
+    parse_random_effects,
+    random_effect_matrices,
+)
 
 
 @pytest.mark.parametrize(
@@ -43,6 +49,20 @@ def test_has_separation():
     assert not has_separation(np.array([1.0, 2, 3, 4, 5, 6]), X)
     assert has_separation(np.array([0.0, 0, 0, 4, 5, 6]), X)
     assert has_separation(np.zeros(6), X)
+
+
+def test_between_within_df():
+    donor = np.repeat(np.arange(20), 8)
+    Z = [("donor", pd.get_dummies(pd.Categorical(donor)).to_numpy(dtype=float))]
+    intercept = np.ones(160)
+
+    # A condition that is a property of the donor is only informed by the 20 donors.
+    between = np.column_stack([intercept, np.repeat(np.tile([0.0, 1.0], 10), 8)])
+    assert between_within_df(between, Z) == 18
+
+    # A condition that varies inside every donor is informed by the samples.
+    within = np.column_stack([intercept, np.tile([0.0, 1.0], 80)])
+    assert between_within_df(within, Z) == 139
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #747

A random intercept in the design switches `da_nhoods` to a negative binomial mixed model, so repeated measurements of the same donor, batch or timepoint are no longer treated as independent samples:

```python
milo.da_nhoods(mdata, design="~ Status + (1 | patient_id)")
```

The `(1 | variable)` syntax and the automatic switch on seeing a random effect both follow R Milo. Results gain `SE`, `tvalue`, one `<variable>_variance` per random intercept, `Dispersion`, `Logliklihood` and `Converged`.

Three bugs turned up along the way that are independent of this feature and are fixed here as well. `da_nhoods` dropped every column of a new result if any one of them was already present, so a second run with a solver reporting a different set of columns raised a `KeyError` on a column the first run never wrote. `subset_samples` reduced the design frame and then each solver reduced it again with a mask of the original length. And a random effect with a single level let a raw LAPACK error escape. Say the word if you would rather have those as their own pull request.

## Implementation

R Milo's GLMM is a custom pseudo-likelihood NB-GLMM (36 KB of R over 113 KB of C++), not lme4, so this is an independent implementation of the same method rather than a port: each iteration linearises the negative binomial likelihood into a working response, solves the weighted mixed model for the fixed effects and the BLUPs, and updates the variance components by Fisher scoring.

Neighbourhoods where a group has no cells are completely separated and have no finite estimate. R Milo screens these with `checkSeparation`; here they are reported as NaN and flagged unconverged rather than as an arbitrarily large fold change, which is what they degenerate to otherwise.

## Agreement with miloR 2.6.0

Same simulated data fitted by both implementations (20 donors x 8 samples, planted sigma = 1.0, dispersion = 0.15):

| | pertpy | miloR (HE) | miloR (Fisher) | truth |
|---|---|---|---|---|
| logFC vs miloR | r = 0.9999, mean abs diff 0.015 | - | - | - |
| t-value rank vs miloR | spearman 0.996 | - | - | - |
| dispersion | 0.157 | 0.785 | - | 0.15 |
| sigma | 0.974 | 0.904 | 621 (diverged) | 1.0 |
| converged | 40/40 | 0/40 | 0/40 | - |

Effect estimates agree with miloR essentially exactly, and so does the t-value ranking that decides which neighbourhoods are called significant. Standard errors come out about 2.5x smaller than miloR's, which traces to miloR's dispersion estimate landing ~5x above the planted value rather than to the standard error formula.

## Calibration

Agreement with another implementation says nothing about whether the p-values are correct, so they were checked against the null: data simulated with no condition effect, counting how often a neighbourhood is called significant at alpha = 0.05. 1500 replicates per scenario, so the Monte Carlo standard error is about 0.56 points.

Testing a coefficient that is constant within every level of a random intercept against the number of samples counts repeated measurements as independent observations, which is the pseudo-replication a mixed model exists to prevent. It matters most where there are few donors carrying many samples each:

| null scenario, condition constant within donor | df = n - p | between-within rule |
|---|---|---|
| 20 donors x 8 samples | 5.7% | 4.6% |
| 20 donors x 8 samples, sigma=1.0 | 5.9% | 4.3% |
| 10 donors x 4 samples | **8.5%** | **5.7%** |
| 8 donors x 6 samples | **9.2%** | **5.0%** |

With the rule in place every scenario tried, whether the condition varies within donors or between them, sits between 4.3% and 6.0% against a nominal 5%.

Two approximations were implemented for this and then removed after measuring them. A Kenward-Roger covariance adjustment changes the standard error by a factor of 1.0000, because a within-cluster contrast is orthogonal to the random intercept and a between-cluster one is already handled by the degrees of freedom. Satterthwaite degrees of freedom, with the dispersion treated as a variance component since it enters the variance matrix through its diagonal, reproduces the between-within rule to within one degree of freedom across balanced, unbalanced, partially confounded and small sample designs (138.0 against 139, 28.8 against 29, 18.0 against 18, 5.9 against 6) for identical type I error at ten times the runtime. The rule is kept; both are validation of it rather than replacements for it.

## On real data

The simulations above generate data from exactly the model the code assumes, which favours any correctly implemented estimator. So the same question was asked of a real graph: `pbmc68k_reduced`, eight donors each with their own composition, three samples per donor, and a condition that is a label on the donor with no effect of its own. Every neighbourhood called significant is a false positive.

| model | neighbourhoods | p<0.05 | SpatialFDR<0.1 | false positive rate |
|---|---|---|---|---|
| fixed effects only | 408 | 27 | 2 | 6.6% |
| random intercept | 407 | 11 | 0 | **2.7%** |

Aggregated over 8 seeds. Ignoring the donor structure calls false positives above the nominal rate and two survive multiple testing correction; the random intercept more than halves them and none survive.

The milo tutorial was also executed end to end against this branch, which runs the mixed model on `stephenson_2021` with `Site` as a random intercept: 4307 neighbourhoods, 6 of them with a group that has no cells and reported as NaN, 21 of the remaining 4301 not converged, and a site variance between 0.02 and 0.66.

## Degrees of freedom

The between-within rule was checked against the Satterthwaite approximation rather than taken on faith. Satterthwaite was implemented with the dispersion as an extra variance component, which is exact here because the dispersion enters the variance matrix through its diagonal so its derivative is the identity. It agrees with the rule across balanced, unbalanced, partially confounded and small sample designs:

| design | Satterthwaite | between-within |
|---|---|---|
| within donor, 20 x 8 | 138.0 | 139 |
| within donor, 10 x 4 | 28.8 | 29 |
| between donor, 20 x 8 | 18.0 | 18 |
| between donor, 10 x 4 | 8.0 | 8 |
| severely unbalanced clusters | 5.9 | 6 |

Type I error was identical in every case while the fit took 10x as long (8.5 to 81.5 ms), so the rule is kept and the Satterthwaite code is not.

## Performance

A neighbourhood is fitted one at a time, so a real run does this thousands of times. Solving against the Cholesky factor of the variance matrix instead of building its pseudoinverse, and taking the score and Fisher information traces in the space of random effect levels rather than of samples, is worth most of it. Timed in separate processes on 150 samples with 25 donors:

| | ms per fit |
|---|---|
| pseudoinverse | 1624 |
| Cholesky | 9.6 |
| Cholesky, products reused, warm start | 8.5 |
| the above with the adjusted profile likelihood dispersion | **13.4** |

The Cholesky rewrite matches the pseudoinverse version to 8e-15.

The dispersion is estimated by maximising the Cox-Reid adjusted profile likelihood rather than by solving a moment equation, iterated with the fit to consistency. A moment estimator needs to be told how many degrees of freedom the fit spent, and getting that wrong left the dispersion between 1% and 16% above the planted value depending on the size of the design; the adjusted profile likelihood holds it at -2% to -6% everywhere. Type I error is unchanged either way, but the dispersion is reported to the user, so its accuracy matters on its own.

## Notes

- Mixed models need `formulaic` for the fixed effects model matrix, which already ships in the `de` extra; `solver` and `model_contrasts` do not apply and the latter raises.
- The offset is the log library size rather than R Milo's `log(norm.factors)`, which omits library size.

The milo tutorial gained a section on this in scverse/pertpy-tutorials#71, which is merged, and the submodule pointer here picks it up, so nothing needs to follow. The notebook job of this pull request executes that section against this branch.

