### PR TITLE
Ensure right fit object is in R scope

### DIFF
--- a/src/pertpy/tools/_differential_gene_expression/_edger.py
+++ b/src/pertpy/tools/_differential_gene_expression/_edger.py
@@ -108,6 +108,7 @@ class EdgeR(LinearModelBase):
         with localconverter(get_conversion() + numpy2ri.converter) as cv:
             contrast_vec_r = cv.py2rpy(np.asarray(contrast))
         ro.globalenv["contrast_vec"] = contrast_vec_r
+        ro.globalenv["fit"] = self.fit        
 
         # Test contrast with R
         ro.r(

--- a/src/pertpy/tools/_differential_gene_expression/_edger.py
+++ b/src/pertpy/tools/_differential_gene_expression/_edger.py
@@ -108,7 +108,7 @@ class EdgeR(LinearModelBase):
         with localconverter(get_conversion() + numpy2ri.converter) as cv:
             contrast_vec_r = cv.py2rpy(np.asarray(contrast))
         ro.globalenv["contrast_vec"] = contrast_vec_r
-        ro.globalenv["fit"] = self.fit        
+        ro.globalenv["fit"] = self.fit
 
         # Test contrast with R
         ro.r(


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [ ] Referenced issue is linked
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

This is a little fix to ensure that the right `fit` object is present in the R environment. This can cause issues if the user creates multiple EdgR objects and doesn't calculate contrasts immediately after fitting the object. 

**Technical details**

N/A

**Additional context**

N/A
