### PR TITLE
Drop empty annotation rows from plot_da_beeswarm

### DIFF
--- a/src/pertpy/tools/_milo.py
+++ b/src/pertpy/tools/_milo.py
@@ -1589,13 +1589,17 @@ class Milo:
                 "Unable to find 'logFC' in mdata.uns['nhood_adata'].obs. Run 'core.da_nhoods(adata)' first."
             ) from None
 
-        sorted_annos = (
-            nhood_adata.obs[[anno_col, "logFC"]].groupby(anno_col).median().sort_values("logFC", ascending=True).index
-        )
-
         anno_df = nhood_adata.obs[[anno_col, "logFC", "SpatialFDR"]].copy()
         anno_df["is_signif"] = anno_df["SpatialFDR"] < padj_threshold
         anno_df = anno_df[anno_df[anno_col] != "nan"]
+
+        sorted_annos = (
+            anno_df[[anno_col, "logFC"]]
+            .groupby(anno_col, observed=True)
+            .median()
+            .sort_values("logFC", ascending=True)
+            .index
+        )
 
         try:
             obs_col = nhood_adata.uns["annotation_obs"]

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -433,6 +433,30 @@ def test_plot_de_nhood_graph(de_nhoods_mdata, milo):
         milo.plot_de_nhood_graph(mdata, de, gene="not_a_real_gene")
 
 
+def test_plot_da_beeswarm_skips_unused_categories(da_nhoods_mdata, milo, solver):
+    """Cell types without a neighbourhood must not be drawn as empty rows."""
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use("Agg")
+    plt.close("all")
+    mdata = da_nhoods_mdata.copy()
+    cell_type = mdata["rna"].obs["louvain"].astype(str).astype("category")
+    mdata["rna"].obs["cell_type"] = cell_type.cat.add_categories(["Unobserved"])
+    milo.da_nhoods(mdata, design="~condition", solver=solver)
+    milo.annotate_nhoods(mdata, anno_col="cell_type")
+
+    annotation = mdata["milo"].var["nhood_annotation"]
+    mdata["milo"].var["nhood_annotation"] = annotation.cat.add_categories(["nan"]).where(
+        np.arange(len(annotation)) > 0, "nan"
+    )
+
+    fig = milo.plot_da_beeswarm(mdata, return_fig=True)
+    labels = [label.get_text() for label in fig.axes[0].get_yticklabels()]
+
+    assert set(labels) == set(mdata["milo"].var["nhood_annotation"].astype(str)) - {"nan"}
+
+
 def test_de_nhoods_statsmodels_runs(de_nhoods_mdata, milo):
     mdata = de_nhoods_mdata.copy()
     de = milo.de_nhoods(


### PR DESCRIPTION
Closes #1076.

The row order was derived from `nhood_adata.obs` before the `"nan"` annotations were filtered out and with the pandas default of `observed=False`, so annotation categories without any neighbourhood were drawn as empty rows.
The order now comes from the plotted frame with `observed=True`, which also makes the plot independent of the pandas version -- the default flipped to `True` in pandas 3.0, so this only shows up for users on pandas 2.