### PR TITLE
Add baseline-aware evaluator for perturbation predictions

### DIFF
--- a/docs/api/tools_index.md
+++ b/docs/api/tools_index.md
@@ -8,6 +8,24 @@
 {class}`~pertpy.tools.Sccoda`, {class}`~pertpy.tools.Tasccoda`, {class}`~pertpy.tools.Cinemaot`, {class}`~pertpy.tools.Scgen`, {class}`~pertpy.tools.MLPClassifierSpace` and the `"wasserstein"` metric of {class}`~pertpy.tools.Distance` need the JAX extra: `pip install 'pertpy[jax]'`, see [installation](../installation.md).
 :::
 
+## Perturbation prediction evaluation
+
+Compare held-out predictions with training-only baselines, preserving unavailable
+scores and checking declared cell membership and feature alignment.
+
+```{eval-rst}
+.. autosummary::
+    :toctree: tools
+
+    tools.PerturbationEvaluator
+```
+
+```{toctree}
+:maxdepth: 1
+
+../perturbation_evaluation
+```
+
 ## Differential gene expression
 
 Differential gene expression involves the quantitative comparison of gene expression levels between two or more groups,

--- a/docs/perturbation_evaluation.md
+++ b/docs/perturbation_evaluation.md
@@ -1,0 +1,93 @@
+# Evaluating perturbation predictions
+
+`pt.tl.PerturbationEvaluator` compares held-out measurements with named predictions
+and simple training-only baselines. It returns one row per model, intervention,
+context, feature scope and metric, retaining unavailable scores with an explicit
+status. It does not fit external models, normalize measurements or discover DEGs.
+
+## A complete synthetic example
+
+```python
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pertpy as pt
+
+adata = ad.AnnData(
+    X=np.array([[10., 20., 30.], [12., 20., 29.],
+                [10., 23., 31.], [12., 23., 30.]]),
+    obs=pd.DataFrame({"condition": ["ctrl", "A", "B", "A+B"]},
+                     index=["control-cell", "a-cell", "b-cell", "ab-cell"]),
+    var=pd.DataFrame(index=["gene-1", "gene-2", "gene-3"]),
+)
+components = {"A+B": ["A", "B"]}
+evaluator = pt.tl.PerturbationEvaluator("condition", "ctrl")
+train, test = evaluator.split(
+    adata, holdout=["A+B"], strategy="combination", components=components
+)
+scores = evaluator.evaluate(test, {}, train=train, components=components)
+print(scores[["model", "metric", "value", "status"]])
+```
+
+The additive baseline predicts `[12, 23, 30]` and has zero mean squared error.
+The control-mean baseline has MSE `13/3`. Its predicted expression change is zero,
+so its delta correlation and effect ranking are undefined, rather than perfect.
+These are point predictions; neither represents cell-to-cell variability.
+
+Supply external predictions as `{"my_model": predicted_adata}`. Predictions must
+carry the same observation grouping columns and exactly the same gene identifiers
+as training and truth. Gene order may differ: alignment uses `var_names`. Numbers
+of predicted and measured cells may differ; individual cells are not paired.
+Missing prediction groups produce rows with `status="missing_prediction"`.
+
+## Declare the question before scoring
+
+- **Perturbation holdout** removes complete, explicitly named labels. Holding out
+  `A` does not remove `A+B`; this is not an atomic-target cold-start split.
+- **Combination holdout** uses an explicit component mapping. Include all known
+  aliases, such as `{"A+B": ["A", "B"], "B+A": ["B", "A"]}`, to hold them out
+  together. Labels are never split on punctuation automatically.
+- **Context holdout** removes an entire cell type or other declared context,
+  including its controls. Baselines cannot use controls from that held-out context.
+  Absolute model errors remain scoreable; missing reference-dependent scores are
+  reported explicitly. Other contexts are never silently pooled.
+
+The split helper records exact cell membership in
+`uns["pertpy_evaluation_split"]`. Evaluation rejects overlapping training and test
+cell identifiers. These checks cannot establish how an external model was trained
+or prevent upstream preprocessing leakage. Fit feature selection, preprocessing
+and hyperparameters on training data; reserve validation data for model selection.
+
+All inputs must be on the same declared scale. Choose `layer_key="lognorm"` to use
+that layer consistently. Otherwise the evaluator uses `X`, never an implicit PCA
+representation. Additivity on log-normalized values is a modelling baseline, not
+a claim that molecular effects are additive in that space. Predictions are not
+clipped to zero.
+
+## Baselines and metrics
+
+The control baseline uses the training control mean in the same context. The
+additive baseline adds training single-intervention mean changes to that control
+mean. Missing singles or controls produce unavailable rows; there is no fallback.
+Nearest-neighbour baselines and log-fold-change scoring are outside this first
+API: they require additional contracts for query representations and expression
+units respectively.
+
+| Metric | Interpretation |
+| --- | --- |
+| `mse` | Existing `Distance("mse")`: mean squared error between gene means; lower is better. |
+| `edistance` | Existing `Distance("edistance")` on cell vectors; lower is better. The within-group estimator can be negative in finite samples. It is not clamped. |
+| `delta_pearson` | Gene-wise Pearson correlation of mean changes from training controls. Constant changes are undefined. |
+| `direction_accuracy` | Fraction of true changes above `effect_threshold` with the correct predicted sign. |
+| `top_k_overlap` | Intersection fraction of the top absolute mean changes. Gene identifiers resolve ties; this is not a statistical DEG test. |
+
+`feature_sets={("A+B",): ["gene-1", "gene-2"]}` adds a `selected` scope alongside
+`all`. With a context column, keys are `(context, perturbation)` tuples. Declare
+where these genes came from, and distinguish outcome-derived descriptive scores
+from a predeclared test. `top_k` is capped at the number of genes in each scope.
+
+Every metric has its own status. Keep unavailable rows visible when reporting
+coverage or aggregating results. `scores.attrs["pertpy_evaluation"]` records the
+configuration, feature sets and cell-membership hashes; save it separately when
+exporting CSV, which does not preserve DataFrame attributes. Neither cell-level
+scores nor resampling cells establishes biological-replicate uncertainty.

--- a/src/pertpy/tools/__init__.py
+++ b/src/pertpy/tools/__init__.py
@@ -9,6 +9,7 @@ from pertpy.tools._enrichment import Enrichment
 from pertpy.tools._milo import Milo
 from pertpy.tools._perturbation_efficacy._mixscale import Mixscale
 from pertpy.tools._perturbation_efficacy._mixscape import Mixscape
+from pertpy.tools._perturbation_evaluator import PerturbationEvaluator
 from pertpy.tools._perturbation_space._clustering import ClusteringSpace
 from pertpy.tools._perturbation_space._comparison import PerturbationComparison
 from pertpy.tools._perturbation_space._discriminator_classifiers import LRClassifierSpace
