### PR TITLE
Include equal distances in permutation-test upper tails

### DIFF
--- a/src/pertpy/tools/_distances/_distance_tests.py
+++ b/src/pertpy/tools/_distances/_distance_tests.py
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
 
 
 def _permutation_pvalues(results: list[pd.DataFrame], df: pd.DataFrame, n_perms: int) -> pd.Series:
-    """Fraction of permutations that reached a larger distance than the observed one, per group of `df`."""
-    comparison_results = pd.concat([r["distance"] - df["distance"] for r in results], axis=1) > 0
+    """Fraction of permutations that reached an equal or larger distance than the observed one, per group of `df`."""
+    comparison_results = pd.concat([r["distance"] - df["distance"] for r in results], axis=1) >= 0
     n_failures = comparison_results.sum(axis=1).clip(lower=1).reindex(df.index)
 
     return n_failures / n_perms

--- a/tests/tools/_distances/test_distance_tests.py
+++ b/tests/tools/_distances/test_distance_tests.py
@@ -69,3 +69,34 @@ def test_distancetest(adata: AnnData, distance: Metric) -> None:
     assert tab["pvalue"].max() <= 1
     assert tab["pvalue_adj"].min() >= 0
     assert tab["pvalue_adj"].max() <= 1
+
+
+@pytest.mark.parametrize("distance", ["euclidean", "edistance"])
+@pytest.mark.parametrize("outlier", [False, True])
+def test_distancetest_all_tied_permutations(distance, outlier):
+    # Every balanced assignment has the same statistic, including the nonconstant case.
+    x = np.ones((8, 3))
+    if outlier:
+        x[-1, 0] = 9
+    adata = AnnData(
+        x,
+        obs=pd.DataFrame(
+            {"group": ["control"] * 4 + ["treated"] * 4},
+            index=[str(i) for i in range(8)],
+        ),
+    )
+    adata.obsm["X_test"] = x.copy()
+    result = pt.tl.DistanceTest(distance, n_perms=100, obsm_key="X_test")(
+        adata, groupby="group", contrast="control", show_progressbar=False
+    )
+    assert result.loc["treated", "pvalue"] == 1.0
+    assert result.loc["treated", "pvalue_adj"] == 1.0
+    assert not result.loc["treated", "significant_adj"]
+    assert result.loc["control", "pvalue"] == 1.0
+
+
+@pytest.mark.parametrize("null,expected", [([2.0, 2.0, 1.0, 1.0], 0.5), ([3.0] * 4, 1.0), ([1.0] * 4, 0.25)])
+def test_permutation_pvalues_inclusive_tail(null, expected):
+    observed = DataFrame({"distance": [2.0]}, index=["treated"])
+    results = [DataFrame({"distance": [value]}, index=["treated"]) for value in null]
+    assert _permutation_pvalues(results, observed, len(null))["treated"] == expected


### PR DESCRIPTION
When all label permutations tie the observed distance, `DistanceTest` currently reports p=1/n_perms instead of 1. This patch counts equal distances in the upper tail and updates the helper's docstring. It preserves the existing group-label alignment fix and minimum-count convention.

For eight observations split 4/4, both identical nonzero embeddings and an embedding with seven rows (1,1,1) plus one row (9,1,1) have the same statistic for all 70 balanced assignments. The latter has Euclidean distance 2 and E-distance 1 for every assignment. Released Pertpy 1.3.0 gives raw p=0.001 with 1,000 permutations; the inclusive-tail correction gives 1. The same strict comparison remains in current upstream base 3001be83e49bb00be7ed2a7482af59eec80cb239.

Minimal public-API reproduction:

```python
import numpy as np
import pandas as pd
from anndata import AnnData
import pertpy as pt
x = np.ones((8, 3))
x[-1, 0] = 9
a = AnnData(x, obs=pd.DataFrame(
    {'group': ['control'] * 4 + ['treated'] * 4,
    }, index=[str(i) for i in range(8)]))
a.obsm['X_test'] = x.copy()
print(pt.tl.DistanceTest('euclidean', n_perms=1000, obsm_key='X_test')(
    a, groupby='group', contrast='control', show_progressbar=False))
```

Seven new checks cover four public-API fixture/metric combinations, a mixed equal/lower tail, and strictly greater/lower controls. Including the existing group-label alignment regression: before, five fail and three pass; after, all eight pass. The other 18 distance tests use a downloaded dataset and were deselected; the full suite was not run. Changed source/tests pass Ruff lint and formatting checks.

The change addresses exact ties. It does not introduce a floating-point near-tie tolerance, randomized tie-breaking, or revise the general Monte Carlo numerator/denominator convention. No affected published conclusion is established. The inclusive upper-tail convention is also documented by https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.permutation_test.html .

Published reproduction, full enumeration, released-wheel before/after outputs and evidence archive: https://cheerfulduck.com/research/audits/pertpy-permutation-ties . Prepared with AI assistance; independent human scientific review and a released fix are not claimed.

- [x] Regression tests added
- [x] Affected helper documentation updated
- No matching existing issue found in bounded searches; this PR is the initial upstream report.
