### PR TITLE
Add native Hill dose-response fitting

### DIFF
--- a/docs/api/tools_index.md
+++ b/docs/api/tools_index.md
@@ -564,4 +564,55 @@ ds_adata = ds.compute(mdata["rna"], target_col="gene_target", metric="edistance"
 similar = ds.nearest_perturbations(ds_adata, "IFNGR2", target_col="gene_target")
 ```
 
-See [perturbation space tutorial](https://pertpy.readthedocs.io/en/latest/tutorials/notebooks/perturbation_space.html).
+### Dose-response curve fitting
+
+`PerturbationSpace.dose_response` calculates a scalar distance from control for every perturbation and dose.
+`PerturbationSpace.fit_dose_response` fits a four-parameter Hill curve to these values and reports the EC50 for this transcriptomic-distance response:
+
+```python
+import pertpy as pt
+import scanpy as sc
+
+adata = pt.dt.srivatsan_2020_sciplex2()
+adata = adata[adata.obs["dose_value"].notna()].copy()
+adata.obs["dose_value"] = adata.obs["dose_value"].astype(float)
+adata.obs["perturbation"] = adata.obs["perturbation"].astype(str)
+adata.obs.loc[adata.obs["dose_value"] == 0, "perturbation"] = "zero_dose"
+sc.pp.normalize_total(adata, target_sum=1e4)
+sc.pp.log1p(adata)
+sc.pp.pca(adata)
+ps = pt.tl.PseudobulkSpace()
+
+responses = ps.dose_response(
+    adata,
+    dose_col="dose_value",
+    reference_key="zero_dose",
+    embedding_key="X_pca",
+)
+fits = ps.fit_dose_response(responses)
+```
+
+This example pools the assigned zero-dose samples as the reference and excludes cells without a dose assignment.
+The existing `control` label in this dataset includes [cells without an assigned sample](https://github.com/sanderlab/scPerturb/blob/master/dataset_processing/scripts/SrivatsanTrapnell2020.py#L55-L56); it is not used as the reference here.
+Doses retain the dataset's recorded units; verify their mapping to physical concentrations before comparing potency between compounds.
+
+The same fitter accepts other scalar assay responses.
+For example, an independently measured and control-normalized viability response can be labelled as inhibition to obtain IC50 rather than EC50 output:
+
+```python
+fits = ps.fit_dose_response(
+    assay_responses,
+    response_col="viability",
+    response_type="inhibition",
+)
+```
+
+`response_type` only determines how the fitted midpoint is interpreted and named; the fitter does not perform biological or control normalization.
+Internal numerical rescaling does not change the output response units.
+EC50 and IC50 are relative midpoints between the fitted `e0` and `emax`.
+Check `r_squared`, the reported standard error and `midpoint_in_range` before interpreting a fit; a midpoint outside the measured positive-dose range is an extrapolation.
+If the uncertainty cannot be estimated numerically, a warning is emitted and the standard error is `NaN`; the fitted parameters remain available for inspection.
+The standard error is a local approximation. Even a small error, high R-squared and an in-range midpoint can be misleading when the doses do not constrain both plateaus; inspect the measured responses and fitted curve.
+The terminology assumes that `dose` represents a concentration, and this first implementation fits a four-parameter curve without automatically selecting fixed-top or fixed-bottom alternatives.
+
+See the [perturbation space tutorial](https://pertpy.readthedocs.io/en/latest/tutorials/notebooks/perturbation_space.html#dose-response) for plotting the measured dose responses and fitted Hill curves together.

--- a/src/pertpy/tools/_perturbation_space/_perturbation_space.py
+++ b/src/pertpy/tools/_perturbation_space/_perturbation_space.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 import pandas as pd
 from anndata import AnnData
+from scipy.optimize import curve_fit
+from scipy.special import expit
 from scipy.stats import entropy
 
 from pertpy._logger import logger
@@ -81,6 +83,16 @@ def _vector_distance(u: np.ndarray, v: np.ndarray, metric: str) -> float:
             return float("nan")
         return 1.0 - float(np.corrcoef(u, v)[0, 1])
     raise ValueError(f"Unknown metric {metric!r}. Choose from 'euclidean', 'cosine', 'pearson'.")
+
+
+def _four_parameter_logistic(
+    dose: np.ndarray, e0: float, emax: float, log_midpoint: float, hill_coefficient: float
+) -> np.ndarray:
+    """Evaluate a four-parameter Hill curve with a positive Hill coefficient."""
+    log_dose = np.full_like(dose, -np.inf, dtype=float)
+    np.log(dose, out=log_dose, where=dose > 0)
+    fraction = expit(hill_coefficient * (log_dose - log_midpoint))
+    return e0 + (emax - e0) * fraction
 
 
 def _subtract_control_mean(
@@ -647,6 +659,147 @@ class PerturbationSpace:
             with contextlib.suppress(ValueError, TypeError):
                 result["dose"] = pd.to_numeric(result["dose"])
         return result.sort_values(["perturbation", "dose"]).reset_index(drop=True)
+
+    def fit_dose_response(
+        self,
+        data: pd.DataFrame,
+        *,
+        perturbation_col: str = "perturbation",
+        dose_col: str = "dose",
+        response_col: str = "distance",
+        response_type: Literal["effect", "inhibition"] = "effect",
+    ) -> pd.DataFrame:
+        """Fit a four-parameter Hill curve for each perturbation.
+
+        ``data`` can be the output of :meth:`dose_response` or a table containing another scalar assay response.
+        ``response_type`` names the fitted midpoint according to the meaning of that response: ``"effect"`` returns
+        ``ec50``, while ``"inhibition"`` returns ``ic50``. It does not perform biological or control normalization.
+        Dose values must represent concentrations for the EC50 or IC50 terminology to apply.
+
+        Args:
+            data: Tidy table containing perturbation, dose and response columns.
+            perturbation_col: Column identifying the perturbation.
+            dose_col: Column containing non-negative numeric doses.
+            response_col: Column containing the scalar response to fit.
+            response_type: Whether the response represents an effect or inhibition.
+
+        Returns:
+            One row per perturbation with the fitted zero-dose response (``e0``), asymptotic response (``emax``),
+            Hill coefficient, EC50 or IC50, its approximate standard error, R-squared and whether the midpoint lies
+            within the tested positive-dose range.
+
+        Notes:
+            Responses are rescaled internally for numerical stability; ``e0`` and ``emax`` retain the input units.
+            The standard error uses a local linear approximation. It is NaN, with a warning, if the parameter
+            covariance is non-finite or numerically rank deficient, or there are no residual degrees of freedom.
+            Parameters are retained for inspection. A small standard error, high R-squared or an in-range midpoint
+            does not establish that the doses capture both plateaus or that the Hill model is appropriate.
+
+        Examples:
+            >>> import pertpy as pt
+            >>> import scanpy as sc
+            >>> adata = pt.dt.srivatsan_2020_sciplex2()
+            >>> adata = adata[adata.obs["dose_value"].notna()].copy()
+            >>> adata.obs["dose_value"] = adata.obs["dose_value"].astype(float)
+            >>> adata.obs["perturbation"] = adata.obs["perturbation"].astype(str)
+            >>> adata.obs.loc[adata.obs["dose_value"] == 0, "perturbation"] = "zero_dose"
+            >>> sc.pp.normalize_total(adata, target_sum=1e4)
+            >>> sc.pp.log1p(adata)
+            >>> sc.pp.pca(adata)
+            >>> ps = pt.tl.PseudobulkSpace()
+            >>> responses = ps.dose_response(
+            ...     adata, dose_col="dose_value", reference_key="zero_dose", embedding_key="X_pca"
+            ... )
+            >>> fits = ps.fit_dose_response(responses)
+        """
+        required = {perturbation_col, dose_col, response_col}
+        missing = required.difference(data.columns)
+        if missing:
+            raise ValueError(f"Columns {sorted(missing)} do not exist in the input data.")
+        if response_type not in {"effect", "inhibition"}:
+            raise ValueError("response_type must be either 'effect' or 'inhibition'.")
+
+        fit_data = data[[perturbation_col, dose_col, response_col]].copy()
+        if fit_data[perturbation_col].isna().any():
+            raise ValueError("Perturbation labels must not be missing.")
+        fit_data[dose_col] = pd.to_numeric(fit_data[dose_col], errors="raise")
+        fit_data[response_col] = pd.to_numeric(fit_data[response_col], errors="raise")
+        if (fit_data[dose_col] < 0).any():
+            raise ValueError("Dose values must be non-negative.")
+
+        midpoint_col = "ec50" if response_type == "effect" else "ic50"
+        records: list[dict[str, object]] = []
+        for perturbation, group in fit_data.groupby(perturbation_col, observed=True, sort=True):
+            doses = group[dose_col].to_numpy(dtype=float)
+            responses = group[response_col].to_numpy(dtype=float)
+            if np.unique(doses).size < 4:
+                raise ValueError(f"Perturbation {perturbation!r} needs at least four distinct dose values.")
+            response_offset = float(np.min(responses))
+            response_scale = float(np.ptp(responses))
+            if response_scale == 0:
+                raise ValueError(
+                    f"Perturbation {perturbation!r} has a constant response, so a Hill curve cannot be fit."
+                )
+
+            responses = (responses - response_offset) / response_scale
+            mean_response = (
+                group.groupby(dose_col, sort=True, observed=True)[response_col].mean() - response_offset
+            ) / response_scale
+            e0_guess = float(mean_response.iloc[0])
+            emax_guess = float(mean_response.iloc[-1])
+            halfway = (e0_guess + emax_guess) / 2
+            positive_response = mean_response[mean_response.index > 0]
+            midpoint_guess = float((positive_response - halfway).abs().idxmin())
+
+            parameters, covariance = curve_fit(
+                _four_parameter_logistic,
+                doses,
+                responses,
+                p0=(e0_guess, emax_guess, np.log(midpoint_guess), 1.0),
+                bounds=((-np.inf, -np.inf, -np.inf, np.finfo(float).eps), np.inf),
+                absolute_sigma=True,
+                maxfev=20_000,
+            )
+
+            e0, emax, log_midpoint, hill_coefficient = parameters
+            midpoint = float(np.exp(log_midpoint))
+            fitted = _four_parameter_logistic(doses, *parameters)
+            residual_sum_squares = float(np.sum((responses - fitted) ** 2))
+            total_sum_squares = float(np.sum((responses - responses.mean()) ** 2))
+            positive_doses = doses[doses > 0]
+
+            # Check conditioning before scaling covariance by residual variance, which may be zero.
+            degrees_of_freedom = len(responses) - len(parameters)
+            if (
+                degrees_of_freedom <= 0
+                or not np.isfinite(covariance).all()
+                or np.linalg.matrix_rank(covariance) < len(parameters)
+            ):
+                midpoint_standard_error = np.nan
+                warnings.warn(
+                    f"Cannot estimate the {midpoint_col.upper()} standard error for perturbation {perturbation!r}. "
+                    "Inspect the dose range and fitted curve before interpreting the estimate.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                residual_variance = residual_sum_squares / degrees_of_freedom
+                midpoint_standard_error = midpoint * np.sqrt(float(covariance[2, 2]) * residual_variance)
+
+            records.append(
+                {
+                    perturbation_col: perturbation,
+                    "e0": float(e0 * response_scale + response_offset),
+                    "emax": float(emax * response_scale + response_offset),
+                    "hill_coefficient": float(hill_coefficient),
+                    midpoint_col: midpoint,
+                    f"{midpoint_col}_standard_error": float(midpoint_standard_error),
+                    "r_squared": 1 - residual_sum_squares / total_sum_squares,
+                    "midpoint_in_range": bool(positive_doses.min() < midpoint < positive_doses.max()),
+                }
+            )
+
+        return pd.DataFrame.from_records(records)
 
     def plot_similarity(  # pragma: no cover
         self,

--- a/tests/tools/_perturbation_space/test_perturbation_space_extras.py
+++ b/tests/tools/_perturbation_space/test_perturbation_space_extras.py
@@ -66,19 +66,159 @@ def test_evaluate_combinations(rng):
     np.testing.assert_allclose(result.loc["A+B", "distance"], 0.0, atol=1e-6)
 
 
-def test_dose_response(rng):
+def test_dose_response():
+    rng = np.random.default_rng(0)
     groups, doses = [], []
     for pert in ["control", "drug"]:
-        for dose in [0.0] if pert == "control" else [1.0, 10.0, 100.0]:
+        for dose in [0.0] if pert == "control" else [0.1, 1.0, 3.0, 10.0, 30.0, 100.0]:
             groups += [pert] * 15
             doses += [dose] * 15
     groups = np.array(groups)
     doses = np.array(doses, dtype=float)
     X = rng.normal(0, 0.3, (len(groups), 8))
-    X[groups == "drug"] += (doses[groups == "drug"] / 10.0)[:, None]
+    drug_doses = doses[groups == "drug"]
+    X[groups == "drug"] += (5 * drug_doses**1.2 / (10**1.2 + drug_doses**1.2))[:, None]
     adata = AnnData(X, obs=pd.DataFrame({"perturbation": groups, "dose": doses}))
     sc.pp.pca(adata, n_comps=5)
 
     curves = pt.tl.PseudobulkSpace().dose_response(adata, dose_col="dose", metric="euclidean", embedding_key="X_pca")
     drug = curves[curves["perturbation"] == "drug"].sort_values("dose")
     assert drug["distance"].is_monotonic_increasing
+
+    fits = pt.tl.PseudobulkSpace().fit_dose_response(curves)
+    assert fits.loc[0, "ec50"] == pytest.approx(10, rel=0.2)
+    assert fits.loc[0, "r_squared"] > 0.99
+    assert fits.loc[0, "midpoint_in_range"]
+
+
+@pytest.mark.parametrize(
+    ("response_type", "e0", "emax", "midpoint", "midpoint_col"),
+    [("effect", 0.1, 1.8, 3.0, "ec50"), ("inhibition", 1.0, 0.05, 8.0, "ic50")],
+)
+@pytest.mark.parametrize("response_scale", [1e-8, 1.0, 1e8])
+def test_fit_dose_response(*, response_type, e0, emax, midpoint, midpoint_col, response_scale):
+    e0, emax = e0 * response_scale, emax * response_scale
+    doses = np.array([0.0, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 100.0])
+    hill_coefficient = 1.4
+    fraction = doses**hill_coefficient / (midpoint**hill_coefficient + doses**hill_coefficient)
+    first = pd.DataFrame(
+        {
+            "compound": "drug_a",
+            "concentration": doses,
+            "response": e0 + (emax - e0) * fraction,
+        }
+    )
+    second_midpoint = midpoint * 2
+    second_fraction = doses**hill_coefficient / (second_midpoint**hill_coefficient + doses**hill_coefficient)
+    second = first.assign(compound="drug_b", response=e0 + (emax - e0) * second_fraction)
+    data = pd.concat([first, second], ignore_index=True)
+
+    fits = (
+        pt.tl.PseudobulkSpace()
+        .fit_dose_response(
+            data,
+            perturbation_col="compound",
+            dose_col="concentration",
+            response_col="response",
+            response_type=response_type,
+        )
+        .set_index("compound")
+    )
+
+    assert midpoint_col in fits
+    assert f"{midpoint_col}_standard_error" in fits
+    assert {"e0", "emax", "hill_coefficient", "r_squared", "midpoint_in_range"} <= set(fits)
+    assert fits.loc["drug_a", "e0"] == pytest.approx(e0, rel=1e-6, abs=0)
+    assert fits.loc["drug_a", "emax"] == pytest.approx(emax, rel=1e-6, abs=0)
+    assert fits.loc["drug_a", "hill_coefficient"] == pytest.approx(hill_coefficient)
+    assert fits.loc["drug_a", midpoint_col] == pytest.approx(midpoint)
+    assert fits.loc["drug_b", midpoint_col] == pytest.approx(second_midpoint)
+    assert fits.loc["drug_a", "r_squared"] == pytest.approx(1)
+    assert np.isfinite(fits[f"{midpoint_col}_standard_error"]).all()
+
+
+@pytest.mark.parametrize("response_scale", [1.0, 100.0])
+def test_fit_dose_response_rank_deficient(response_scale):
+    doses = np.array([0.0, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 100.0, 300.0])
+    responses = doses / (10 + doses) + np.random.default_rng(2026).normal(0, 0.025, len(doses))
+    complete = pd.DataFrame({"perturbation": "complete", "dose": doses, "distance": response_scale * responses})
+    limited = complete.loc[complete["dose"] <= 3].assign(perturbation="limited")
+
+    with pytest.warns(UserWarning, match="Cannot estimate.*'limited'"):
+        fits = pt.tl.PseudobulkSpace().fit_dose_response(pd.concat([complete, limited])).set_index("perturbation")
+
+    assert fits.loc["complete", "ec50"] == pytest.approx(10, rel=0.1)
+    assert np.isfinite(fits.loc["complete", "ec50_standard_error"])
+    # A high R-squared and an in-range midpoint do not expose this poorly determined curve.
+    assert fits.loc["limited", "r_squared"] > 0.98
+    assert fits.loc["limited", "midpoint_in_range"]
+    assert np.isfinite(fits.loc["limited", "ec50"])
+    assert np.isnan(fits.loc["limited", "ec50_standard_error"])
+
+
+@pytest.mark.parametrize("response_scale", [1e-8, 1.0, 1e8])
+def test_fit_dose_response_standard_error(response_scale):
+    doses = np.array([0.0, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 100.0, 300.0])
+    responses = doses / (10 + doses) + np.random.default_rng(2026).normal(0, 0.025, len(doses))
+    responses *= response_scale
+    data = pd.DataFrame({"perturbation": "drug", "dose": doses, "distance": responses})
+    fit = pt.tl.PseudobulkSpace().fit_dose_response(data).iloc[0]
+
+    # Independent derivatives with respect to EC50 itself, rather than the fitted log(EC50).
+    midpoint, slope = fit["ec50"], fit["hill_coefficient"]
+    fraction = doses**slope / (midpoint**slope + doses**slope)
+    log_ratio = np.zeros_like(doses)
+    np.log(doses / midpoint, out=log_ratio, where=doses > 0)
+    sensitivity = (fit["emax"] - fit["e0"]) * fraction * (1 - fraction)
+    jacobian = np.column_stack((1 - fraction, fraction, -slope * sensitivity / midpoint, sensitivity * log_ratio))
+    residuals = responses - (fit["e0"] + (fit["emax"] - fit["e0"]) * fraction)
+    variance = np.sum(residuals**2) / (len(doses) - 4)
+    expected_error = np.sqrt(np.linalg.inv(jacobian.T @ jacobian)[2, 2] * variance)
+    assert fit["ec50_standard_error"] == pytest.approx(expected_error, rel=1e-4)
+
+
+def test_fit_dose_response_insufficient_dof():
+    doses = np.array([0.0, 1.0, 10.0, 100.0])
+    data = pd.DataFrame({"perturbation": "drug", "dose": doses, "distance": doses / (10 + doses)})
+    with pytest.warns(UserWarning, match="Cannot estimate.*'drug'"):
+        fit = pt.tl.PseudobulkSpace().fit_dose_response(data).iloc[0]
+    assert fit["ec50"] == pytest.approx(10)
+    assert np.isnan(fit["ec50_standard_error"])
+
+
+@pytest.mark.parametrize(
+    ("data", "kwargs", "match"),
+    [
+        (pd.DataFrame(), {}, "Columns"),
+        (
+            pd.DataFrame(
+                {"perturbation": ["drug", "drug", None, "drug"], "dose": [0, 1, 2, 3], "distance": [0, 1, 2, 3]}
+            ),
+            {},
+            "Perturbation labels",
+        ),
+        (
+            pd.DataFrame({"perturbation": ["drug"] * 4, "dose": [-1, 1, 2, 3], "distance": [0, 1, 2, 3]}),
+            {},
+            "non-negative",
+        ),
+        (
+            pd.DataFrame({"perturbation": ["drug"] * 3, "dose": [0, 1, 2], "distance": [0, 1, 2]}),
+            {},
+            "four distinct",
+        ),
+        (
+            pd.DataFrame({"perturbation": ["drug"] * 4, "dose": [0, 1, 2, 3], "distance": [1, 1, 1, 1]}),
+            {},
+            "constant response",
+        ),
+        (
+            pd.DataFrame({"perturbation": ["drug"] * 4, "dose": [0, 1, 2, 3], "distance": [0, 1, 2, 3]}),
+            {"response_type": "unknown"},
+            "response_type",
+        ),
+    ],
+)
+def test_fit_dose_response_validation(data, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        pt.tl.PseudobulkSpace().fit_dose_response(data, **kwargs)


### PR DESCRIPTION
**PR Checklist**

-   [x] Referenced issue is linked
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

Adds native `PerturbationSpace.fit_dose_response` for the Hill-fitting part of #1036. It accepts the table returned by `dose_response()` or another scalar assay response and stores per-perturbation curve parameters, relative EC50/IC50, approximate standard error, R-squared and a dose-range indicator in `adata.uns[key_added]`, together with the fit settings.

**Technical details**

Uses a four-parameter Hill curve with SciPy and adds no new dependency. `response_type` selects EC50 or IC50 terminology; biological/control normalization remains the user's responsibility. The documentation explains the limitations of midpoint and uncertainty estimates. Bliss/Loewe and other combination analyses remain outside this PR.

**Additional context**

Validation: 25 tests passed in `test_perturbation_space_extras.py`; Ruff and format checks passed for the changed Python files.