@@ -75,6 +76,7 @@ __all__ = [
     "Mixscale",
     "ClusteringSpace",
     "PerturbationComparison",
+    "PerturbationEvaluator",
     "LRClassifierSpace",
     "MLPClassifierSpace",
     "CentroidSpace",

--- a/src/pertpy/tools/_perturbation_evaluator.py
+++ b/src/pertpy/tools/_perturbation_evaluator.py
@@ -375,7 +375,7 @@ class PerturbationEvaluator:
         rows = []
         for group, positions in target_groups.items():
             observed = real_matrix[positions]
-            observed = observed.toarray() if sparse.issparse(observed) else observed
+            observed = observed if isinstance(observed, np.ndarray) else observed.toarray()
             observed = np.asarray(observed, dtype=np.float64)
             control_group = (*group[:-1], self.control)
             reference, reference_source = None, "unavailable"
@@ -389,7 +389,7 @@ class PerturbationEvaluator:
                 genes = feature_sets[group]
                 if isinstance(genes, str) or len(genes) == 0 or len(set(genes)) != len(genes):
                     raise ValueError("Feature sets must be nonempty sequences of distinct gene identifiers.")
-                indices = features.get_indexer(genes)
+                indices = features.get_indexer(pd.Index(genes))
                 if (indices < 0).any():
                     raise ValueError("Selected genes are absent from the measurement feature space.")
                 scopes["selected"] = indices
@@ -403,7 +403,7 @@ class PerturbationEvaluator:
             for model, (candidate, status) in candidates.items():
                 predicted = None
                 if candidate is not None:
-                    predicted = candidate.toarray() if sparse.issparse(candidate) else candidate
+                    predicted = candidate if isinstance(candidate, np.ndarray) else candidate.toarray()
                     predicted = np.asarray(predicted, dtype=np.float64)
                 for scope, indices in scopes.items():
                     values = (

--- a/src/pertpy/tools/_perturbation_evaluator.py
+++ b/src/pertpy/tools/_perturbation_evaluator.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+
+from pertpy._types import cast_frame, cast_matrix
+from pertpy.tools._distances._distances import Distance
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from anndata import AnnData
+
+    from pertpy._types import CSBase
+
+Metric = Literal["mse", "edistance", "delta_pearson", "direction_accuracy", "top_k_overlap"]
+Baseline = Literal["control_mean", "additive"]
+Group = tuple[str, ...]
+
+
+def _identifiers(adata: AnnData) -> None:
+    if not adata.obs_names.is_unique or not adata.var_names.is_unique:
+        raise ValueError("Observation and feature identifiers must be unique.")
+    if adata.n_obs == 0 or adata.n_vars == 0:
+        raise ValueError("AnnData must contain observations and features.")
+
+
+def _digest(values: Sequence[str]) -> str:
+    return hashlib.sha256(json.dumps(sorted(values), ensure_ascii=False).encode()).hexdigest()
+
+
+class PerturbationEvaluator:
+    """Compare perturbation predictions with baselines fitted only on training cells.
+
+    Features are aligned by ``var_names``; all inputs must have exactly the same
+    feature set and measurement scale. No normalization or log transformation is
+    performed. Cells are compared as groups, not paired observations.
+
+    Args:
+        perturbation_key: Column of ``obs`` identifying interventions.
+        control: Label identifying unperturbed cells.
+        context_key: Optional ``obs`` column (for example cell type). Groups and
+            baselines are conditioned on this column; contexts are never pooled.
+        layer_key: Matrix in ``layers`` to use for every input, or ``X`` if None.
+
+    Examples:
+        >>> evaluator = pt.tl.PerturbationEvaluator("condition", "ctrl")
+        >>> train, test = evaluator.split(
+        ...     adata, holdout=["A+B"], strategy="combination", components={"A+B": ["A", "B"]}
+        ... )
+        >>> scores = evaluator.evaluate(test, {"model": predicted}, train=train, components={"A+B": ["A", "B"]})
+    """
+
+    def __init__(
+        self,
+        perturbation_key: str,
+        control: str,
+        *,
+        context_key: str | None = None,
+        layer_key: str | None = None,
+    ) -> None:
+        if not perturbation_key or not isinstance(control, str) or not control:
+            raise ValueError("Provide a perturbation column and a nonempty string control label.")
+        if context_key is not None and (not isinstance(context_key, str) or not context_key):
+            raise ValueError("context_key must be a nonempty column name or None.")
+        if context_key == perturbation_key:
+            raise ValueError("Context and perturbation columns must be different.")
+        self.perturbation_key = perturbation_key
+        self.control = control
+        self.context_key = context_key
+        self.layer_key = layer_key
+
+    @property
+    def _columns(self) -> list[str]:
+        return [self.context_key, self.perturbation_key] if self.context_key else [self.perturbation_key]
+
+    def _groups(self, adata: AnnData) -> dict[Group, np.ndarray]:
+        _identifiers(adata)
+        obs = cast_frame(adata.obs)
+        for col in self._columns:
+            if col not in obs:
+                raise ValueError(f"Missing observation column {col!r}.")
+            if obs[col].isna().any() or not all(isinstance(x, str) and x for x in obs[col]):
+                raise ValueError(f"Column {col!r} must contain nonempty string labels without missing values.")
+        groups: dict[Group, list[int]] = {}
+        for pos, row in enumerate(obs[self._columns].itertuples(index=False, name=None)):
+            groups.setdefault(row, []).append(pos)
+        return {key: np.asarray(groups[key], dtype=int) for key in sorted(groups)}
+
+    def _matrix(self, adata: AnnData, features: pd.Index) -> np.ndarray | CSBase:
+        if len(features) != adata.n_vars or set(features) != set(adata.var_names):
+            raise ValueError("Inputs must have exactly the same feature identifiers; align or select them explicitly.")
+        if self.layer_key is None:
+            matrix = adata.X
+        else:
+            if self.layer_key not in adata.layers:
+                raise ValueError(f"Missing layer {self.layer_key!r}.")
+            matrix = adata.layers[self.layer_key]
+        if not isinstance(matrix, np.ndarray) and not sparse.issparse(matrix):
+            raise TypeError("Use an in-memory NumPy or SciPy sparse matrix; load backed or lazy data explicitly.")
+        matrix = cast_matrix(matrix)
+        if matrix.dtype.kind not in "biuf":
+            raise ValueError("Measurements must be real numeric values.")
+        if isinstance(matrix, np.ndarray):
+            values = matrix
+        else:
+            matrix = matrix.tocsr()
+            values = matrix.data
+        if not np.isfinite(values).all():
+            raise ValueError("Measurements must be finite; missing values are not biological zeros.")
+        return matrix[:, adata.var_names.get_indexer(features)]
+
+    def split(
+        self,
+        adata: AnnData,
+        *,
+        holdout: Sequence[str],
+        strategy: Literal["perturbation", "combination", "context"] = "perturbation",
+        components: Mapping[str, Sequence[str]] | None = None,
+    ) -> tuple[AnnData, AnnData]:
+        """Create explicit group holdouts without randomly splitting cells of an intervention.
+
+        Args:
+            adata: Data with globally unique cell identifiers.
+            holdout: Intervention labels, or context labels for ``strategy='context'``.
+            strategy: Hold out entire perturbations, entire combinations, or entire
+                contexts. Control cells stay in training for intervention holdouts.
+                A context holdout includes that context's control cells in test.
+                Perturbation holdout uses exact labels, not every combination
+                containing a target. Combination holdout also removes aliases
+                with the same component set declared in ``components``.
+            components: For combination holdouts, map each held-out label to its
+                distinct single-intervention labels. Labels are never parsed implicitly.
+
+        Returns:
+            Independent training and test copies. Both include the same versioned
+            ``uns['pertpy_evaluation_split']`` record with exact cell membership.
+            Context holdouts may have unavailable context-matched baselines;
+            :meth:`evaluate` reports those explicitly instead of using test controls.
+        """
+        self._groups(adata)
+        if strategy not in ("perturbation", "combination", "context"):
+            raise ValueError("Unknown split strategy.")
+        if isinstance(holdout, str) or len(holdout) == 0 or len(set(holdout)) != len(holdout):
+            raise ValueError("holdout must be a nonempty sequence of distinct labels.")
+        if strategy == "context" and self.context_key is None:
+            raise ValueError("A context split requires context_key.")
+        col = self.context_key if strategy == "context" else self.perturbation_key
+        labels = cast_frame(adata.obs)[col]
+        if set(holdout) - set(labels):
+            raise ValueError("Every held-out label must occur in the data.")
+        if strategy != "context" and self.control in holdout:
+            raise ValueError("The control cannot be a held-out perturbation.")
+        test_mask = labels.isin(holdout).to_numpy()
+        if strategy == "combination":
+            held_out_components = set()
+            for label in holdout:
+                parts = self._components(label, components)
+                if len(parts) < 2:
+                    raise ValueError("Each held-out combination needs at least two distinct component labels.")
+                held_out_components.add(frozenset(parts))
+            # Known aliases such as A+B and B+A describe the same split unit.
+            aliases = [
+                label for label in set(labels) if frozenset(self._components(label, components)) in held_out_components
+            ]
+            test_mask = labels.isin(aliases).to_numpy()
+        if test_mask.all() or not test_mask.any():
+            raise ValueError("Both training and test partitions must be nonempty.")
+        train, test = adata[~test_mask].copy(), adata[test_mask].copy()
+        manifest = {
+            "schema_version": 1,
+            "strategy": strategy,
+            "column": col,
+            "holdout": sorted(holdout),
+            "train_obs_names": train.obs_names.tolist(),
+            "test_obs_names": test.obs_names.tolist(),
+        }
+        train.uns["pertpy_evaluation_split"] = json.loads(json.dumps(manifest))
+        test.uns["pertpy_evaluation_split"] = json.loads(json.dumps(manifest))
+        return train, test
+
+    def _components(self, label: str, components: Mapping[str, Sequence[str]] | None) -> tuple[str, ...]:
+        if components is None or label not in components:
+            return ()
+        parts = components[label]
+        if (
+            isinstance(parts, str)
+            or len(parts) == 0
+            or any(not isinstance(x, str) or not x or x == self.control for x in parts)
+            or len(set(parts)) != len(parts)
+            or label in parts
+        ):
+            raise ValueError("Components must be distinct non-control intervention labels.")
+        if any(part in components and len(components[part]) > 1 for part in parts):
+            raise ValueError("Components must name single interventions, not nested combinations.")
+        return tuple(parts)
+
+    def _baseline(
+        self,
+        name: Baseline,
+        group: Group,
+        train_matrix,
+        train_groups: dict[Group, np.ndarray],
+        components: Mapping[str, Sequence[str]] | None,
+    ) -> tuple[np.ndarray | None, str]:
+        control_group = (*group[:-1], self.control)
+        if control_group not in train_groups:
+            return None, "missing_training_control"
+        control_mean = np.asarray(train_matrix[train_groups[control_group]].astype(np.float64).mean(axis=0)).reshape(
+            1, -1
+        )
+        if name == "control_mean":
+            return control_mean, "ok"
+        parts = self._components(group[-1], components)
+        if not parts:
+            return None, "missing_components"
+        component_groups = [(*group[:-1], part) for part in parts]
+        if any(key not in train_groups for key in component_groups):
+            return None, "missing_training_component"
+        prediction = control_mean.copy()
+        for key in component_groups:
+            prediction += (
+                np.asarray(train_matrix[train_groups[key]].astype(np.float64).mean(axis=0)).reshape(1, -1)
+                - control_mean
+            )
+        if not np.isfinite(prediction).all():
+            return None, "nonfinite_baseline"
+        return prediction, "ok"
+
+    @staticmethod
+    def _scores(
+        real: np.ndarray,
+        predicted: np.ndarray,
+        reference: np.ndarray | None,
+        genes: np.ndarray,
+        *,
+        metrics: Sequence[Metric],
+        top_k: int,
+        effect_threshold: float,
+    ) -> dict[str, tuple[float, str]]:
+        scores: dict[str, tuple[float, str]] = {}
+        actual_mean, predicted_mean = real.mean(axis=0), predicted.mean(axis=0)
+        for metric in metrics:
+            if metric in ("mse", "edistance"):
+                scores[metric] = (float(Distance(metric)(real, predicted)), "ok")
+                continue
+            if reference is None:
+                scores[metric] = (np.nan, "missing_reference_control")
+                continue
+            actual, estimated = actual_mean - reference, predicted_mean - reference
+            if not np.isfinite(actual).all() or not np.isfinite(estimated).all():
+                scores[metric] = (np.nan, "nonfinite_result")
+                continue
+            if metric == "delta_pearson":
+                # Correlation is invariant to positive rescaling. Scale before
+                # centering to avoid overflow in otherwise finite deltas/norms.
+                a_scale, b_scale = np.abs(actual).max(), np.abs(estimated).max()
+                a = actual / a_scale if a_scale > 0 else actual
+                b = estimated / b_scale if b_scale > 0 else estimated
+                a, b = a - a.mean(), b - b.mean()
+                denominator = np.linalg.norm(a) * np.linalg.norm(b)
+                scores[metric] = (
+                    (float(np.clip(np.dot(a, b) / denominator, -1, 1)), "ok")
+                    if denominator > 0
+                    else (np.nan, "undefined_constant")
+                )
+            elif metric == "direction_accuracy":
+                changed = np.abs(actual) > effect_threshold
+                value = (
+                    float(np.mean(np.sign(actual[changed]) == np.sign(estimated[changed]))) if changed.any() else np.nan
+                )
+                scores[metric] = (value, "ok" if changed.any() else "no_reference_effect")
+            else:
+                # Tie order depends on identifiers, never on the input feature order.
+                k = min(top_k, len(genes))
+                truth_top = np.lexsort((genes, -np.abs(actual)))[:k]
+                prediction_top = np.lexsort((genes, -np.abs(estimated)))[:k]
+                if np.abs(actual).max() <= effect_threshold or np.abs(estimated).max() <= effect_threshold:
+                    scores[metric] = (np.nan, "no_rankable_effect")
+                else:
+                    scores[metric] = (float(len(set(truth_top) & set(prediction_top)) / k), "ok")
+        return {
+            key: (np.nan, "nonfinite_result") if status == "ok" and not np.isfinite(value) else (value, status)
+            for key, (value, status) in scores.items()
+        }
+
+    def evaluate(
+        self,
+        ground_truth: AnnData,
+        predictions: Mapping[str, AnnData],
+        *,
+        train: AnnData,
+        components: Mapping[str, Sequence[str]] | None = None,
+        baselines: Sequence[Baseline] = ("control_mean", "additive"),
+        metrics: Sequence[Metric] = ("mse", "edistance", "delta_pearson", "direction_accuracy", "top_k_overlap"),
+        feature_sets: Mapping[Group, Sequence[str]] | None = None,
+        top_k: int = 20,
+        effect_threshold: float = 0.0,
+        split_name: str = "test",
+    ) -> pd.DataFrame:
+        """Return one row per model, test group, feature scope and metric.
+
+        Args:
+            ground_truth: Held-out measured cells. Control rows, if present, are
+                excluded from scoring. Only training controls define the reference
+                for changes in expression, including for external predictions.
+            predictions: Named AnnData predictions, grouped by the same labels.
+                Cell counts may differ. Missing prediction groups produce explicit
+                unavailable rows. Unknown non-control groups are rejected.
+            train: Training cells, disjoint from ground truth by cell identifier.
+                Baselines use only this data. This checks declared membership, not
+                an external model's training history or upstream preprocessing.
+            components: Map a combination label to its single-intervention labels.
+                The additive point prediction is the training control mean plus
+                the sum of the component mean changes in the same context/scale.
+            baselines: Include control-mean and additive point predictions. Missing
+                training components/controls are reported; no fallback is hidden.
+            metrics: ``mse`` and ``edistance`` reuse :class:`Distance`. Delta Pearson
+                correlates gene-wise changes relative to the reference control.
+                Direction accuracy considers only reference changes larger than
+                ``effect_threshold``. Top-k overlap ranks absolute mean changes;
+                it is not a statistical differential-expression test.
+            feature_sets: Optional predeclared genes for each group tuple, ordered
+                as ``(context, perturbation)`` or ``(perturbation,)``. Adds a
+                ``selected`` scope alongside ``all``; this tool does not discover DEGs.
+            top_k: Number of genes ranked for overlap, capped at the scope's size.
+            effect_threshold: Nonnegative change magnitude below which a reference
+                effect is treated as zero. Specify in the input measurement units.
+            split_name: Label included in every output row.
+
+        Returns:
+            Tidy DataFrame with explicit counts, scope, reference source, direction
+            of improvement, and status. Unavailable or undefined scores are NaN,
+            never perfect scores. ``attrs['pertpy_evaluation']`` records the
+            measurement choice, features, configuration and membership hashes.
+            No aggregate silently drops unavailable groups. E-distance uses
+            Pertpy's within-group estimator and can be negative in finite samples;
+            a point baseline does not model the cell distribution.
+        """
+        allowed_metrics = {"mse", "edistance", "delta_pearson", "direction_accuracy", "top_k_overlap"}
+        if len(metrics) == 0 or len(set(metrics)) != len(metrics) or set(metrics) - allowed_metrics:
+            raise ValueError("Provide distinct supported metrics.")
+        if len(set(baselines)) != len(baselines) or set(baselines) - {"control_mean", "additive"}:
+            raise ValueError("Provide distinct supported baselines.")
+        if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k < 1:
+            raise ValueError("top_k must be a positive integer.")
+        if not np.isfinite(effect_threshold) or effect_threshold < 0:
+            raise ValueError("effect_threshold must be finite and nonnegative.")
+        if not predictions and not baselines:
+            raise ValueError("Provide at least one prediction or baseline.")
+        if any(not isinstance(name, str) or not name or name.startswith("baseline:") for name in predictions):
+            raise ValueError("Model names must be nonempty strings and cannot start with 'baseline:'.")
+        real_groups, train_groups = self._groups(ground_truth), self._groups(train)
+        if len(ground_truth.obs_names.intersection(train.obs_names)):
+            raise ValueError("Training and test cell identifiers overlap; split the data before evaluation.")
+        features = ground_truth.var_names
+        real_matrix = self._matrix(ground_truth, features)
+        train_matrix = self._matrix(train, features)
+        target_groups = {key: rows for key, rows in real_groups.items() if key[-1] != self.control}
+        if not target_groups:
+            raise ValueError("Ground truth contains no perturbed test groups.")
+        if feature_sets is not None and set(feature_sets) - set(target_groups):
+            raise ValueError("Feature sets must use test-group tuples as keys.")
+        models = {}
+        for name, data in predictions.items():
+            groups = self._groups(data)
+            if any(key not in target_groups and key[-1] != self.control for key in groups):
+                raise ValueError(f"Prediction {name!r} contains groups absent from ground truth.")
+            models[name] = (self._matrix(data, features), groups)
+        rows = []
+        for group, positions in target_groups.items():
+            observed = real_matrix[positions]
+            observed = observed.toarray() if sparse.issparse(observed) else observed
+            observed = np.asarray(observed, dtype=np.float64)
+            control_group = (*group[:-1], self.control)
+            reference, reference_source = None, "unavailable"
+            if control_group in train_groups:
+                reference = np.asarray(
+                    train_matrix[train_groups[control_group]].astype(np.float64).mean(axis=0)
+                ).ravel()
+                reference_source = "train_control"
+            scopes = {"all": np.arange(len(features))}
+            if feature_sets is not None and group in feature_sets:
+                genes = feature_sets[group]
+                if isinstance(genes, str) or len(genes) == 0 or len(set(genes)) != len(genes):
+                    raise ValueError("Feature sets must be nonempty sequences of distinct gene identifiers.")
+                indices = features.get_indexer(genes)
+                if (indices < 0).any():
+                    raise ValueError("Selected genes are absent from the measurement feature space.")
+                scopes["selected"] = indices
+            candidates = {}
+            for name, (matrix, groups) in models.items():
+                candidates[name] = (matrix[groups[group]], "ok") if group in groups else (None, "missing_prediction")
+            for baseline in baselines:
+                candidates[f"baseline:{baseline}"] = self._baseline(
+                    baseline, group, train_matrix, train_groups, components
+                )
+            for model, (candidate, status) in candidates.items():
+                predicted = None
+                if candidate is not None:
+                    predicted = candidate.toarray() if sparse.issparse(candidate) else candidate
+                    predicted = np.asarray(predicted, dtype=np.float64)
+                for scope, indices in scopes.items():
+                    values = (
+                        self._scores(
+                            observed[:, indices],
+                            predicted[:, indices],
+                            reference[indices] if reference is not None else None,
+                            features.to_numpy()[indices],
+                            metrics=metrics,
+                            top_k=top_k,
+                            effect_threshold=effect_threshold,
+                        )
+                        if predicted is not None
+                        else dict.fromkeys(metrics, (np.nan, status))
+                    )
+                    for metric, (value, metric_status) in values.items():
+                        rows.append(
+                            {
+                                "model": model,
+                                "split": split_name,
+                                "context": group[0] if self.context_key else None,
+                                "perturbation": group[-1],
+                                "scope": scope,
+                                "metric": metric,
+                                "value": value,
+                                "status": metric_status,
+                                "higher_is_better": metric not in ("mse", "edistance"),
+                                "n_true": len(observed),
+                                "n_predicted": len(predicted) if predicted is not None else 0,
+                                "n_features": len(indices),
+                                "reference_source": reference_source,
+                            }
+                        )
+        result = pd.DataFrame(rows)
+        result.attrs["pertpy_evaluation"] = {
+            "schema_version": 1,
+            "perturbation_key": self.perturbation_key,
+            "control": self.control,
+            "context_key": self.context_key,
+            "layer_key": self.layer_key,
+            "features": features.tolist(),
+            "train_cell_ids_sha256": _digest(train.obs_names.tolist()),
+            "test_cell_ids_sha256": _digest(ground_truth.obs_names.tolist()),
+            "n_train": train.n_obs,
+            "n_test": ground_truth.n_obs,
+            "split": split_name,
+            "metrics": list(metrics),
+            "baselines": list(baselines),
+            "top_k": top_k,
+            "effect_threshold": effect_threshold,
+            "components": {key: list(value) for key, value in (components or {}).items()},
+            "feature_sets": [
+                {"group": list(key), "features": list(value)} for key, value in (feature_sets or {}).items()
+            ],
+        }
+        return result

--- a/tests/tools/test_perturbation_evaluator.py
+++ b/tests/tools/test_perturbation_evaluator.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 import pandas as pd
 import pytest
-from anndata import AnnData
+from anndata import AnnData, read_h5ad
 from scipy import sparse
 from scipy.spatial.distance import cdist, pdist
 
@@ -309,3 +309,151 @@ def test_float32_control_reduction_matches_independent_float64(storage):
     )
     expected = np.mean(values.astype(np.float64).mean(axis=0) ** 2)
     np.testing.assert_allclose(value(scores, "baseline:control_mean", "mse").value, expected, rtol=1e-14)
+
+
+@pytest.mark.parametrize("empty_axis", ["observations", "features"])
+def test_empty_measurements_cannot_produce_a_scorecard(experiment, empty_axis):
+    evaluator, train, truth = experiment
+    empty = truth[:0].copy() if empty_axis == "observations" else truth[:, :0].copy()
+    with pytest.raises(ValueError, match="observations and features"):
+        evaluator.evaluate(empty, {}, train=train)
+
+
+def test_context_cannot_reuse_the_intervention_column():
+    with pytest.raises(ValueError, match="must be different"):
+        pt.tl.PerturbationEvaluator("condition", "ctrl", context_key="condition")
+
+
+def test_backed_predictions_require_explicit_materialization(experiment, tmp_path):
+    evaluator, train, truth = experiment
+    path = tmp_path / "predictions.h5ad"
+    truth.write_h5ad(path)
+    backed = read_h5ad(path, backed="r")
+    try:
+        with pytest.raises(TypeError, match="in-memory"):
+            evaluator.evaluate(truth, {"model": backed}, train=train, baselines=(), metrics=("mse",))
+    finally:
+        backed.file.close()
+
+
+def test_complex_measurements_are_not_silently_cast_to_real(experiment):
+    evaluator, train, truth = experiment
+    predicted = truth.copy()
+    predicted.X = predicted.X.astype(complex) + 1j
+    with pytest.raises(ValueError, match="real numeric"):
+        evaluator.evaluate(truth, {"model": predicted}, train=train, baselines=(), metrics=("mse",))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"holdout": ["A"], "strategy": "random_cells"}, "split strategy"),
+        ({"holdout": []}, "nonempty sequence"),
+        ({"holdout": "A"}, "nonempty sequence"),
+        ({"holdout": ["A", "A"]}, "distinct labels"),
+        ({"holdout": ["absent"]}, "must occur"),
+        ({"holdout": ["ctrl"]}, "control cannot"),
+        ({"holdout": ["A"], "strategy": "context"}, "requires context_key"),
+        ({"holdout": ["A"], "strategy": "combination"}, "at least two"),
+    ],
+)
+def test_invalid_holdout_cannot_silently_change_the_split_unit(kwargs, message):
+    adata = cells([[0], [1], [2]], ["ctrl", "A", "B"], "cell")
+    evaluator = pt.tl.PerturbationEvaluator("condition", "ctrl")
+    original = adata.copy()
+    with pytest.raises(ValueError, match=message):
+        evaluator.split(adata, **kwargs)
+    np.testing.assert_array_equal(adata.X, original.X)
+    pd.testing.assert_frame_equal(adata.obs, original.obs)
+    assert "pertpy_evaluation_split" not in adata.uns
+
+
+def test_context_holdout_cannot_remove_every_training_cell():
+    adata = cells([[0], [1]], ["ctrl", "A"], "cell", contexts=["only", "only"])
+    evaluator = pt.tl.PerturbationEvaluator("condition", "ctrl", context_key="cell_type")
+    with pytest.raises(ValueError, match="partitions must be nonempty"):
+        evaluator.split(adata, holdout=["only"], strategy="context")
+
+
+@pytest.mark.parametrize("name", ["baseline:control_mean", "baseline:custom", "", 1])
+def test_model_names_cannot_impersonate_a_baseline(experiment, name):
+    evaluator, train, truth = experiment
+    with pytest.raises(ValueError, match="Model names"):
+        evaluator.evaluate(truth, {name: truth.copy()}, train=train, metrics=("mse",))
+
+
+def test_evaluation_requires_a_candidate_and_perturbed_truth(experiment):
+    evaluator, train, truth = experiment
+    with pytest.raises(ValueError, match="prediction or baseline"):
+        evaluator.evaluate(truth, {}, train=train, baselines=())
+    controls_only = truth.copy()
+    controls_only.obs["condition"] = "ctrl"
+    with pytest.raises(ValueError, match="no perturbed test groups"):
+        evaluator.evaluate(controls_only, {}, train=train)
+
+
+@pytest.mark.parametrize(
+    ("selected", "message"),
+    [
+        ({"A+B": ["g0"]}, "test-group tuples"),
+        ({("absent",): ["g0"]}, "test-group tuples"),
+        ({("A+B",): "g0"}, "sequences of distinct gene"),
+        ({("A+B",): []}, "sequences of distinct gene"),
+        ({("A+B",): ["g0", "g0"]}, "sequences of distinct gene"),
+    ],
+)
+def test_invalid_selected_scope_cannot_change_gene_weighting(experiment, selected, message):
+    evaluator, train, truth = experiment
+    with pytest.raises(ValueError, match=message):
+        evaluator.evaluate(truth, {}, train=train, feature_sets=selected, metrics=("mse",))
+
+
+def test_overflowed_additive_prediction_stays_unavailable():
+    # Every input is finite, but adding two component effects exceeds float64.
+    train = cells([[0, 0], [1e308, 0], [1e308, 0]], ["ctrl", "A", "B"], "train")
+    truth = cells([[1, 0]], ["A+B"], "test")
+    with np.errstate(over="ignore", invalid="ignore"):
+        scores = pt.tl.PerturbationEvaluator("condition", "ctrl").evaluate(
+            truth, {}, train=train, components={"A+B": ["A", "B"]}, metrics=("mse",)
+        )
+    unavailable = value(scores, "baseline:additive", "mse")
+    assert unavailable.status == "nonfinite_baseline"
+    assert np.isnan(unavailable.value)
+    assert unavailable.n_predicted == 0
+    available = value(scores, "baseline:control_mean", "mse")
+    assert available.status == "ok"
+    assert available.value == pytest.approx(0.5)
+
+
+def test_overflowed_delta_cannot_be_ranked_as_a_real_effect():
+    train = cells([[-1e308, 0]], ["ctrl"], "train")
+    truth = cells([[1e308, 1]], ["A+B"], "test")
+    predicted = truth.copy()
+    with np.errstate(over="ignore", invalid="ignore"):
+        scores = pt.tl.PerturbationEvaluator("condition", "ctrl").evaluate(
+            truth,
+            {"model": predicted},
+            train=train,
+            baselines=(),
+            metrics=("mse", "delta_pearson", "direction_accuracy", "top_k_overlap"),
+        )
+    assert value(scores, "model", "mse").value == 0
+    undefined = scores[scores.metric != "mse"]
+    assert undefined.status.eq("nonfinite_result").all()
+    assert undefined.value.isna().all()
+
+
+def test_overflowed_distance_does_not_hide_a_finite_correlation():
+    train = cells([[0, 0]], ["ctrl"], "train")
+    truth = cells([[1e308, -1e308]], ["A+B"], "test")
+    predicted = cells([[-1e308, 1e308]], ["A+B"], "pred")
+    with np.errstate(over="ignore", invalid="ignore"):
+        scores = pt.tl.PerturbationEvaluator("condition", "ctrl").evaluate(
+            truth, {"model": predicted}, train=train, baselines=(), metrics=("mse", "delta_pearson")
+        )
+    unavailable = value(scores, "model", "mse")
+    assert unavailable.status == "nonfinite_result"
+    assert np.isnan(unavailable.value)
+    correlation = value(scores, "model", "delta_pearson")
+    assert correlation.status == "ok"
+    assert correlation.value == pytest.approx(-1)

