### PR TITLE
Bump the version to 1.3.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: "1.2.0 🌈"
-tag-template: 1.2.0
+name-template: "1.3.0 🌈"
+tag-template: 1.3.0
 exclude-labels:
     - "skip-changelog"
 


### PR DESCRIPTION
The package version comes from the git tag via hatch-vcs, so this only updates the release drafter templates.