### PR TITLE
Keep permutation p-values aligned with their group labels in DistanceTest

### DIFF
--- a/src/pertpy/tools/_distances/_distance_tests.py
+++ b/src/pertpy/tools/_distances/_distance_tests.py
@@ -17,6 +17,14 @@ if TYPE_CHECKING:
     from anndata import AnnData
 
 
+def _permutation_pvalues(results: list[pd.DataFrame], df: pd.DataFrame, n_perms: int) -> pd.Series:
+    """Fraction of permutations that reached a larger distance than the observed one, per group of `df`."""
+    comparison_results = pd.concat([r["distance"] - df["distance"] for r in results], axis=1) > 0
+    n_failures = comparison_results.sum(axis=1).clip(lower=1).reindex(df.index)
+
+    return n_failures / n_perms
+
+
 class DistanceTest:
     """Run permutation tests using a distance of choice between groups of cells.
 
@@ -191,13 +199,7 @@ class DistanceTest:
             df.loc[group, "distance"] = self.distance(X, Y)
 
         # Evaluate the test
-        # count times shuffling resulted in larger distance
-        comparison_results = np.array(
-            pd.concat([r["distance"] - df["distance"] for r in results], axis=1) > 0,
-            dtype=int,
-        )
-        n_failures = pd.Series(np.clip(np.sum(comparison_results, axis=1), 1, np.inf), index=df.index)
-        pvalues = n_failures / self.n_perms
+        pvalues = _permutation_pvalues(results, df, self.n_perms)
 
         # Apply multiple testing correction
         significant_adj, pvalue_adj, _, _ = multipletests(
@@ -305,13 +307,7 @@ class DistanceTest:
             df.loc[group, "distance"] = distance_result
 
         # Evaluate the test
-        # count times shuffling resulted in larger distance
-        comparison_results = np.array(
-            pd.concat([r["distance"] - df["distance"] for r in results], axis=1) > 0,
-            dtype=int,
-        )
-        n_failures = pd.Series(np.clip(np.sum(comparison_results, axis=1), 1, np.inf), index=df.index)
-        pvalues = n_failures / self.n_perms
+        pvalues = _permutation_pvalues(results, df, self.n_perms)
 
         # Apply multiple testing correction
         significant_adj, pvalue_adj, _, _ = multipletests(

--- a/tests/tools/_distances/test_distance_tests.py
+++ b/tests/tools/_distances/test_distance_tests.py
@@ -1,9 +1,12 @@
+import numpy as np
+import pandas as pd
 import pytest
 import scanpy as sc
 from anndata import AnnData
 from pandas import DataFrame
 
 import pertpy as pt
+from pertpy.tools._distances._distance_tests import _permutation_pvalues
 from pertpy.tools._distances._distances import Metric
 
 distances: tuple[Metric, ...] = (
@@ -38,6 +41,18 @@ def adata() -> AnnData:
     adata = sc.pp.sample(adata, 0.1, copy=True, rng=0)
 
     return adata
+
+
+def test_permutation_pvalues_follow_group_labels() -> None:
+    """The permutations are stored in alphabetical order while the observed distances keep the order of appearance."""
+    index = pd.Index(["control", "zeta", "alpha"])
+    df = DataFrame({"distance": [np.nan, 10.0, 0.1]}, index=index)
+    results = [DataFrame({"distance": [np.nan, 0.5, 0.2]}, index=index).sort_index() for _ in range(4)]
+
+    pvalues = _permutation_pvalues(results, df, 4)
+
+    assert pvalues["zeta"] == 0.25
+    assert pvalues["alpha"] == 1.0
 
 
 @pytest.mark.parametrize("distance", distances)


### PR DESCRIPTION
Closes #1072.

The null distribution is stored per permutation in alphabetical order while the observed distances keep the order of appearance of `adata.obs[groupby]`.
Counting the failures went through a bare numpy array, which dropped the labels, and the counts were then reattached positionally to the order of appearance, so groups whose two orders differ received each other's p-values.
Both `test_xy` and `test_precomputed` now share `_permutation_pvalues`, which stays in pandas and reindexes onto the observed order, so the array that `multipletests` returns is positional against the right groups as well.