--- a/tests/tools/test_perturbation_evaluator.py
+++ b/tests/tools/test_perturbation_evaluator.py
@@ -1,0 +1,311 @@
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+from anndata import AnnData
+from scipy import sparse
+from scipy.spatial.distance import cdist, pdist
+
+import pertpy as pt
+
+
+def cells(values, labels, prefix, *, contexts=None, genes=None):
+    values = np.asarray(values, dtype=float)
+    obs = pd.DataFrame({"condition": labels}, index=[f"{prefix}-{i}" for i in range(len(labels))])
+    if contexts is not None:
+        obs["cell_type"] = contexts
+    return AnnData(values, obs=obs, var=pd.DataFrame(index=genes or [f"g{i}" for i in range(values.shape[1])]))
+
+
+def value(scores, model, metric, scope="all", perturbation="A+B"):
+    row = scores.query("model == @model and metric == @metric and scope == @scope and perturbation == @perturbation")
+    assert len(row) == 1
+    return row.iloc[0]
+
+
+@pytest.fixture
+def experiment():
+    # The combination is exactly additive; control mean alone is insufficient.
+    train = cells([[10, 20, 30], [10, 20, 30], [12, 20, 29], [10, 23, 31]], ["ctrl", "ctrl", "A", "B"], "train")
+    truth = cells([[12, 23, 30], [12, 23, 30]], ["A+B", "A+B"], "test")
+    return pt.tl.PerturbationEvaluator("condition", "ctrl"), train, truth
+
+
+def test_additive_and_control_baselines(experiment):
+    evaluator, train, truth = experiment
+    scores = evaluator.evaluate(truth, {}, train=train, components={"A+B": ["A", "B"]}, top_k=2)
+    assert value(scores, "baseline:additive", "mse").value == pytest.approx(0)
+    assert value(scores, "baseline:control_mean", "mse").value == pytest.approx(13 / 3)
+    assert value(scores, "baseline:additive", "edistance").value == pytest.approx(0)
+    assert value(scores, "baseline:additive", "delta_pearson").value == pytest.approx(1)
+    assert value(scores, "baseline:additive", "direction_accuracy").value == pytest.approx(1)
+    assert value(scores, "baseline:additive", "top_k_overlap").value == pytest.approx(1)
+    assert value(scores, "baseline:control_mean", "delta_pearson").status == "undefined_constant"
+    assert value(scores, "baseline:control_mean", "top_k_overlap").status == "no_rankable_effect"
+    assert scores.n_predicted.eq(1).all()
+    assert scores.reference_source.eq("train_control").all()
+
+
+def test_hand_calculated_metric_oracle():
+    train = cells([[10, 100, 1000, 10000]], ["ctrl"], "train")
+    truth = cells([[12, 99, 1000, 10003]], ["A+B"], "test")
+    predicted = cells([[11, 102, 1000, 10003]], ["A+B"], "pred")
+    evaluator = pt.tl.PerturbationEvaluator("condition", "ctrl")
+    scores = evaluator.evaluate(truth, {"model": predicted}, train=train, top_k=2, baselines=())
+    assert value(scores, "model", "mse").value == pytest.approx(2.5)
+    assert value(scores, "model", "delta_pearson").value == pytest.approx(3 / np.sqrt(50))
+    assert value(scores, "model", "direction_accuracy").value == pytest.approx(2 / 3)
+    assert value(scores, "model", "top_k_overlap").value == pytest.approx(0.5)
+    assert value(scores, "model", "edistance").value == pytest.approx(2 * np.sqrt(10))
+
+
+def test_energy_distance_matches_independent_pairwise_oracle():
+    a = np.array([[0.0, 1.0], [2.0, 3.0], [4.0, 0.0]])
+    b = np.array([[1.0, 2.0], [5.0, 2.0]])
+    train = cells([[0, 0]], ["ctrl"], "train")
+    truth = cells(a, ["A+B"] * 3, "test")
+    predicted = cells(b, ["A+B"] * 2, "pred")
+    expected = 2 * cdist(a, b).mean() - pdist(a).mean() - pdist(b).mean()
+    scores = pt.tl.PerturbationEvaluator("condition", "ctrl").evaluate(
+        truth, {"model": predicted}, train=train, baselines=(), metrics=("edistance",)
+    )
+    assert scores.value.iloc[0] == pytest.approx(expected)
+    assert scores.n_true.iloc[0] == 3 and scores.n_predicted.iloc[0] == 2
+
+
+def test_negative_energy_estimate_is_preserved():
+    truth = cells([[0], [2]], ["A+B", "A+B"], "test")
+    train = cells([[0]], ["ctrl"], "train")
+    scores = pt.tl.PerturbationEvaluator("condition", "ctrl").evaluate(
+        truth, {"identical": truth.copy()}, train=train, baselines=(), metrics=("edistance",)
+    )
+    assert scores.value.iloc[0] == pytest.approx(-2)
+    assert scores.status.iloc[0] == "ok"
+
+
+@pytest.mark.parametrize("matrix_type", [np.asarray, sparse.csr_matrix, sparse.csc_matrix, sparse.csr_array])
+def test_feature_permutation_sparse_and_no_mutation(experiment, matrix_type):
+    evaluator, train, truth = experiment
+    predicted = truth[:, [2, 0, 1]].copy()
+    train = train[:, [1, 2, 0]].copy()
+    original_truth = truth.X.copy()
+    for adata in (train, truth, predicted):
+        adata.X = matrix_type(adata.X)
+    scores = evaluator.evaluate(
+        truth, {"model": predicted}, train=train, metrics=("mse", "delta_pearson"), baselines=()
+    )
+    assert value(scores, "model", "mse").value == pytest.approx(0)
+    assert value(scores, "model", "delta_pearson").value == pytest.approx(1)
+    actual = truth.X.toarray() if sparse.issparse(truth.X) else truth.X
+    np.testing.assert_array_equal(actual, original_truth)
+    assert predicted.var_names.tolist() == ["g2", "g0", "g1"]
+
+
+def test_explicit_layer_ignores_x(experiment):
+    _, train, truth = experiment
+    predicted = truth.copy()
+    for adata in (train, truth, predicted):
+        adata.layers["measurement"] = adata.X.copy()
+        adata.X[:] = -1000
+    predicted.X[:] = 9999
+    scores = pt.tl.PerturbationEvaluator("condition", "ctrl", layer_key="measurement").evaluate(
+        truth, {"model": predicted}, train=train, baselines=(), metrics=("mse",)
+    )
+    assert scores.value.iloc[0] == 0
+    assert scores.attrs["pertpy_evaluation"]["layer_key"] == "measurement"
+
+
+def test_missing_prediction_stays_in_scorecard(experiment):
+    evaluator, train, truth = experiment
+    more = cells([[1, 2, 3]], ["C"], "more")
+    from anndata import concat
+
+    both = concat([truth, more])
+    scores = evaluator.evaluate(both, {"partial": truth.copy()}, train=train)
+    missing = scores[(scores.model == "partial") & (scores.perturbation == "C")]
+    assert len(missing) == 5
+    assert missing.value.isna().all() and missing.status.eq("missing_prediction").all()
+    assert missing.n_predicted.eq(0).all()
+
+
+def test_no_effect_does_not_manufacture_a_score():
+    train = cells([[1, 2, 3]], ["ctrl"], "train")
+    truth = cells([[1, 2, 3]], ["A+B"], "test")
+    scores = pt.tl.PerturbationEvaluator("condition", "ctrl").evaluate(
+        truth, {}, train=train, baselines=("control_mean",)
+    )
+    assert value(scores, "baseline:control_mean", "mse").value == 0
+    assert value(scores, "baseline:control_mean", "direction_accuracy").status == "no_reference_effect"
+    assert value(scores, "baseline:control_mean", "top_k_overlap").status == "no_rankable_effect"
+
+
+def test_context_holdout_does_not_fit_test_controls():
+    adata = cells(
+        [[0, 0], [1, 2], [100, 100], [101, 102]],
+        ["ctrl", "A", "ctrl", "A"],
+        "cell",
+        contexts=["source", "source", "target", "target"],
+    )
+    evaluator = pt.tl.PerturbationEvaluator("condition", "ctrl", context_key="cell_type")
+    train, test = evaluator.split(adata, holdout=["target"], strategy="context")
+    predictions = test[test.obs.condition == "A"].copy()
+    scores = evaluator.evaluate(test, {"model": predictions}, train=train)
+    assert scores[scores.model.str.startswith("baseline:")].status.eq("missing_training_control").all()
+    model = scores[scores.model == "model"]
+    assert model[model.metric == "mse"].value.iloc[0] == 0
+    assert model[model.metric == "delta_pearson"].status.iloc[0] == "missing_reference_control"
+
+
+def test_missing_additive_component_has_no_fallback(experiment):
+    evaluator, train, truth = experiment
+    train = train[train.obs.condition != "B"].copy()
+    scores = evaluator.evaluate(truth, {}, train=train, components={"A+B": ["A", "B"]})
+    unavailable = scores[scores.model == "baseline:additive"]
+    assert unavailable.status.eq("missing_training_component").all()
+    assert unavailable.value.isna().all()
+    assert scores[scores.model == "baseline:control_mean"].status.ne("missing_training_component").all()
+
+
+def test_group_split_and_combination_aliases():
+    adata = cells([[0], [1], [2], [3], [3], [4]], ["ctrl", "A", "B", "A+B", "B+A", "C"], "cell")
+    evaluator = pt.tl.PerturbationEvaluator("condition", "ctrl")
+    train, test = evaluator.split(
+        adata, holdout=["A+B"], strategy="combination", components={"A+B": ["A", "B"], "B+A": ["B", "A"]}
+    )
+    assert set(test.obs.condition) == {"A+B", "B+A"}
+    assert set(train.obs.condition) == {"ctrl", "A", "B", "C"}
+    assert not len(train.obs_names.intersection(test.obs_names))
+    assert train.uns["pertpy_evaluation_split"] == test.uns["pertpy_evaluation_split"]
+    test.X[:] = 99
+    assert adata.X.max() == 4
+    # A perturbation-label split does not promise cold atomic-target exclusion.
+    train, test = evaluator.split(adata, holdout=["A"])
+    assert "A+B" in set(train.obs.condition)
+    assert set(test.obs.condition) == {"A"}
+
+
+def test_selected_genes_and_manifest(experiment):
+    evaluator, train, truth = experiment
+    selected = {("A+B",): truth.var_names[:2]}
+    scores = evaluator.evaluate(
+        truth, {}, train=train, feature_sets=selected, metrics=("mse",), baselines=("control_mean",)
+    )
+    assert value(scores, "baseline:control_mean", "mse", "selected").value == pytest.approx(6.5)
+    manifest = json.loads(json.dumps(scores.attrs["pertpy_evaluation"]))
+    assert manifest["feature_sets"] == [{"group": ["A+B"], "features": ["g0", "g1"]}]
+    assert manifest["train_cell_ids_sha256"] != manifest["test_cell_ids_sha256"]
+
+
+def test_heldout_values_cannot_change_baseline(experiment):
+    evaluator, train, truth = experiment
+    scores = evaluator.evaluate(truth, {}, train=train, baselines=("control_mean",), metrics=("mse",))
+    changed = truth.copy()
+    changed.X += 7
+    changed_scores = evaluator.evaluate(changed, {}, train=train, baselines=("control_mean",), metrics=("mse",))
+    assert scores.value.iloc[0] == pytest.approx((2**2 + 3**2) / 3)
+    assert changed_scores.value.iloc[0] == pytest.approx((9**2 + 10**2 + 7**2) / 3)
+
+
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "overlap",
+        "duplicate_feature",
+        "duplicate_cell",
+        "missing_feature",
+        "extra_feature",
+        "nan",
+        "inf",
+        "missing_label",
+        "missing_column",
+        "missing_layer",
+        "unknown_group",
+    ],
+)
+def test_invalid_inputs_fail(experiment, fault):
+    evaluator, train, truth = experiment
+    predicted = truth.copy()
+    if fault == "overlap":
+        truth.obs_names = train.obs_names[:2]
+    elif fault == "duplicate_feature":
+        predicted.var_names = ["g0", "g0", "g2"]
+    elif fault == "duplicate_cell":
+        truth.obs_names = ["same", "same"]
+    elif fault == "missing_feature":
+        predicted = predicted[:, :2].copy()
+    elif fault == "extra_feature":
+        predicted.var_names = ["extra", "g1", "g2"]
+    elif fault in ("nan", "inf"):
+        predicted.X[0, 0] = float(fault)
+    elif fault == "missing_label":
+        predicted.obs.loc[predicted.obs_names[0], "condition"] = None
+    elif fault == "missing_column":
+        del predicted.obs["condition"]
+    elif fault == "missing_layer":
+        evaluator = pt.tl.PerturbationEvaluator("condition", "ctrl", layer_key="absent")
+    else:
+        predicted.obs["condition"] = "not-in-test"
+    with pytest.raises(ValueError):
+        evaluator.evaluate(truth, {"model": predicted}, train=train)
+
+
+@pytest.mark.parametrize(
+    "components",
+    [
+        {"A+B": "A+B"},
+        {"A+B": ["A", "A"]},
+        {"A+B": ["ctrl", "A"]},
+        {"A+B": ["A+B", "A"]},
+        {"A+B": ["X", "A"], "X": ["B", "C"]},
+    ],
+)
+def test_invalid_components(experiment, components):
+    evaluator, train, truth = experiment
+    with pytest.raises(ValueError):
+        evaluator.evaluate(truth, {}, train=train, components=components)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"top_k": 0},
+        {"top_k": True},
+        {"effect_threshold": -1},
+        {"effect_threshold": np.inf},
+        {"metrics": ()},
+        {"metrics": ("made-up",)},
+        {"baselines": ("made-up",)},
+        {"feature_sets": {("A+B",): ["absent"]}},
+    ],
+)
+def test_invalid_configuration(experiment, kwargs):
+    evaluator, train, truth = experiment
+    with pytest.raises(ValueError):
+        evaluator.evaluate(truth, {}, train=train, **kwargs)
+
+
+@pytest.mark.parametrize("magnitude", [1e-200, 1e200])
+def test_delta_pearson_preserves_scale_invariance(magnitude):
+    train = cells([[0, 0]], ["ctrl"], "train")
+    truth = cells([[magnitude, -magnitude]], ["A+B"], "test")
+    prediction = cells([[1, -1]], ["A+B"], "prediction")
+    scores = pt.tl.PerturbationEvaluator("condition", "ctrl").evaluate(
+        truth, {"model": prediction}, train=train, baselines=(), metrics=("delta_pearson",)
+    )
+    actual = value(scores, "model", "delta_pearson")
+    assert actual.status == "ok"
+    assert actual.value == pytest.approx(1)
+
+
+@pytest.mark.parametrize("storage", [np.asarray, sparse.csr_matrix])
+def test_float32_control_reduction_matches_independent_float64(storage):
+    values = np.array([[0.1, 1.3], [0.2, 2.7], [0.3, 3.1]], dtype=np.float32)
+    train = cells(values, ["ctrl"] * 3, "train")
+    train.X = storage(values)
+    truth = cells([[0, 0]], ["A+B"], "test")
+    scores = pt.tl.PerturbationEvaluator("condition", "ctrl").evaluate(
+        truth, {}, train=train, baselines=("control_mean",), metrics=("mse",)
+    )
+    expected = np.mean(values.astype(np.float64).mean(axis=0) ** 2)
+    np.testing.assert_allclose(value(scores, "baseline:control_mean", "mse").value, expected, rtol=1e-14)


### PR DESCRIPTION
**PR Checklist**

- [x] Referenced issue is linked
- [x] Tests added for the new code
- [x] Documentation in `docs` is updated

**Description of changes**

Relates to #1035. Comparing perturbation predictions currently requires callers to assemble splits, references and baselines themselves. This adds `pt.tl.PerturbationEvaluator`, which aligns genes by identifier and returns tidy per-group metrics with explicit unavailable/undefined statuses.

Baselines use training controls and single interventions only. Explicit label, combination and context holdouts preserve cell membership; known combination aliases are grouped through an explicit component mapping. Evaluation rejects declared train/test cell overlap and mismatched feature sets while retaining missing prediction groups. MSE and E-distance reuse the existing `Distance` API. The guide documents point-baseline, measurement-scale and split limitations.

**Technical details**

This is a proposed first API slice: control-mean and additive baselines, MSE, E-distance, delta Pearson, sign agreement and top-k absolute response overlap. It does not close the entire issue: nearest-neighbour baselines, logFC scoring and DEG discovery are not implemented. Input contracts for the first two would benefit from maintainer agreement. No new dependencies are added.

Validation: 44 contribution tests and 40 independent audit cases passed on Python 3.12.3 and 3.14.7; the existing comparison tests passed. Whole-project mypy checked 101 files; applicable pre-commit hooks and the full Sphinx build passed. An eight-combination Norman example produced 80 score/status rows, agreed with independent numerical calculations, and preserved the case where additive prediction is worse than the control baseline.

- [Runtime and real-data evidence](https://github.com/thantiklermcirony/pertpy/actions/runs/34415474373)
- [Whole-project checks](https://github.com/thantiklermcirony/pertpy/actions/runs/34415474369)

**Additional context**

The clean diff contains only implementation, tests and documentation. The audit workflow, data recipe and independent tests remain in the fork’s audit branch. The five contribution files are byte-identical to the files tested there. No raw data or claim of a new biological prediction method is included.